### PR TITLE
Show "Mailchimp" customer tab when the extension is enabled

### DIFF
--- a/view/adminhtml/layout/customer_index_edit.xml
+++ b/view/adminhtml/layout/customer_index_edit.xml
@@ -15,7 +15,7 @@
     <body>
         <referenceContainer name="content">
             <referenceBlock name="customer_form">
-                <block class="Ebizmarts\MailChimp\Block\Adminhtml\Customer\Edit\Tabs\Mailchimp" name="customer_edit_tab_mailchimp" template="tab/view.phtml">
+                <block class="Ebizmarts\MailChimp\Block\Adminhtml\Customer\Edit\Tabs\Mailchimp" name="customer_edit_tab_mailchimp" template="tab/view.phtml" ifconfig="mailchimp/general/active">
                     <arguments>
                         <argument name="sort_order" xsi:type="number">50</argument>
                     </arguments>


### PR DESCRIPTION
This PR fixes the page layout for Customer > Index > Edit so that the "Mailchimp" tab is only displayed when the extension is enabled.

As a side effect, attempting to load the customer's interests no longer happens, which should fix #200 .