### PR TITLE
Fix for broken admin grid in production

### DIFF
--- a/Model/ResourceModel/MailChimpStores/Grid/Collection.php
+++ b/Model/ResourceModel/MailChimpStores/Grid/Collection.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Copyright © 2013-2017 Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Ebizmarts\MailChimp\Model\ResourceModel\MailChimpStores\Grid;
+
+use Magento\Framework\View\Element\UiComponent\DataProvider\Document;
+use Magento\Framework\Data\Collection\Db\FetchStrategyInterface as FetchStrategy;
+use Magento\Framework\Data\Collection\EntityFactoryInterface as EntityFactory;
+use Magento\Framework\Event\ManagerInterface as EventManager;
+use Psr\Log\LoggerInterface as Logger;
+
+class Collection extends \Magento\Framework\View\Element\UiComponent\DataProvider\SearchResult
+{
+    /**
+     * @inheritdoc
+     */
+    protected $document = Document::class;
+
+    /**
+     * Initialize dependencies.
+     *
+     * @param EntityFactory $entityFactory
+     * @param Logger $logger
+     * @param FetchStrategy $fetchStrategy
+     * @param EventManager $eventManager
+     * @param string $mainTable
+     * @param string $resourceModel
+     */
+    public function __construct(
+        EntityFactory $entityFactory,
+        Logger $logger,
+        FetchStrategy $fetchStrategy,
+        EventManager $eventManager,
+        $mainTable = 'mailchimp_stores',
+        $resourceModel = '\Ebizmarts\MailChimp\Model\ResourceModel\MailChimpStores'
+    ) {
+        parent::__construct($entityFactory, $logger, $fetchStrategy, $eventManager, $mainTable, $resourceModel);
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -46,7 +46,7 @@
     <type name="Magento\Framework\View\Element\UiComponent\DataProvider\CollectionFactory">
         <arguments>
             <argument name="collections" xsi:type="array">
-                <item name="mailchimp_stores_grid_data_source" xsi:type="string">Ebizmarts\MailChimp\Model\ResourceModel\MailChimpStores\Collection</item>
+                <item name="mailchimp_stores_grid_data_source" xsi:type="string">Ebizmarts\MailChimp\Model\ResourceModel\MailChimpStores\Grid\Collection</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
## Title
Fix for broken grid in  **production environment** on the Mailchimp Stores grid

## Current Status
When trying to go to the grid of Mailchimp stores I get following error: 
`Warning: Invalid argument supplied for foreach() in /vendor/magento/framework/View/Element/UiComponent/DataProvider/DataProvider.php on line 252
`
## Fixes issues
issue #170 : Error on Mailchimp Stores Grid 

## Description
I used the implementation of the Magento Customer Grid as a base for this implementation on the stores Grid and this fixes the problem. Working both on development / production 

### Steps to reproduce
1. Go to the grid of the Mailchimp stores
2. See the error 

### Result after PR

1. Go to the grid of the Mailchimp stores
2. See the stores

