### PR TITLE
bump version on module.xml to allow schema upgrade

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -11,7 +11,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Ebizmarts_MailChimp" setup_version="1.0.24">
+    <module name="Ebizmarts_MailChimp" setup_version="1.0.25">
         <sequence>
             <module name="Magento_Newsletter"/>
         </sequence>


### PR DESCRIPTION
On large catalogs, an index on mailchimp_sync_ecommerce table is required.

This is implemented in etup/UpgradeSchema.php:415, but the version on module.xml is outdated causing the module does not upgrade schema.