### PR TITLE
bugfix STOREID null for error: "Data did not match any of the schemas described in anyOf."

### DIFF
--- a/Controller/Adminhtml/Stores/Get.php
+++ b/Controller/Adminhtml/Stores/Get.php
@@ -53,6 +53,9 @@ class Get extends Action
             $result = [];
             foreach ($stores['stores'] as $store) {
                 if ($store['platform'] == \Ebizmarts\MailChimp\Helper\Data::PLATFORM) {
+                    if($store['list_id']=='') {
+                        continue;
+                    }
                     $list = $api->lists->getLists($store['list_id']);
                     $result[] = ['id' => $store['id'], 'name' => $store['name'], 'list_name' => $list['name'], 'list_id' => $store['list_id']];
                 }

--- a/Controller/Adminhtml/Stores/Save.php
+++ b/Controller/Adminhtml/Stores/Save.php
@@ -89,6 +89,7 @@ class Save extends \Ebizmarts\MailChimp\Controller\Adminhtml\Stores
         } else {
             $date = $this->_helper->getDateMicrotime();
             $mailchimpStoreId = md5($name. '_' . $date);
+            $is_sync = true;
             $ret =$api->ecommerce->stores->add(
                 $mailchimpStoreId,
                 $formData['list_id'],

--- a/Controller/Cart/Loadquote.php
+++ b/Controller/Cart/Loadquote.php
@@ -128,6 +128,7 @@ class Loadquote extends Action
                 $quote->setData('mailchimp_abandonedcart_flag', true);
                 $quote->getResource()->save($quote);
                 if (!$quote->getCustomerId()) {
+                    $this->_helper->log('is guest');
                     $this->_customerSession->setQuoteId($quote->getId());
                     $this->_redirect($url);
                 } else {

--- a/Cron/Ecommerce.php
+++ b/Cron/Ecommerce.php
@@ -166,10 +166,12 @@ class Ecommerce
                 }
             }
             $countTotal = $countCustomers + $countProducts + $countOrders + $countSubscribers;
-            if ($countTotal == 0 && $this->_helper->getMCMinSyncing($storeId)) {
+            $alreadySynced = $this->_helper->getMCMinSyncing($storeId);
+            $this->_helper->log("Already Synced $alreadySynced total $countTotal");
+            if ($countTotal == 0 && !$alreadySynced) {
                 $api = $this->_helper->getApi($storeId);
                 $api->ecommerce->stores->edit($mailchimpStoreId, null, null, null, null, null, null, null, null, null, null, false);
-                $this->_helper->saveConfigValue(\Ebizmarts\MailChimp\Helper\Data::XML_PATH_IS_SYNC, true, $storeId);
+                $this->_helper->saveConfigValue(\Ebizmarts\MailChimp\Helper\Data::XML_PATH_IS_SYNC, date('Y-m-d His'), $storeId);
             }
         }
 

--- a/Cron/Ecommerce.php
+++ b/Cron/Ecommerce.php
@@ -167,7 +167,6 @@ class Ecommerce
             }
             $countTotal = $countCustomers + $countProducts + $countOrders + $countSubscribers;
             $alreadySynced = $this->_helper->getMCMinSyncing($storeId);
-            $this->_helper->log("Already Synced $alreadySynced total $countTotal");
             if ($countTotal == 0 && !$alreadySynced) {
                 $api = $this->_helper->getApi($storeId);
                 $api->ecommerce->stores->edit($mailchimpStoreId, null, null, null, null, null, null, null, null, null, null, false);

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -739,6 +739,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
 
     public function createWebHook($apikey, $listId)
     {
+        $this->log(__METHOD__);
         $events = [
             'subscribe' => true,
             'unsubscribe' => true,
@@ -758,6 +759,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
             '_nosid' => true,
             '_secure' => true]);
         try {
+            $this->log($hookUrl);
             $ret = $api->lists->webhooks->add($listId, urlencode($hookUrl), $events, $sources);
         } catch (\Mailchimp_Error $e) {
             $this->log($e->getMessage());

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -284,6 +284,19 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         $ret = $this->getConfigValue(\Ebizmarts\MailChimp\Helper\Data::XML_PATH_IS_SYNC, $storeId);
         return !$ret;
     }
+    public function getCartUrl($storeId,$cartId,$token)
+    {
+        $rc = $this->_storeManager->getStore($storeId)->getUrl(
+            'mailchimp/cart/loadquote',
+            [
+                'id' => $cartId,
+                'token' => $token,
+                '_nosid' => true,
+                '_secure' => true
+            ]
+        );
+        return $rc;
+    }
     /**
      * @param null $store
      * @return mixed

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -257,15 +257,12 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      */
     public function getConfigValue($path, $storeId = null, $scope = null)
     {
-        switch ($scope) {
-            case 'website':
-                $value = $this->_scopeConfig->getValue($path, \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITE, $storeId);
-                break;
-            default:
-                $value = $this->_scopeConfig->getValue($path, \Magento\Store\Model\ScopeInterface::SCOPE_STORES, $storeId);
-                break;
+        if($scope) {
+            $value = $this->_scopeConfig->getValue($path, $scope, $storeId);
         }
-
+        else {
+            $value = $this->_scopeConfig->getValue($path, \Magento\Store\Model\ScopeInterface::SCOPE_STORES, $storeId);
+        }
         return $value;
     }
     public function deleteConfig($path, $storeId = null, $scope = null)
@@ -275,13 +272,11 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
 
     public function saveConfigValue($path, $value, $storeId = null, $scope = null)
     {
-        switch ($scope) {
-            case 'website':
-                $this->_config->saveConfig($path, $value, \Magento\Store\Model\ScopeInterface::SCOPE_WEBSITE, $storeId);
-                break;
-            default:
-                $this->_config->saveConfig($path, $value, \Magento\Store\Model\ScopeInterface::SCOPE_STORES, $storeId);
-                break;
+        if($scope) {
+            $this->_config->saveConfig($path, $value, $scope, $storeId);
+        }
+        else {
+            $this->_config->saveConfig($path, $value, \Magento\Store\Model\ScopeInterface::SCOPE_STORES, $storeId);
         }
     }
     public function getMCMinSyncing($storeId)

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -345,6 +345,10 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     {
         return $this->_storeManager->getStore($storeId)->getFrontendName();
     }
+    public function getBaserUrl($storeId, $type)
+    {
+        return $this->_storeManager->getStore($storeId)->getBaseUrl($type);
+    }
     public function createStore($listId = null, $storeId)
     {
         if ($listId) {

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -490,7 +490,10 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
                     $merge_vars = array_merge($merge_vars, $this->_getCustomerGroup($customer, $key, $merge_vars));
                     break;
                 case 'store_id':
-                    $merge_vars[$key] = $customer->getStoreId();
+                    $storeId = $customer->getStoreId();
+                    if($storeId) {
+                        $merge_vars[$key] = $storeId;
+                    }
                     break;
             }
             return $merge_vars;
@@ -523,7 +526,9 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
                     $merge_vars = $this->_getCustomerGroup($subscriber, $key, $merge_vars);
                     break;
                 case 'store_id':
-                    $merge_vars[$key] = $subscriber->getStoreId();
+                    if($subscriber->getStoreId()) {
+                        $merge_vars[$key] = $subscriber->getStoreId();
+                    }
                     break;
             }
             return $merge_vars;

--- a/Model/Api/Cart.php
+++ b/Model/Api/Cart.php
@@ -213,6 +213,7 @@ class Cart
          * @var $cart \Magento\Quote\Model\Quote
          */
         foreach ($modifiedCarts as $cart) {
+            $this->_token = null;
             $cartId = $cart->getEntityId();
             $allCarts[$this->_counter]['method'] = 'DELETE';
             $allCarts[$this->_counter]['path'] = '/ecommerce/stores/' . $mailchimpStoreId . '/carts/' . $cartId;
@@ -309,6 +310,7 @@ class Cart
          * @var $cart \Magento\Quote\Model\Quote
          */
         foreach ($newCarts as $cart) {
+            $this->_token = null;
             $cartId = $cart->getEntityId();
             $orderCollection = $this->_getOrderCollection();
             $orderCollection->addFieldToFilter('main_table.customer_email', ['eq' => $cart->getCustomerEmail()])
@@ -399,7 +401,6 @@ class Cart
      */
     protected function _makeCart(\Magento\Quote\Model\Quote $cart, $mailchimpStoreId, $magentoStoreId)
     {
-        $this->_token = null;
         $campaignId = $cart->getMailchimpCampaignId();
         $oneCart = [];
         $oneCart['id'] = $cart->getEntityId();
@@ -408,7 +409,7 @@ class Cart
             $oneCart['campaign_id'] = $campaignId;
         }
 
-        $oneCart['checkout_url'] = $this->_getCheckoutUrl($cart);
+        $oneCart['checkout_url'] = $this->_getCheckoutUrl($cart,$magentoStoreId);
         $oneCart['currency_code'] = $cart->getQuoteCurrencyCode();
         $oneCart['order_total'] = $cart->getGrandTotal();
         $oneCart['tax_total'] = 0;
@@ -468,18 +469,10 @@ class Cart
      * @param \Magento\Quote\Model\Quote $cart
      * @return string
      */
-    protected function _getCheckoutUrl(\Magento\Quote\Model\Quote $cart)
+    protected function _getCheckoutUrl(\Magento\Quote\Model\Quote $cart, $storeId)
     {
         $token = md5(rand(0, 9999999));
-        $url = $this->_urlHelper->getUrl(
-            'mailchimp/cart/loadquote',
-            [
-                'id' => $cart->getId(),
-                'token' => $token,
-                '_nosid' => true,
-                '_secure' => true
-            ]
-        );
+        $url = $this->_helper->getCartUrl($storeId,$cart->getId(),$token);
         $this->_token = $token;
         return $url;
     }

--- a/Model/Api/Customer.php
+++ b/Model/Api/Customer.php
@@ -180,7 +180,7 @@ class Customer
             if ($address->getPostcode()) {
                 $customerAddress["postal_code"] = $address->getPostcode();
             }
-            if ($address->getCountry()) {
+            if ($address->getCountryId()) {
                 $country = $this->_countryInformation->getCountryInfo($address->getCountryId());
                 $countryName = $country->getFullNameLocale();
                 $customerAddress["country"] = $countryName;

--- a/Model/Api/Order.php
+++ b/Model/Api/Order.php
@@ -453,7 +453,7 @@ class Order
             $data['billing_address']["postal_code"] = $billingAddress->getPostcode();
         }
 
-        if ($billingAddress->getCountry()) {
+        if ($billingAddress->getCountryId()) {
             $country = $this->_countryInformation->getCountryInfo($billingAddress->getCountryId());
             $countryName = $country->getFullNameLocale();
             $address["country"] =$data['billing_address']['country'] = $countryName;

--- a/Model/Api/Order.php
+++ b/Model/Api/Order.php
@@ -167,7 +167,12 @@ class Order
                 $orderId = $item->getEntityId();
                 $order = $this->_order->get($orderId);
                 //create missing products first
-                $productData = $this->_apiProduct->sendModifiedProduct($order, $mailchimpStoreId, $magentoStoreId);
+                try {
+                    $productData = $this->_apiProduct->sendModifiedProduct($order, $mailchimpStoreId, $magentoStoreId);
+                } catch(\Exception $e) {
+                    $this->_helper->log($e->getMessage());
+                    continue;
+                }
                 if (count($productData)) {
                     foreach ($productData as $p) {
                         $batchArray[$this->_counter] = $p;
@@ -229,7 +234,12 @@ class Order
                 $orderId = $item->getEntityId();
                 $order = $this->_order->get($orderId);
                 //create missing products first
-                $productData = $this->_apiProduct->sendModifiedProduct($order, $mailchimpStoreId, $magentoStoreId);
+                try {
+                    $productData = $this->_apiProduct->sendModifiedProduct($order, $mailchimpStoreId, $magentoStoreId);
+                } catch(\Exception $e) {
+                    $this->_helper->log($e->getMessage());
+                    continue;
+                }
                 if (count($productData)) {
                     foreach ($productData as $p) {
                         $batchArray[$this->_counter] = $p;

--- a/Model/Api/Order.php
+++ b/Model/Api/Order.php
@@ -187,7 +187,7 @@ class Order
                     $batchArray[$this->_counter]['operation_id'] = $this->_batchId . '_' . $orderId;
                     $batchArray[$this->_counter]['body'] = $orderJson;
                 } else {
-                    $error = $this->_helper->__('Something went wrong when retreiving product information.');
+                    $error = __('Something went wrong when retreiving product information.');
                     $this->_updateOrder($mailchimpStoreId, $orderId, $this->_date->gmtDate(), $error, 0);
                     continue;
                 }

--- a/Model/Api/Product.php
+++ b/Model/Api/Product.php
@@ -271,7 +271,8 @@ class Product
         $data["title"] = $product->getName();
         $data["url"] = $product->getProductUrl();
         if ($product->getImage()) {
-            $data["image_url"] = $this->_imageHelper->init($product, self::PRODUCTIMAGE)->setImageFile($product->getImage())->getUrl();
+            $filePath = 'catalog/product'.$product->getImage();
+            $data["image_url"] = $this->_helper->getBaserUrl($magentoStoreId, \Magento\Framework\UrlInterface::URL_TYPE_MEDIA).$filePath;
         } elseif ($this->_parentImage) {
             $data['image_url'] = $this->_parentImage;
         }

--- a/Model/Api/Product.php
+++ b/Model/Api/Product.php
@@ -314,7 +314,6 @@ class Product
                     $this->_childtUrl = $data['url'] = $parent->getProductUrl() . $tailUrl;
                 }
             } else {
-                $this->_helper->log('is visible');
                 $data["visibility"] = 'true';
             }
         } else {

--- a/Model/Config/Backend/MonkeyList.php
+++ b/Model/Config/Backend/MonkeyList.php
@@ -72,7 +72,9 @@ class MonkeyList extends \Magento\Framework\App\Config\Value
         $data = $this->getData('groups');
         $oldListId = $this->getOldValue();
         $this->_registry->register('oldListId', $oldListId);
-        $this->_registry->register('apiKey', $data['general']['fields']['apikey']['value']);
+        if(isset($data['general']['fields']['apikey'])) {
+            $this->_registry->register('apiKey', $data['general']['fields']['apikey']['value']);
+        }
         return parent::afterSave();
     }
 }

--- a/Model/Config/Backend/MonkeyList.php
+++ b/Model/Config/Backend/MonkeyList.php
@@ -66,15 +66,17 @@ class MonkeyList extends \Magento\Framework\App\Config\Value
         parent::__construct($context, $registry, $config, $cacheTypeList, $resource, $resourceCollection, $data);
     }
 
-    public function afterSave()
-    {
-        $generalData = $this->getData();
-        $data = $this->getData('groups');
-        $oldListId = $this->getOldValue();
-        $this->_registry->register('oldListId', $oldListId);
-        if(isset($data['general']['fields']['apikey'])) {
-            $this->_registry->register('apiKey', $data['general']['fields']['apikey']['value']);
-        }
-        return parent::afterSave();
-    }
+//    public function afterSave()
+//    {
+//        $generalData = $this->getData();
+//        $data = $this->getData('groups');
+//        $oldListId = $this->getOldValue();
+//        $this->_registry->register('oldListId', $oldListId);
+//        $apiKey = $this->getDataByPath(\Ebizmarts\MailChimp\Helper\Data::XML_PATH_APIKEY);
+////        if(isset($data['general']['fields']['apikey'])) {
+//        if($apiKey) {
+//            $this->_registry->register('apiKey', $apiKey);
+//        }
+//        return parent::afterSave();
+//    }
 }

--- a/Model/Config/Backend/MonkeyStore.php
+++ b/Model/Config/Backend/MonkeyStore.php
@@ -74,6 +74,7 @@ class MonkeyStore extends \Magento\Framework\App\Config\Value
     {
         $data = $this->getData('groups');
         $found = 0;
+        $newListId = null;
         if (isset($data['ecommerce']['fields']['active']['value'])) {
             $active = $data['ecommerce']['fields']['active']['value'];
         } elseif ($data['ecommerce']['fields']['active']['inherit']) {
@@ -81,7 +82,9 @@ class MonkeyStore extends \Magento\Framework\App\Config\Value
         }
         if ($active && $this->isValueChanged()) {
             $mailchimpStore     = $this->getOldValue();
-            $newListId = $data['general']['fields']['monkeylist']['value'];
+            if(isset($data['general']['fields']['monkeylist'])) {
+                $newListId = $data['general']['fields']['monkeylist']['value'];
+            }
             $this->oldListId = $this->_helper->getConfigValue(\Ebizmarts\MailChimp\Helper\Data::XML_PATH_LIST, $this->getScopeId());
 
             $createWebhook = true;
@@ -100,7 +103,7 @@ class MonkeyStore extends \Magento\Framework\App\Config\Value
                 $this->_helper->markAllBatchesAs($mailchimpStore, 'canceled');
                 $this->_helper->resetErrors($mailchimpStore);
             }
-            if ($createWebhook) {
+            if ($createWebhook&&isset($data['general']['fields']['apikey'])) {
                 $this->_helper->createWebHook($data['general']['fields']['apikey']['value'], $newListId);
             }
         }

--- a/Model/Config/Source/MonkeyList.php
+++ b/Model/Config/Source/MonkeyList.php
@@ -27,10 +27,21 @@ class MonkeyList implements \Magento\Framework\Option\ArrayInterface
         \Magento\Framework\App\RequestInterface $request
     ) {
         $storeId = (int) $request->getParam("store", 0);
+        if($request->getParam('website',0)) {
+            $scope = 'websites';
+            $storeId = $request->getParam('website',0);
+        }
+        elseif($request->getParam('store',0)) {
+            $scope = 'stores';
+            $storeId = $request->getParam('store',0);
+        }
+        else {
+            $scope = 'default';
+        }
 
         if ($helper->getApiKey($storeId)) {
             try {
-                $this->options = $helper->getApi()->lists->getLists($helper->getConfigValue(\Ebizmarts\MailChimp\Helper\Data::XML_PATH_LIST, $storeId));
+                $this->options = $helper->getApi()->lists->getLists($helper->getConfigValue(\Ebizmarts\MailChimp\Helper\Data::XML_PATH_LIST, $storeId,$scope));
             } catch (\Exception $e) {
                 $helper->log($e->getMessage());
             }

--- a/Model/Config/Source/MonkeyList.php
+++ b/Model/Config/Source/MonkeyList.php
@@ -18,18 +18,19 @@ class MonkeyList implements \Magento\Framework\Option\ArrayInterface
     private $options = null;
 
     /**
-     * MonkeyStore constructor.
+     * MonkeyList constructor.
      * @param \Ebizmarts\MailChimp\Helper\Data $helper
-     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
+     * @param \Magento\Framework\App\RequestInterface $request
      */
     public function __construct(
         \Ebizmarts\MailChimp\Helper\Data $helper,
-        \Magento\Store\Model\StoreManagerInterface $storeManager
+        \Magento\Framework\App\RequestInterface $request
     ) {
-    
-        if ($helper->getApiKey($storeManager->getStore()->getId())) {
+        $storeId = (int) $request->getParam("store", 0);
+
+        if ($helper->getApiKey($storeId)) {
             try {
-                $this->options = $helper->getApi()->lists->getLists($helper->getConfigValue(\Ebizmarts\MailChimp\Helper\Data::XML_PATH_LIST, $storeManager->getStore()->getId()));
+                $this->options = $helper->getApi()->lists->getLists($helper->getConfigValue(\Ebizmarts\MailChimp\Helper\Data::XML_PATH_LIST, $storeId));
             } catch (\Exception $e) {
                 $helper->log($e->getMessage());
             }

--- a/Model/Config/Source/MonkeyStore.php
+++ b/Model/Config/Source/MonkeyStore.php
@@ -20,14 +20,15 @@ class MonkeyStore implements \Magento\Framework\Option\ArrayInterface
     /**
      * MonkeyStore constructor.
      * @param \Ebizmarts\MailChimp\Helper\Data $helper
-     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
+     * @param \Magento\Framework\App\RequestInterface $request
      */
     public function __construct(
         \Ebizmarts\MailChimp\Helper\Data $helper,
-        \Magento\Store\Model\StoreManagerInterface $storeManager
+        \Magento\Framework\App\RequestInterface $request
     ) {
-    
-        if ($helper->getApiKey($storeManager->getStore()->getId())) {
+        $storeId = (int) $request->getParam("store", 0);
+
+        if ($helper->getApiKey($storeId)) {
             try {
                 $this->options = $helper->getApi()->ecommerce->stores->get(null, null, null, \Ebizmarts\MailChimp\Helper\Data::MAXSTORES);
             } catch (\Exception $e) {

--- a/Model/Plugin/Subscriber.php
+++ b/Model/Plugin/Subscriber.php
@@ -113,6 +113,13 @@ class Subscriber
 //        $this->_helper->log(__METHOD__);
         $storeId = $this->_storeManager->getStore()->getId();
 
+        /**
+         * Set storeId in $subscriber because if customer subscribe newsletter as a guest, storeId is null and generate error "Data did not match any of the schemas described in anyOf."
+         */
+        if(!$subscriber->getStoreId()) {
+            $subscriber->setStoreId($storeId);
+        }
+
         if ($this->_helper->isMailChimpEnabled($storeId)) {
             $api = $this->_api;
             if ($this->_helper->isDoubleOptInEnabled($storeId)) {

--- a/Model/Plugin/Subscriber.php
+++ b/Model/Plugin/Subscriber.php
@@ -54,18 +54,14 @@ class Subscriber
         $subscriber,
         $customerId
     ) {
-//        $this->_helper->log(__METHOD__);
         $subscriber->loadByCustomerId($customerId);
-//        if ($subscriber->getMailchimpId() != null) {
-            $api = $this->_api;
+        $api = $this->_api;
         try {
             $md5HashEmail = md5(strtolower($subscriber->getSubscriberEmail()));
             $api->lists->members->update($this->_helper->getDefaultList(), $md5HashEmail, null, 'unsubscribed');
-//                $subscriber->setMailchimpId('')->save();
         } catch (\Exception $e) {
             $this->_helper->log($e->getMessage());
         }
-//        }
         return [$customerId];
     }
 
@@ -73,7 +69,6 @@ class Subscriber
         $subscriber,
         $customerId
     ) {
-//        $this->_helper->log(__METHOD__);
         $subscriber->loadByCustomerId($customerId);
         $subscriber->setImportMode(true);
         $storeId = $subscriber->getStoreId();
@@ -93,12 +88,7 @@ class Subscriber
                 $emailHash = md5(strtolower($customer->getEmail()));
                 if (!$subscriber->getMailchimpId()) {
                     $return = $api->lists->members->addOrUpdate($this->_helper->getDefaultList(), $emailHash, null, $status, $mergeVars, null, null, null, null, $email, $status);
-//                    $this->_helper->log($return);
-//                    if (isset($return['id'])) {
-//                        $subscriber->setMailchimpId($return['id']);
-//                    }
                 }
-//                $subscriber->setMailchimpId($emailHash)->save();
             } catch (\Exception $e) {
                 $this->_helper->log($e->getMessage());
             }
@@ -110,7 +100,6 @@ class Subscriber
         $subscriber,
         $email
     ) {
-//        $this->_helper->log(__METHOD__);
         $storeId = $this->_storeManager->getStore()->getId();
 
         if ($this->_helper->isMailChimpEnabled($storeId)) {
@@ -124,10 +113,6 @@ class Subscriber
             try {
                 $md5HashEmail = md5(strtolower($email));
                 $return = $api->lists->members->addOrUpdate($this->_helper->getDefaultList(), $md5HashEmail, null, $status, $mergeVars, null, null, null, null, $email, $status);
-//                $this->_helper->log($return);
-//                if (isset($return['id'])) {
-//                    $subscriber->setMailchimpId($return['id']);
-//                }
             } catch (\Exception $e) {
                 $this->_helper->log($e->getMessage());
             }
@@ -137,19 +122,15 @@ class Subscriber
 
     public function beforeUnsubscribe(
         $subscriber
-    ) {
-//        $this->_helper->log(__METHOD__);
-//        if ($subscriber->getMailchimpId()) {
-//            $this->_helper->log('has id');
+    )
+    {
             $api = $this->_helper->getApi();
         try {
             $md5HashEmail = md5(strtolower($subscriber->getSubscriberEmail()));
             $api->lists->members->update($this->_helper->getDefaultList(), $md5HashEmail, null, 'unsubscribed');
-//                $subscriber->setMailchimpId('');
         } catch (\Exception $e) {
             $this->_helper->log($e->getMessage());
         }
-//        }
         return null;
     }
 }

--- a/Observer/Sales/Order/SaveAfter.php
+++ b/Observer/Sales/Order/SaveAfter.php
@@ -49,5 +49,6 @@ class SaveAfter implements \Magento\Framework\Event\ObserverInterface
             $ecom->setMailchimpSyncModified(1);
             $ecom->getResource()->save($ecom);
         }
+
     }
 }

--- a/Observer/Sales/Order/SubmitBefore.php
+++ b/Observer/Sales/Order/SubmitBefore.php
@@ -27,13 +27,17 @@ class SubmitBefore implements \Magento\Framework\Event\ObserverInterface
         $order = $observer->getEvent()->getData('order');
         /* @var \Magento\Quote\Model\Quote $quote */
         $quote = $observer->getEvent()->getData('quote');
+        $flag = 0;
 
         foreach ($this->attributes as $attribute) {
             if ($quote->hasData($attribute)) {
                 $order->setData($attribute, $quote->getData($attribute));
+                if($quote->getData($attribute)) {
+                    $flag = 1;
+                }
             }
         }
-
+        $order->setData('mailchimp_flag',$flag);
         return $this;
     }
 }

--- a/Setup/InstallSchema.php
+++ b/Setup/InstallSchema.php
@@ -17,6 +17,7 @@ use Magento\Framework\Setup\ModuleContextInterface;
 use Magento\Framework\Setup\SchemaSetupInterface;
 use Symfony\Component\Config\Definition\Exception\Exception;
 use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\App\DeploymentConfig;
 
 class InstallSchema implements InstallSchemaInterface
 {
@@ -24,9 +25,14 @@ class InstallSchema implements InstallSchemaInterface
      * @var ResourceConnection
      */
     protected $_resource;
-    public function __construct(ResourceConnection $resource)
+    /**
+     * @var DeploymentConfig
+     */
+    protected $_deploymentConfig;
+    public function __construct(ResourceConnection $resource,DeploymentConfig $deploymentConfig)
     {
         $this->_resource = $resource;
+        $this->_deploymentConfig = $deploymentConfig;
     }
 
     /**
@@ -205,7 +211,9 @@ class InstallSchema implements InstallSchemaInterface
                 'comment' => 'Retrieved from Mailchimp'
             ]
         );
-        $connection = $this->_resource->getConnectionByName('checkout');
+        if ($this->_deploymentConfig->get(\Magento\Framework\Config\ConfigOptionsListConstants::CONFIG_PATH_DB_CONNECTIONS . '/checkout')) {
+            $connection = $this->_resource->getConnectionByName('checkout');
+        }
         $connection->addColumn(
             $connection->getTableName('quote'),
             'mailchimp_abandonedcart_flag',

--- a/Setup/InstallSchema.php
+++ b/Setup/InstallSchema.php
@@ -19,13 +19,6 @@ use Symfony\Component\Config\Definition\Exception\Exception;
 
 class InstallSchema implements InstallSchemaInterface
 {
-    private $_helper;
-
-    public function __construct(\Ebizmarts\MailChimp\Helper\Data $helper)
-    {
-        $this->_helper = $helper;
-    }
-
     /**
      * {@inheritdoc}
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
@@ -228,13 +221,9 @@ class InstallSchema implements InstallSchemaInterface
             ]
         );
 
-        $path = $this->_helper->getBaseDir() . DIRECTORY_SEPARATOR . 'var' . DIRECTORY_SEPARATOR . 'Mailchimp';
-        try {
-            if (!is_dir($path)) {
-                mkdir($path);
-            }
-        } catch (Exception $e) {
-            $this->_helper->log($e->getMessage());
+        $path = BP . DIRECTORY_SEPARATOR . 'var' . DIRECTORY_SEPARATOR . 'Mailchimp';
+        if (!is_dir($path)) {
+            mkdir($path);
         }
         $installer->endSetup();
     }

--- a/Setup/InstallSchema.php
+++ b/Setup/InstallSchema.php
@@ -202,6 +202,10 @@ class InstallSchema implements InstallSchemaInterface
 
         $connection->createTable($table);
 
+        if ($this->_deploymentConfig->get(\Magento\Framework\Config\ConfigOptionsListConstants::CONFIG_PATH_DB_CONNECTIONS . '/sales')) {
+            $connection = $this->_resource->getConnectionByName('sales');
+        }
+
         $connection->addColumn(
             $connection->getTableName('sales_order'),
             'mailchimp_abandonedcart_flag',

--- a/Setup/InstallSchema.php
+++ b/Setup/InstallSchema.php
@@ -16,21 +16,28 @@ use Magento\Framework\Setup\InstallSchemaInterface;
 use Magento\Framework\Setup\ModuleContextInterface;
 use Magento\Framework\Setup\SchemaSetupInterface;
 use Symfony\Component\Config\Definition\Exception\Exception;
+use Magento\Framework\App\ResourceConnection;
 
 class InstallSchema implements InstallSchemaInterface
 {
+    /**
+     * @var ResourceConnection
+     */
+    protected $_resource;
+    public function __construct(ResourceConnection $resource)
+    {
+        $this->_resource = $resource;
+    }
+
     /**
      * {@inheritdoc}
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
     public function install(SchemaSetupInterface $setup, ModuleContextInterface $context)
     {
-        $installer = $setup;
-
-        $installer->startSetup();
-        $connection = $installer->getConnection();
-        $table = $installer->getConnection()
-            ->newTable($installer->getTable('mailchimp_sync_batches'))
+        $connection = $this->_resource->getConnectionByName('default');
+        $table = $connection
+            ->newTable($connection->getTableName('mailchimp_sync_batches'))
             ->addColumn(
                 'id',
                 \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
@@ -67,10 +74,10 @@ class InstallSchema implements InstallSchemaInterface
                 'Status'
             );
 
-        $installer->getConnection()->createTable($table);
+        $connection->createTable($table);
 
-        $table = $installer->getConnection()
-            ->newTable($installer->getTable('mailchimp_errors'))
+        $table = $connection
+            ->newTable($connection->getTableName('mailchimp_errors'))
             ->addColumn(
                 'id',
                 \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
@@ -121,11 +128,11 @@ class InstallSchema implements InstallSchemaInterface
                 'regtype'
             );
 
-        $installer->getConnection()->createTable($table);
+        $connection->createTable($table);
 
 
-        $table = $installer->getConnection()
-            ->newTable($installer->getTable('mailchimp_sync_ecommerce'))
+        $table = $connection
+            ->newTable($connection->getTableName('mailchimp_sync_ecommerce'))
             ->addColumn(
                 'id',
                 \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
@@ -187,22 +194,10 @@ class InstallSchema implements InstallSchemaInterface
                 'Quote token'
             );
 
-        $installer->getConnection()->createTable($table);
-
-
-
-//        $connection->addColumn(
-//            $installer->getTable('newsletter_subscriber'),
-//            'mailchimp_id',
-//            [
-//                'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
-//                'default' => '',
-//                'comment' => 'Mailchimp reference'
-//            ]
-//        );
+        $connection->createTable($table);
 
         $connection->addColumn(
-            $installer->getTable('quote'),
+            $connection->getTableName('sales_order'),
             'mailchimp_abandonedcart_flag',
             [
                 'type' => \Magento\Framework\DB\Ddl\Table::TYPE_BOOLEAN,
@@ -210,9 +205,9 @@ class InstallSchema implements InstallSchemaInterface
                 'comment' => 'Retrieved from Mailchimp'
             ]
         );
-
+        $connection = $this->_resource->getConnectionByName('checkout');
         $connection->addColumn(
-            $installer->getTable('sales_order'),
+            $connection->getTableName('quote'),
             'mailchimp_abandonedcart_flag',
             [
                 'type' => \Magento\Framework\DB\Ddl\Table::TYPE_BOOLEAN,
@@ -225,6 +220,5 @@ class InstallSchema implements InstallSchemaInterface
         if (!is_dir($path)) {
             mkdir($path);
         }
-        $installer->endSetup();
     }
 }

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -393,5 +393,25 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 );
             $connection->createTable($table);
         }
+        if (version_compare($context->getVersion(), '1.0.24') < 0) {
+            $salesConnection->addColumn(
+                $salesConnection->getTableName('sales_order_grid'),
+                'mailchimp_flag',
+                [
+                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_BOOLEAN,
+                    'default' => 0,
+                    'comment' => 'Retrieved from Mailchimp'
+                ]
+            );
+            $salesConnection->addColumn(
+                $salesConnection->getTableName('sales_order'),
+                'mailchimp_flag',
+                [
+                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_BOOLEAN,
+                    'default' => 0,
+                    'comment' => 'Retrieved from Mailchimp'
+                ]
+            );
+        }
     }
 }

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -16,6 +16,7 @@ use Magento\Framework\Setup\UpgradeSchemaInterface;
 use Magento\Framework\Setup\SchemaSetupInterface;
 use Magento\Framework\Setup\ModuleContextInterface;
 use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\App\DeploymentConfig;
 
 class UpgradeSchema implements UpgradeSchemaInterface
 {
@@ -23,9 +24,14 @@ class UpgradeSchema implements UpgradeSchemaInterface
      * @var ResourceConnection
      */
     protected $_resource;
-    public function __construct(ResourceConnection $resource)
+    /**
+     * @var DeploymentConfig
+     */
+    protected $_deploymentConfig;
+    public function __construct(ResourceConnection $resource,DeploymentConfig $deploymentConfig)
     {
         $this->_resource = $resource;
+        $this->_deploymentConfig = $deploymentConfig;
     }
 
     /**
@@ -34,7 +40,12 @@ class UpgradeSchema implements UpgradeSchemaInterface
     public function upgrade(SchemaSetupInterface $setup, ModuleContextInterface $context)
     {
         $connection = $this->_resource->getConnectionByName('default');
-        $checkoutConnection = $this->_resource->getConnectionByName('checkout');
+        if ($this->_deploymentConfig->get(\Magento\Framework\Config\ConfigOptionsListConstants::CONFIG_PATH_DB_CONNECTIONS . '/checkout')) {
+            $checkoutConnection = $this->_resource->getConnectionByName('checkout');
+        }
+        else {
+            $checkoutConnection = $connection;
+        }
         if (version_compare($context->getVersion(), '1.0.5') < 0) {
             $table = $connection
                 ->newTable($connection->getTableName('mailchimp_stores'))

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -15,19 +15,29 @@ namespace Ebizmarts\MailChimp\Setup;
 use Magento\Framework\Setup\UpgradeSchemaInterface;
 use Magento\Framework\Setup\SchemaSetupInterface;
 use Magento\Framework\Setup\ModuleContextInterface;
+use Magento\Framework\App\ResourceConnection;
 
 class UpgradeSchema implements UpgradeSchemaInterface
 {
+    /**
+     * @var ResourceConnection
+     */
+    protected $_resource;
+    public function __construct(ResourceConnection $resource)
+    {
+        $this->_resource = $resource;
+    }
+
     /**
      * {@inheritdoc}
      */
     public function upgrade(SchemaSetupInterface $setup, ModuleContextInterface $context)
     {
-        $installer = $setup;
-        $installer->startSetup();
+        $connection = $this->_resource->getConnectionByName('default');
+        $checkoutConnection = $this->_resource->getConnectionByName('checkout');
         if (version_compare($context->getVersion(), '1.0.5') < 0) {
-            $table = $installer->getConnection()
-                ->newTable($installer->getTable('mailchimp_stores'))
+            $table = $connection
+                ->newTable($connection->getTableName('mailchimp_stores'))
                 ->addColumn(
                     'id',
                     \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
@@ -176,11 +186,11 @@ class UpgradeSchema implements UpgradeSchemaInterface
                     'store country code'
                 );
 
-            $installer->getConnection()->createTable($table);
+            $connection->createTable($table);
         }
         if (version_compare($context->getVersion(), '1.0.7') < 0) {
-            $installer->getConnection()->addColumn(
-                $installer->getTable('quote'),
+            $checkoutConnection->addColumn(
+                $checkoutConnection->getTableName('quote'),
                 'mailchimp_campaign_id',
                 [
                     'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
@@ -190,8 +200,8 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 ]
             );
 
-            $installer->getConnection()->addColumn(
-                $installer->getTable('sales_order'),
+            $connection->addColumn(
+                $connection->getTableName('sales_order'),
                 'mailchimp_campaign_id',
                 [
                     'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
@@ -200,8 +210,8 @@ class UpgradeSchema implements UpgradeSchemaInterface
                     'comment' => 'Campaign'
                 ]
             );
-            $installer->getConnection()->addColumn(
-                $installer->getTable('quote'),
+            $checkoutConnection->addColumn(
+                $checkoutConnection->getTableName('quote'),
                 'mailchimp_landing_page',
                 [
                     'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
@@ -211,8 +221,8 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 ]
             );
 
-            $installer->getConnection()->addColumn(
-                $installer->getTable('sales_order'),
+            $connection->addColumn(
+                $connection->getTableName('sales_order'),
                 'mailchimp_landing_page',
                 [
                     'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
@@ -223,8 +233,8 @@ class UpgradeSchema implements UpgradeSchemaInterface
             );
         }
         if (version_compare($context->getVersion(), '1.0.8') < 0) {
-            $installer->getConnection()->addColumn(
-                $installer->getTable('mailchimp_errors'),
+            $connection->addColumn(
+                $connection->getTableName('mailchimp_errors'),
                 'original_id',
                 [
                     'type' => \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
@@ -233,8 +243,8 @@ class UpgradeSchema implements UpgradeSchemaInterface
                     'comment' => 'Associated object ID'
                 ]
             );
-            $installer->getConnection()->addColumn(
-                $installer->getTable('mailchimp_errors'),
+            $connection->addColumn(
+                $connection->getTableName('mailchimp_errors'),
                 'batch_id',
                 [
                     'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
@@ -245,8 +255,8 @@ class UpgradeSchema implements UpgradeSchemaInterface
             );
         }
         if (version_compare($context->getVersion(), '1.0.10') < 0) {
-            $installer->getConnection()->addColumn(
-                $installer->getTable('mailchimp_errors'),
+            $connection->addColumn(
+                $connection->getTableName('mailchimp_errors'),
                 'store_id',
                 [
                     'type' => \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
@@ -257,8 +267,8 @@ class UpgradeSchema implements UpgradeSchemaInterface
             );
         }
         if (version_compare($context->getVersion(), '1.0.11') < 0) {
-            $installer->getConnection()->addColumn(
-                $installer->getTable('mailchimp_stores'),
+            $connection->addColumn(
+                $connection->getTableName('mailchimp_stores'),
                 'domain',
                 [
                     'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
@@ -269,8 +279,8 @@ class UpgradeSchema implements UpgradeSchemaInterface
             );
         }
         if (version_compare($context->getVersion(), '1.0.12') < 0) {
-            $installer->getConnection()->changecolumn(
-                $installer->getTable('mailchimp_stores'),
+            $connection->changecolumn(
+                $connection->getTableName('mailchimp_stores'),
                 'address_address1',
                 'address_address_one',
                 [
@@ -280,8 +290,8 @@ class UpgradeSchema implements UpgradeSchemaInterface
                     'comment' => 'first street address'
                 ]
             );
-            $installer->getConnection()->changecolumn(
-                $installer->getTable('mailchimp_stores'),
+            $connection->changecolumn(
+                $connection->getTableName('mailchimp_stores'),
                 'address_address2',
                 'address_address_two',
                 [
@@ -293,8 +303,8 @@ class UpgradeSchema implements UpgradeSchemaInterface
             );
         }
         if (version_compare($context->getVersion(), '1.0.13') < 0) {
-            $installer->getConnection()->addColumn(
-                $installer->getTable('mailchimp_stores'),
+            $connection->addColumn(
+                $connection->getTableName('mailchimp_stores'),
                 'mc_account_name',
                 [
                     'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
@@ -303,8 +313,8 @@ class UpgradeSchema implements UpgradeSchemaInterface
                     'comment' => 'MC account name'
                 ]
             );
-            $installer->getConnection()->addColumn(
-                $installer->getTable('mailchimp_stores'),
+            $connection->addColumn(
+                $connection->getTableName('mailchimp_stores'),
                 'list_name',
                 [
                     'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
@@ -315,8 +325,8 @@ class UpgradeSchema implements UpgradeSchemaInterface
             );
         }
         if (version_compare($context->getVersion(), '1.0.14') < 0) {
-            $installer->getConnection()->addColumn(
-                $installer->getTable('mailchimp_sync_ecommerce'),
+            $connection->addColumn(
+                $connection->getTableName('mailchimp_sync_ecommerce'),
                 'batch_id',
                 [
                     'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
@@ -327,8 +337,8 @@ class UpgradeSchema implements UpgradeSchemaInterface
             );
         }
         if (version_compare($context->getVersion(), '1.0.15') < 0) {
-            $table = $installer->getConnection()
-                ->newTable($installer->getTable('mailchimp_webhook_request'))
+            $table = $connection
+                ->newTable($connection->getTableName('mailchimp_webhook_request'))
                 ->addColumn(
                     'id',
                     \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
@@ -364,8 +374,7 @@ class UpgradeSchema implements UpgradeSchemaInterface
                     [],
                     'Already processed'
                 );
-            $installer->getConnection()->createTable($table);
+            $connection->createTable($table);
         }
-        $installer->endSetup();
     }
 }

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -46,6 +46,12 @@ class UpgradeSchema implements UpgradeSchemaInterface
         else {
             $checkoutConnection = $connection;
         }
+        if ($this->_deploymentConfig->get(\Magento\Framework\Config\ConfigOptionsListConstants::CONFIG_PATH_DB_CONNECTIONS . '/sales')) {
+            $salesConnection = $this->_resource->getConnectionByName('sales');
+        }
+        else {
+            $salesConnection = $connection;
+        }
         if (version_compare($context->getVersion(), '1.0.5') < 0) {
             $table = $connection
                 ->newTable($connection->getTableName('mailchimp_stores'))
@@ -211,8 +217,8 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 ]
             );
 
-            $connection->addColumn(
-                $connection->getTableName('sales_order'),
+            $salesConnection->addColumn(
+                $salesConnection->getTableName('sales_order'),
                 'mailchimp_campaign_id',
                 [
                     'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
@@ -232,8 +238,8 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 ]
             );
 
-            $connection->addColumn(
-                $connection->getTableName('sales_order'),
+            $salesConnection->addColumn(
+                $salesConnection->getTableName('sales_order'),
                 'mailchimp_landing_page',
                 [
                     'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,

--- a/Ui/Component/Listing/Column/Monkey.php
+++ b/Ui/Component/Listing/Column/Monkey.php
@@ -37,6 +37,10 @@ class Monkey extends Column
      * @var \Magento\Framework\App\RequestInterface
      */
     protected $_requestInterfase;
+    /**
+     * @var \Ebizmarts\MailChimp\Helper\Data
+     */
+    protected $_helper;
 
     /**
      * Monkey constructor.
@@ -46,6 +50,7 @@ class Monkey extends Column
      * @param \Magento\Framework\View\Asset\Repository $assetRepository
      * @param \Magento\Framework\App\RequestInterface $requestInterface
      * @param SearchCriteriaBuilder $criteria
+     * @param \Ebizmarts\MailChimp\Helper\Data $helper
      * @param array $components
      * @param array $data
      */
@@ -56,6 +61,7 @@ class Monkey extends Column
         \Magento\Framework\View\Asset\Repository $assetRepository,
         \Magento\Framework\App\RequestInterface $requestInterface,
         SearchCriteriaBuilder $criteria,
+        \Ebizmarts\MailChimp\Helper\Data $helper,
         array $components = [],
         array $data = []
     ) {
@@ -64,6 +70,7 @@ class Monkey extends Column
         $this->_searchCriteria  = $criteria;
         $this->_assetRepository = $assetRepository;
         $this->_requestInterfase= $requestInterface;
+        $this->_helper          = $helper;
         parent::__construct($context, $uiComponentFactory, $components, $data);
     }
 
@@ -71,11 +78,7 @@ class Monkey extends Column
     {
         if (isset($dataSource['data']['items'])) {
             foreach ($dataSource['data']['items'] as & $item) {
-                $order = $this->_orderRepository->get($item["entity_id"]);
-                $status = $order->getData("mailchimp_abandonedcart_flag");
-                if ($order->getMailchimpCampaignId() || $order->getMailchimpLandingPage()) {
-                    $status = 1;
-                }
+                $status = $item['mailchimp_flag'];
                 $fieldName = $this->getData('name');
 
                 switch ($status) {
@@ -92,7 +95,6 @@ class Monkey extends Column
                         $item[$fieldName . '_src'] = $url;
                         $item[$fieldName . '_alt'] = 'hep hep thanks MailChimp';
                         $item[$fieldName . '_link'] = '';
-//                        $item[$fieldName . '_orig_src'] = $url;
                         break;
                 }
             }

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   },
   "description": "Connect MailChimp with Magento",
   "type": "magento2-module",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "authors": [
     {
       "name": "Ebizmarts Corp",

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   },
   "description": "Connect MailChimp with Magento",
   "type": "magento2-module",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "authors": [
     {
       "name": "Ebizmarts Corp",

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   },
   "description": "Connect MailChimp with Magento",
   "type": "magento2-module",
-  "version": "1.0.24",
+  "version": "1.0.24.1",
   "authors": [
     {
       "name": "Ebizmarts Corp",

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   },
   "description": "Connect MailChimp with Magento",
   "type": "magento2-module",
-  "version": "1.0.21",
+  "version": "1.0.21.1",
   "authors": [
     {
       "name": "Ebizmarts Corp",

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   },
   "description": "Connect MailChimp with Magento",
   "type": "magento2-module",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "authors": [
     {
       "name": "Ebizmarts Corp",

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -57,7 +57,7 @@
                 <field id="monkeylist" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Mailchimp List</label>
                     <source_model>Ebizmarts\MailChimp\Model\Config\Source\MonkeyList</source_model>
-                    <backend_model>Ebizmarts\MailChimp\Model\Config\Backend\MonkeyList</backend_model>
+                    <!--<backend_model>Ebizmarts\MailChimp\Model\Config\Backend\MonkeyList</backend_model>-->
                     <depends>
                         <field id="*/*/active">1</field>
                     </depends>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -56,4 +56,11 @@
     <type name="Magento\Customer\Model\AccountManagement">
         <plugin name="abandoned-checkout-save-quote" type="Ebizmarts\MailChimp\Model\Plugin\AccountManagement" sortOrder="10"/>
     </type>
+    <virtualType name="Magento\Sales\Model\ResourceModel\Order\Grid" type="Magento\Sales\Model\ResourceModel\Grid">
+        <arguments>
+            <argument name="columns" xsi:type="array">
+                <item name="mailchimp_flag" xsi:type="string">sales_order.mailchimp_flag</item>
+            </argument>
+        </arguments>
+    </virtualType>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -11,7 +11,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Ebizmarts_MailChimp" setup_version="1.0.21">
+    <module name="Ebizmarts_MailChimp" setup_version="1.0.22">
         <sequence>
             <module name="Magento_Newsletter"/>
         </sequence>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -11,7 +11,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Ebizmarts_MailChimp" setup_version="1.0.23">
+    <module name="Ebizmarts_MailChimp" setup_version="1.0.24">
         <sequence>
             <module name="Magento_Newsletter"/>
         </sequence>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -11,7 +11,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Ebizmarts_MailChimp" setup_version="1.0.22">
+    <module name="Ebizmarts_MailChimp" setup_version="1.0.23">
         <sequence>
             <module name="Magento_Newsletter"/>
         </sequence>

--- a/view/frontend/web/js/mailchimpjs.js
+++ b/view/frontend/web/js/mailchimpjs.js
@@ -1,6 +1,6 @@
 require(["jquery"], function ($) {
     $.ajax({
-        url: 'mailchimp/script/get',
+        url: '/mailchimp/script/get',
         type: 'POST',
         dataType: 'json',
         showLoader: false


### PR DESCRIPTION
If customer subscribe newsletter as a guest, the variable $subscriber in the function beforeSubscribe (class Ebizmarts/MailChimp/Model/Plugin/Subscriber.php) has storeId null. This situation generate error "Data did not match any of the schemas described in anyOf." when module calls api for add subscribe in mailchimp.

We set storeId for resolve issue. For our company policy we modified also composer version because we editing a module third parts.

