### PR TITLE
remove the use of data helper from InstallSchema

### DIFF
--- a/Setup/InstallSchema.php
+++ b/Setup/InstallSchema.php
@@ -19,13 +19,6 @@ use Symfony\Component\Config\Definition\Exception\Exception;
 
 class InstallSchema implements InstallSchemaInterface
 {
-    private $_helper;
-
-    public function __construct(\Ebizmarts\MailChimp\Helper\Data $helper)
-    {
-        $this->_helper = $helper;
-    }
-
     /**
      * {@inheritdoc}
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
@@ -228,13 +221,9 @@ class InstallSchema implements InstallSchemaInterface
             ]
         );
 
-        $path = $this->_helper->getBaseDir() . DIRECTORY_SEPARATOR . 'var' . DIRECTORY_SEPARATOR . 'Mailchimp';
-        try {
-            if (!is_dir($path)) {
-                mkdir($path);
-            }
-        } catch (Exception $e) {
-            $this->_helper->log($e->getMessage());
+        $path = BP . DIRECTORY_SEPARATOR . 'var' . DIRECTORY_SEPARATOR . 'Mailchimp';
+        if (!is_dir($path)) {
+            mkdir($path);
         }
         $installer->endSetup();
     }


### PR DESCRIPTION
Problem:

When we do a clean magento2 install we get an exception caused by this
module.

  [Magento\Framework\Exception\LocalizedException]
  Invalid entity_type specified: customer

The reason for this is that de InstallData is executed after all
installations of schemas and updates of schemas.

Solution:

Remove the use of the helper in the InstallSchema, the helper will cause
the ObjectManager to instantiate several objects and that causes the
exception because the eav entity type for customer is not yet set.

The helper got removed from the InstallSchema, and due to that we use BP
now instead of the helpers getBasePath method. Additionally the try
catch to ignore the failure of creating the MailChimp folder in var is
removed. I think its better to fail hard there instead of ignoring the
fact the folder could not be created.

Signed-off-by: BlackEagle <ike.devolder@gmail.com>