### PR TITLE
Adds getUrl() function to get the correct script URL (fixes issue 164)

### DIFF
--- a/view/frontend/web/js/mailchimpjs.js
+++ b/view/frontend/web/js/mailchimpjs.js
@@ -1,6 +1,10 @@
 require(["jquery"], function ($) {
+    function getUrl(path) {
+        return require.toUrl('').split('static/')[0] + path.replace(/^\//g, '');
+    };
+
     $.ajax({
-        url: '/mailchimp/script/get',
+        url: getUrl('/mailchimp/script/get'),
         type: 'POST',
         dataType: 'json',
         showLoader: false


### PR DESCRIPTION
Fixes [issues/164](https://github.com/mailchimp/mc-magento2/issues/164)

--

This probably isn't the cleanest approach to getting the correct Magento base URL, but it works just fine. It was the only way I could think of without changing the way the `mailchimp.js` script is included. 