### PR TITLE
Wrong error management

### DIFF
--- a/Controller/Checkout/Success.php
+++ b/Controller/Checkout/Success.php
@@ -37,10 +37,6 @@ class Success extends \Magento\Framework\App\Action\Action
      * @var \Ebizmarts\MailChimp\Model\MailChimpInterestGroupFactory
      */
     protected $_interestGroupFactory;
-    /**
-     * @var \Magento\Framework\Stdlib\DateTime\DateTime
-     */
-    protected $_date;
 
     /**
      * Success constructor.
@@ -50,7 +46,6 @@ class Success extends \Magento\Framework\App\Action\Action
      * @param \Magento\Checkout\Model\Session $checkoutSession
      * @param \Magento\Newsletter\Model\SubscriberFactory $subscriberFactory
      * @param \Ebizmarts\MailChimp\Model\MailChimpInterestGroupFactory $interestGroupFactory
-     * @param \Magento\Framework\Stdlib\DateTime\DateTime $date
      */
     public function __construct(
         \Magento\Framework\App\Action\Context $context,
@@ -58,8 +53,7 @@ class Success extends \Magento\Framework\App\Action\Action
         \Ebizmarts\MailChimp\Helper\Data $helper,
         \Magento\Checkout\Model\Session $checkoutSession,
         \Magento\Newsletter\Model\SubscriberFactory $subscriberFactory,
-        \Ebizmarts\MailChimp\Model\MailChimpInterestGroupFactory $interestGroupFactory,
-        \Magento\Framework\Stdlib\DateTime\DateTime $date
+        \Ebizmarts\MailChimp\Model\MailChimpInterestGroupFactory $interestGroupFactory
     )
     {
         $this->_pageFactory         =$pageFactory;
@@ -67,7 +61,6 @@ class Success extends \Magento\Framework\App\Action\Action
         $this->_checkoutSession     = $checkoutSession;
         $this->_subscriberFactory   = $subscriberFactory;
         $this->_interestGroupFactory= $interestGroupFactory;
-        $this->_date                = $date;
         parent::__construct($context);
     }
 
@@ -88,10 +81,10 @@ class Success extends \Magento\Framework\App\Action\Action
                 $interestGroup->setGroupdata(serialize($params));
                 $interestGroup->setSubscriberId($subscriber->getSubscriberId());
                 $interestGroup->setStoreId($subscriber->getStoreId());
-                $interestGroup->setUpdatedAt($this->_date->gmtDate());
+                $interestGroup->setUpdatedAt($this->_helper->getGmtDate());
                 $interestGroup->getResource()->save($interestGroup);
                 $listId = $this->_helper->getGeneralList($order->getStoreId());
-                $this->_updateSubscriber($listId, $subscriber->getId(), $this->_date->gmtDate(), '', 1);
+                $this->_updateSubscriber($listId, $subscriber->getId(), $this->_helper->getGmtDate(), '', 1);
             } else {
                 $this->_subscriberFactory->create()->subscribe($order->getCustomerEmail());
                 $subscriber->loadByEmail($order->getCustomerEmail());
@@ -99,7 +92,7 @@ class Success extends \Magento\Framework\App\Action\Action
                 $interestGroup->setGroupdata(serialize($params));
                 $interestGroup->setSubscriberId($subscriber->getSubscriberId());
                 $interestGroup->setStoreId($subscriber->getStoreId());
-                $interestGroup->setUpdatedAt($this->_date->gmtDate());
+                $interestGroup->setUpdatedAt($this->_helper->getGmtDate());
                 $interestGroup->getResource()->save($interestGroup);
             }
         } catch(\Exception $e) {
@@ -108,9 +101,9 @@ class Success extends \Magento\Framework\App\Action\Action
         $this->messageManager->addSuccessMessage(__('Thanks for share your interest with us'));
         $this->_redirect($this->_helper->getBaserUrl($order->getStoreId(),\Magento\Framework\UrlInterface::URL_TYPE_WEB));
     }
-    protected function _updateSubscriber($listId, $entityId, $sync_delta, $sync_error='', $sync_modified=0)
+    protected function _updateSubscriber($listId, $entityId, $sync_delta = null, $sync_error=null, $sync_modified=null)
     {
-        $this->_helper->saveEcommerceData($listId, $entityId, $sync_delta, $sync_error, $sync_modified,
-            \Ebizmarts\MailChimp\Helper\Data::IS_SUBSCRIBER);
+        $this->_helper->saveEcommerceData($listId, $entityId, \Ebizmarts\MailChimp\Helper\Data::IS_SUBSCRIBER,
+            $sync_delta, $sync_error, $sync_modified);
     }
 }

--- a/Cron/Ecommerce.php
+++ b/Cron/Ecommerce.php
@@ -112,7 +112,7 @@ class Ecommerce
     {
         $connection = $this->_chimpSyncEcommerce->getResource()->getConnection();
         $tableName = $this->_chimpSyncEcommerce->getResource()->getMainTable();
-        $connection->delete($tableName, 'batch_id is null');
+        $connection->delete($tableName, 'batch_id is null and mailchimp_sync_modified != 1');
 
         foreach ($this->_storeManager->getStores() as $storeId => $val) {
             $this->_storeManager->setCurrentStore($storeId);
@@ -123,8 +123,8 @@ class Ecommerce
                     $this->_apiResult->processResponses($storeId, true, $mailchimpStoreId);
                     $batchId = $this->_processStore($storeId, $mailchimpStoreId, $listId);
                     if ($batchId) {
-                        $connection->update($tableName, ['batch_id' => $batchId], "batch_id is null and mailchimp_store_id = '$mailchimpStoreId'");
-                        $connection->update($tableName, ['batch_id' => $batchId], "batch_id is null and mailchimp_store_id = '$listId'");
+                        $connection->update($tableName, ['batch_id' => $batchId, 'mailchimp_sync_modified' => 0, 'mailchimp_sync_delta' => $this->_helper->getGmtDate()], "batch_id is null and mailchimp_store_id = '$mailchimpStoreId'");
+                        $connection->update($tableName, ['batch_id' => $batchId, 'mailchimp_sync_modified' => 0, 'mailchimp_sync_delta' => $this->_helper->getGmtDate()], "batch_id is null and mailchimp_store_id = '$listId'");
                     }
                 }
             }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -165,6 +165,10 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      * @var \Ebizmarts\MailChimp\Model\MailChimpInterestGroupFactory
      */
     protected $_interestGroupFactory;
+    /**
+     * @var \Magento\Framework\Stdlib\DateTime\DateTime
+     */
+    protected $_date;
 
 
     private $customerAtt    = null;
@@ -197,6 +201,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      * @param \Magento\Directory\Api\CountryInformationAcquirerInterface $countryInformation
      * @param \Magento\Framework\App\ResourceConnection $resource
      * @param \Ebizmarts\MailChimp\Model\MailChimpInterestGroupFactory $interestGroupFactory
+     * @param \Magento\Framework\Stdlib\DateTime\DateTime $date
      */
     public function __construct(
         \Magento\Framework\App\Helper\Context $context,
@@ -223,7 +228,8 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         \Magento\Customer\Model\CustomerFactory $customerFactory,
         \Magento\Directory\Api\CountryInformationAcquirerInterface $countryInformation,
         \Magento\Framework\App\ResourceConnection $resource,
-        \Ebizmarts\MailChimp\Model\MailChimpInterestGroupFactory $interestGroupFactory
+        \Ebizmarts\MailChimp\Model\MailChimpInterestGroupFactory $interestGroupFactory,
+        \Magento\Framework\Stdlib\DateTime\DateTime $date
     ) {
 
         $this->_storeManager  = $storeManager;
@@ -253,6 +259,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         $this->_customerFactory         = $customerFactory;
         $this->_countryInformation      = $countryInformation;
         $this->_interestGroupFactory    = $interestGroupFactory;
+        $this->_date                    = $date;
         parent::__construct($context);
     }
 
@@ -672,18 +679,31 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     {
         $this->resetErrors();
     }
-    public function saveEcommerceData($storeId, $entityId, $date, $error, $modified, $type, $deleted = 0, $token = null)
+    public function saveEcommerceData($storeId, $entityId, $type, $date = null, $error = null , $modified = null, $deleted = null, $token = null)
     {
 
         $chimpSyncEcommerce = $this->getChimpSyncEcommerce($storeId, $entityId, $type);
         $chimpSyncEcommerce->setMailchimpStoreId($storeId);
         $chimpSyncEcommerce->setType($type);
         $chimpSyncEcommerce->setRelatedId($entityId);
-        $chimpSyncEcommerce->setMailchimpSyncModified($modified);
-        $chimpSyncEcommerce->setMailchimpSyncDelta($date);
-        $chimpSyncEcommerce->setMailchimpSyncError($error);
-        $chimpSyncEcommerce->setMailchimpSyncDeleted($deleted);
-        $chimpSyncEcommerce->setMailchimpToken($token);
+        if($modified) {
+            $chimpSyncEcommerce->setMailchimpSyncModified($modified);
+        }
+        if($date) {
+            $chimpSyncEcommerce->setMailchimpSyncDelta($date);
+        } else {
+            $chimpSyncEcommerce->setBatchId(null);
+        }
+        if($error) {
+            $chimpSyncEcommerce->setMailchimpSyncError($error);
+        }
+        if($deleted) {
+            $chimpSyncEcommerce->setMailchimpSyncDeleted($deleted);
+            $chimpSyncEcommerce->setMailchimpSyncModified(0);
+        }
+        if($token) {
+            $chimpSyncEcommerce->setMailchimpToken($token);
+        }
         $chimpSyncEcommerce->getResource()->save($chimpSyncEcommerce);
     }
 
@@ -979,4 +999,13 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         }
         return $interest;
     }
+    public function getGmtDate()
+    {
+        return $this->_date->gmtDate();
+    }
+    public function getGmtTimeStamp()
+    {
+        return $this->_date->gmtTimestamp();
+    }
+
 }

--- a/Model/Api/Customer.php
+++ b/Model/Api/Customer.php
@@ -33,10 +33,6 @@ class Customer
      */
     protected $_orderCollection;
     /**
-     * @var \Magento\Framework\Stdlib\DateTime\DateTime
-     */
-    protected $_date;
-    /**
      * @var CountryFactory
      */
     protected $_countryFactory;
@@ -59,7 +55,6 @@ class Customer
      * @param \Magento\Sales\Model\ResourceModel\Order\CollectionFactory $orderCollection
      * @param CountryFactory $countryFactory
      * @param \Magento\Customer\Model\Address $address
-     * @param \Magento\Framework\Stdlib\DateTime\DateTime $date
      */
     public function __construct(
         \Ebizmarts\MailChimp\Helper\Data $helper,
@@ -67,15 +62,13 @@ class Customer
         \Magento\Customer\Model\ResourceModel\Customer\CollectionFactory $collection,
         \Magento\Sales\Model\ResourceModel\Order\CollectionFactory $orderCollection,
         \Magento\Directory\Model\CountryFactory $countryFactory,
-        \Magento\Customer\Model\Address $address,
-        \Magento\Framework\Stdlib\DateTime\DateTime $date
+        \Magento\Customer\Model\Address $address
     ) {
     
         $this->_helper              = $helper;
         $this->_collection          = $collection;
         $this->_orderCollection     = $orderCollection;
-        $this->_date                = $date;
-        $this->_batchId             = \Ebizmarts\MailChimp\Helper\Data::IS_CUSTOMER. '_' . $this->_date->gmtTimestamp();
+        $this->_batchId             = \Ebizmarts\MailChimp\Helper\Data::IS_CUSTOMER. '_' . $this->_helper->getGmtTimeStamp();
         $this->_address             = $address;
         $this->_customerFactory     = $customerFactory;
         $this->_countryFactory      = $countryFactory;
@@ -119,7 +112,7 @@ class Customer
                 $customerArray[$counter]['body'] = $customerJson;
 
                 //update customers delta
-                $this->_updateCustomer($mailchimpStoreId, $customer->getId(), $this->_date->gmtDate(), '', 0);
+                $this->_updateCustomer($mailchimpStoreId, $customer->getId());
             }
             $counter++;
         }
@@ -223,15 +216,15 @@ class Customer
         }
         return $optin;
     }
-    protected function _updateCustomer($storeId, $entityId, $sync_delta, $sync_error, $sync_modified)
+    protected function _updateCustomer($storeId, $entityId, $sync_delta = null, $sync_error = null, $sync_modified = null)
     {
         $this->_helper->saveEcommerceData(
             $storeId,
             $entityId,
+            \Ebizmarts\MailChimp\Helper\Data::IS_CUSTOMER,
             $sync_delta,
             $sync_error,
-            $sync_modified,
-            \Ebizmarts\MailChimp\Helper\Data::IS_CUSTOMER
+            $sync_modified
         );
     }
 }

--- a/Model/Api/Order.php
+++ b/Model/Api/Order.php
@@ -43,10 +43,6 @@ class Order
      */
     protected $_orderCollectionFactory;
     /**
-     * @var \Magento\Framework\Stdlib\DateTime\DateTime
-     */
-    protected $_date;
-    /**
      * @var Product
      */
     protected $_apiProduct;
@@ -82,7 +78,6 @@ class Order
      * @param \Magento\Sales\Model\OrderRepository $order
      * @param \Magento\Sales\Model\ResourceModel\Order\CollectionFactory $orderCollectionFactory
      * @param \Magento\Catalog\Model\ResourceModel\Product $product
-     * @param \Magento\Framework\Stdlib\DateTime\DateTime $date
      * @param Product $apiProduct
      * @param Customer $apiCustomer
      * @param \Magento\Catalog\Model\ProductFactory $productFactory
@@ -96,7 +91,6 @@ class Order
         \Magento\Sales\Model\OrderRepository $order,
         \Magento\Sales\Model\ResourceModel\Order\CollectionFactory $orderCollectionFactory,
         \Magento\Catalog\Model\ResourceModel\Product $product,
-        \Magento\Framework\Stdlib\DateTime\DateTime $date,
         \Ebizmarts\MailChimp\Model\Api\Product $apiProduct,
         \Ebizmarts\MailChimp\Model\Api\Customer $apiCustomer,
         \Magento\Catalog\Model\ProductFactory $productFactory,
@@ -108,14 +102,13 @@ class Order
         $this->_helper          = $helper;
         $this->_order           = $order;
         $this->_orderCollectionFactory = $orderCollectionFactory;
-        $this->_date            = $date;
         $this->_apiProduct      = $apiProduct;
         $this->_productFactory   = $productFactory;
         $this->_product         = $product;
         $this->_apiCustomer     = $apiCustomer;
         $this->_countryFactory  = $countryFactory;
         $this->_chimpSyncEcommerce  = $chimpSyncEcommerce;
-        $this->_batchId         = \Ebizmarts\MailChimp\Helper\Data::IS_ORDER. '_' . $this->_date->gmtTimestamp();
+        $this->_batchId         = \Ebizmarts\MailChimp\Helper\Data::IS_ORDER. '_' . $this->_helper->getGmtTimeStamp();
         $this->_firstDate = $this->_helper->getConfigValue(\Ebizmarts\MailChimp\Helper\Data::XML_ECOMMERCE_FIRSTDATE);
         $this->_counter = 0;
         $this->_urlHelper    = $urlHelper;
@@ -173,7 +166,7 @@ class Order
                     $productData = $this->_apiProduct->sendModifiedProduct($order, $mailchimpStoreId, $magentoStoreId);
                 } catch(\Exception $e) {
                     $error = $e->getMessage();
-                    $this->_updateOrder($mailchimpStoreId, $orderId, $this->_date->gmtDate(), $error, 0);
+                    $this->_updateOrder($mailchimpStoreId, $orderId, $this->_helper->getGmtDate(), $error, 0);
                     continue;
                 }
                 if (count($productData)) {
@@ -191,12 +184,12 @@ class Order
                     $batchArray[$this->_counter]['body'] = $orderJson;
                 } else {
                     $error = __('Something went wrong when retreiving product information.');
-                    $this->_updateOrder($mailchimpStoreId, $orderId, $this->_date->gmtDate(), $error, 0);
+                    $this->_updateOrder($mailchimpStoreId, $orderId, $this->_helper->getGmtDate(), $error, 0);
                     continue;
                 }
 
                 //update order delta
-                $this->_updateOrder($mailchimpStoreId, $orderId, $this->_date->gmtDate(), $error, 0);
+                $this->_updateOrder($mailchimpStoreId, $orderId);
                 $this->_counter++;
             } catch (Exception $e) {
                 $this->_helper->log($e->getMessage());
@@ -241,7 +234,7 @@ class Order
                     $productData = $this->_apiProduct->sendModifiedProduct($order, $mailchimpStoreId, $magentoStoreId);
                 } catch(\Exception $e) {
                     $error = $e->getMessage();
-                    $this->_updateOrder($mailchimpStoreId, $orderId, $this->_date->gmtDate(), $error, 0);
+                    $this->_updateOrder($mailchimpStoreId, $orderId, $this->_helper->getGmtDate(), $error, 0);
                     continue;
                 }
                 if (count($productData)) {
@@ -262,7 +255,7 @@ class Order
                 }
 
                 //update order delta
-                $this->_updateOrder($mailchimpStoreId, $orderId, $this->_date->gmtDate(), $error, 0);
+                $this->_updateOrder($mailchimpStoreId, $orderId);
                 $this->_counter++;
             } catch (Exception $e) {
                 $this->_helper->log($e->getMessage());
@@ -652,15 +645,15 @@ class Order
 //        return $this->_api;
 //    }
 
-    protected function _updateOrder($storeId, $entityId, $sync_delta, $sync_error, $sync_modified)
+    protected function _updateOrder($storeId, $entityId, $sync_delta = null, $sync_error=null, $sync_modified=null)
     {
         $this->_helper->saveEcommerceData(
             $storeId,
             $entityId,
+            \Ebizmarts\MailChimp\Helper\Data::IS_ORDER,
             $sync_delta,
             $sync_error,
-            $sync_modified,
-            \Ebizmarts\MailChimp\Helper\Data::IS_ORDER
+            $sync_modified
         );
     }
 }

--- a/Model/Api/Product.php
+++ b/Model/Api/Product.php
@@ -28,10 +28,6 @@ class Product
      */
     protected $_helper;
     /**
-     * @var \Magento\Framework\Stdlib\DateTime\DateTime
-     */
-    protected $_date;
-    /**
      * @var \Magento\Catalog\Model\ProductRepository
      */
     protected $_productRepository;
@@ -76,7 +72,6 @@ class Product
      * Product constructor.
      * @param \Magento\Catalog\Model\ResourceModel\Product\CollectionFactory $productCollection
      * @param \Magento\Catalog\Model\ProductRepository $productRepository
-     * @param \Magento\Framework\Stdlib\DateTime\DateTime $date
      * @param \Ebizmarts\MailChimp\Helper\Data $helper
      * @param \Magento\Catalog\Helper\Image $imageHelper
      * @param \Magento\CatalogInventory\Api\StockRegistryInterface $stockRegistry
@@ -89,7 +84,6 @@ class Product
     public function __construct(
         \Magento\Catalog\Model\ResourceModel\Product\CollectionFactory $productCollection,
         \Magento\Catalog\Model\ProductRepository $productRepository,
-        \Magento\Framework\Stdlib\DateTime\DateTime $date,
         \Ebizmarts\MailChimp\Helper\Data $helper,
         \Magento\Catalog\Helper\Image $imageHelper,
         \Magento\CatalogInventory\Api\StockRegistryInterface $stockRegistry,
@@ -102,7 +96,6 @@ class Product
     
         $this->_productRepository   = $productRepository;
         $this->_helper              = $helper;
-        $this->_date                = $date;
         $this->_productCollection   = $productCollection;
         $this->_imageHelper         = $imageHelper;
         $this->_stockRegistry       = $stockRegistry;
@@ -111,7 +104,7 @@ class Product
         $this->_configurable        = $configurable;
         $this->_option              = $option;
         $this->_categoryCollection  = $categoryCollection;
-        $this->_batchId             = \Ebizmarts\MailChimp\Helper\Data::IS_PRODUCT. '_' . $this->_date->gmtTimestamp();
+        $this->_batchId             = \Ebizmarts\MailChimp\Helper\Data::IS_PRODUCT. '_' . $this->_helper->getGmtTimeStamp();
     }
     public function _sendProducts($magentoStoreId)
     {
@@ -139,7 +132,7 @@ class Product
             if ($item->getMailchimpSyncModified() && $item->getMailchimpSyncDelta() &&
                 $item->getMailchimpSyncDelta() > $this->_helper->getMCMinSyncDateFlag()) {
                 $batchArray = array_merge($this->_buildOldProductRequest($product,$this->_batchId,$mailchimpStoreId, $magentoStoreId),$batchArray);
-                $this->_updateProduct($mailchimpStoreId, $product->getId(), $this->_date->gmtDate(), "", 0);
+                $this->_updateProduct($mailchimpStoreId, $product->getId());
                 continue;
             } else {
                 $data = $this->_buildNewProductRequest($product, $mailchimpStoreId, $magentoStoreId);
@@ -149,12 +142,12 @@ class Product
                 $counter++;
 
                 //update product delta
-                $this->_updateProduct($mailchimpStoreId, $product->getId(), $this->_date->gmtDate(), "", 0);
+                $this->_updateProduct($mailchimpStoreId, $product->getId());
             } else {
                 $this->_updateProduct(
                     $mailchimpStoreId,
                     $product->getId(),
-                    $this->_date->gmtDate(),
+                    $this->_helper->getGmtDate(),
                     "This product type is not supported on MailChimp.",
                     0
                 );
@@ -428,7 +421,7 @@ class Product
     public function sendModifiedProduct(\Magento\Sales\Model\Order $order, $mailchimpStoreId, $magentoStoreId)
     {
         $data = [];
-        $batchId = \Ebizmarts\MailChimp\Helper\Data::IS_PRODUCT . '_' . $this->_date->gmtTimestamp();
+        $batchId = \Ebizmarts\MailChimp\Helper\Data::IS_PRODUCT . '_' . $this->_helper->getGmtTimeStamp();
         $items = $order->getAllVisibleItems();
         foreach ($items as $item) {
             //@todo get from the store not the default
@@ -444,11 +437,11 @@ class Product
             if ($productSyncData->getMailchimpSyncModified() &&
                 $productSyncData->getMailchimpSyncDelta() > $this->_helper->getMCMinSyncDateFlag()) {
                 $data[] = $this->_buildOldProductRequest($product, $batchId, $mailchimpStoreId, $magentoStoreId);
-                $this->_updateProduct($mailchimpStoreId, $product->getId(), $this->_date->gmtDate(), '', 0);
+                $this->_updateProduct($mailchimpStoreId, $product->getId());
             } elseif (!$productSyncData->getMailchimpSyncDelta() ||
                 $productSyncData->getMailchimpSyncDelta() < $this->_helper->getMCMinSyncDateFlag()) {
                 $data[] = $this->_buildNewProductRequest($product, $mailchimpStoreId, $magentoStoreId);
-                $this->_updateProduct($mailchimpStoreId, $product->getId(), $this->_date->gmtDate(), '', 0);
+                $this->_updateProduct($mailchimpStoreId, $product->getId());
             }
         }
         return $data;
@@ -457,7 +450,7 @@ class Product
     public function sendQuoteModifiedProduct(\Magento\Quote\Model\Quote $quote, $mailchimpStoreId, $magentoStoreId)
     {
         $data = [];
-        $batchId = \Ebizmarts\MailChimp\Helper\Data::IS_PRODUCT . '_' . $this->_date->gmtTimestamp();
+        $batchId = \Ebizmarts\MailChimp\Helper\Data::IS_PRODUCT . '_' . $this->_helper->getGmtTimeStamp();
         $items = $quote->getAllVisibleItems();
         /**
          * @var $item \Magento\Quote\Model\Quote\Item
@@ -478,11 +471,11 @@ class Product
             if ($productSyncData->getMailchimpSyncModified() &&
                 $productSyncData->getMailchimpSyncDelta() > $this->_helper->getMCMinSyncDateFlag()) {
                 $data[] = $this->_buildOldProductRequest($product, $batchId, $mailchimpStoreId, $magentoStoreId);
-                $this->_updateProduct($mailchimpStoreId, $product->getId(), $this->_date->gmtDate(), '', 0);
+                $this->_updateProduct($mailchimpStoreId, $product->getId());
             } elseif (!$productSyncData->getMailchimpSyncDelta() ||
                 $productSyncData->getMailchimpSyncDelta() < $this->_helper->getMCMinSyncDateFlag()) {
                 $data[] = $this->_buildNewProductRequest($product, $mailchimpStoreId, $magentoStoreId);
-                $this->_updateProduct($mailchimpStoreId, $product->getId(), $this->_date->gmtDate(), '', 0);
+                $this->_updateProduct($mailchimpStoreId, $product->getId());
             }
         }
         return $data;
@@ -494,15 +487,15 @@ class Product
      * @param $sync_error
      * @param $sync_modified
      */
-    protected function _updateProduct($storeId, $entityId, $sync_delta, $sync_error, $sync_modified)
+    protected function _updateProduct($storeId, $entityId, $sync_delta=null, $sync_error=null, $sync_modified=null)
     {
         $this->_helper->saveEcommerceData(
             $storeId,
             $entityId,
+            \Ebizmarts\MailChimp\Helper\Data::IS_PRODUCT,
             $sync_delta,
             $sync_error,
-            $sync_modified,
-            \Ebizmarts\MailChimp\Helper\Data::IS_PRODUCT
+            $sync_modified
         );
     }
 }

--- a/Model/Api/PromoCodes.php
+++ b/Model/Api/PromoCodes.php
@@ -36,10 +36,6 @@ class PromoCodes
      */
     private $_chimpSyncEcommerce;
     /**
-     * @var \Magento\Framework\Stdlib\DateTime\DateTime
-     */
-    private $_date;
-    /**
      * @var PromoRules
      */
     private $_promoRules;
@@ -54,7 +50,6 @@ class PromoCodes
      * @param \Magento\SalesRule\Model\ResourceModel\Coupon\CollectionFactory $couponCollection
      * @param \Magento\SalesRule\Model\ResourceModel\Rule\CollectionFactory $ruleCollection
      * @param \Ebizmarts\MailChimp\Model\MailChimpSyncEcommerceFactory $chimpSyncEcommerce
-     * @param \Magento\Framework\Stdlib\DateTime\DateTime $date
      * @param PromoRules $promoRules
      * @param \Ebizmarts\MailChimp\Model\ResourceModel\MailChimpSyncEcommerce\CollectionFactory $syncCollection
      */
@@ -63,7 +58,6 @@ class PromoCodes
         \Magento\SalesRule\Model\ResourceModel\Coupon\CollectionFactory $couponCollection,
         \Magento\SalesRule\Model\ResourceModel\Rule\CollectionFactory $ruleCollection,
         \Ebizmarts\MailChimp\Model\MailChimpSyncEcommerceFactory $chimpSyncEcommerce,
-        \Magento\Framework\Stdlib\DateTime\DateTime $date,
         \Ebizmarts\MailChimp\Model\Api\PromoRules $promoRules,
         \Ebizmarts\MailChimp\Model\ResourceModel\MailChimpSyncEcommerce\CollectionFactory $syncCollection
     )
@@ -72,8 +66,7 @@ class PromoCodes
         $this->_couponCollection    = $couponCollection;
         $this->_ruleCollection      = $ruleCollection;
         $this->_chimpSyncEcommerce  = $chimpSyncEcommerce;
-        $this->_date                = $date;
-        $this->_batchId             = \Ebizmarts\MailChimp\Helper\Data::IS_PROMO_CODE. '_' . $this->_date->gmtTimestamp();
+        $this->_batchId             = \Ebizmarts\MailChimp\Helper\Data::IS_PROMO_CODE. '_' . $this->_helper->getGmtTimeStamp();
         $this->_promoRules          = $promoRules;
         $this->_syncCollection      = $syncCollection;
     }
@@ -159,14 +152,14 @@ class PromoCodes
                             $counter++;
                         } else {
                             $error = __('Parent rule with id ' . $ruleId . 'has not been correctly sent.');
-                            $this->_updateSyncData($mailchimpStoreId, $ruleId, $this->_date->gmtDate(), $error, 0);
+                            $this->_updateSyncData($mailchimpStoreId, $ruleId, $this->_helper->getGmtDate(), $error, 0);
                             continue;
                         }
                     }
                     if ($promoRule->getMailchimpSyncError()) {
                         // the promorule associated has an error
                         $error = __('Parent rule with id ' . $ruleId . 'has not been correctly sent.');
-                        $this->_updateSyncData($mailchimpStoreId, $couponId, $this->_date->gmtDate(), $error, 0);
+                        $this->_updateSyncData($mailchimpStoreId, $couponId, $this->_helper->getGmtDate(), $error, 0);
                         continue;
                     }
                     $promoCodeJson = json_encode($this->generateCodeData($item, $magentoStoreId));
@@ -177,11 +170,11 @@ class PromoCodes
                         $batchArray[$counter]['body'] = $promoCodeJson;
                     } else {
                         $error = __('Something went wrong when retrieving the information for promo rule');
-                        $this->_updateSyncData($mailchimpStoreId, $couponId, $this->_date->gmtDate(), $error, 0);
+                        $this->_updateSyncData($mailchimpStoreId, $couponId, $this->_helper->getGmtDate(), $error, 0);
                         continue;
                     }
                     $counter++;
-                    $this->_updateSyncData($mailchimpStoreId, $couponId, $this->_date->gmtDate(), '', 0);
+                    $this->_updateSyncData($mailchimpStoreId, $couponId);
                 } catch (Exception $e) {
                     $this->_helper->log($e->getMessage());
                 }
@@ -207,15 +200,15 @@ class PromoCodes
         return $url;
 
     }
-    protected function _updateSyncData($storeId, $entityId, $sync_delta, $sync_error = '', $sync_modified = 0, $sync_deleted = 0)
+    protected function _updateSyncData($storeId, $entityId, $sync_delta=null, $sync_error = null, $sync_modified = null, $sync_deleted = null)
     {
         $this->_helper->saveEcommerceData(
             $storeId,
             $entityId,
+            \Ebizmarts\MailChimp\Helper\Data::IS_PROMO_CODE,
             $sync_delta,
             $sync_error,
             $sync_modified,
-            \Ebizmarts\MailChimp\Helper\Data::IS_PROMO_CODE,
             $sync_deleted,
             $this->_token
         );

--- a/Model/Api/PromoRules.php
+++ b/Model/Api/PromoRules.php
@@ -30,10 +30,6 @@ class PromoRules
      */
     private $_collection;
     /**
-     * @var \Magento\Framework\Stdlib\DateTime\DateTime
-     */
-    private $_date;
-    /**
      * @var \Ebizmarts\MailChimp\Helper\Data
      */
     private $_helper;
@@ -57,23 +53,20 @@ class PromoRules
      * @param \Magento\SalesRule\Model\RuleRepository $ruleRepo
      * @param \Ebizmarts\MailChimp\Model\MailChimpSyncEcommerceFactory $chimpSyncEcommerce
      * @param \Ebizmarts\MailChimp\Model\ResourceModel\MailChimpSyncEcommerce\CollectionFactory $syncCollection
-     * @param \Magento\Framework\Stdlib\DateTime\DateTime $date
      */
     public function __construct(
         \Ebizmarts\MailChimp\Helper\Data $helper,
         \Magento\SalesRule\Model\ResourceModel\Rule\CollectionFactory $collection,
         \Magento\SalesRule\Model\RuleRepository $ruleRepo,
         \Ebizmarts\MailChimp\Model\MailChimpSyncEcommerceFactory $chimpSyncEcommerce,
-        \Ebizmarts\MailChimp\Model\ResourceModel\MailChimpSyncEcommerce\CollectionFactory $syncCollection,
-        \Magento\Framework\Stdlib\DateTime\DateTime $date
+        \Ebizmarts\MailChimp\Model\ResourceModel\MailChimpSyncEcommerce\CollectionFactory $syncCollection
     )
     {
         $this->_helper              = $helper;
         $this->_collection          = $collection;
         $this->_chimpSyncEcommerce  = $chimpSyncEcommerce;
-        $this->_date                = $date;
         $this->_ruleRepo             = $ruleRepo;
-        $this->_batchId             = \Ebizmarts\MailChimp\Helper\Data::IS_PROMO_RULE. '_' . $this->_date->gmtTimestamp();
+        $this->_batchId             = \Ebizmarts\MailChimp\Helper\Data::IS_PROMO_RULE. '_' . $this->_helper->getGmtTimeStamp();
         $this->_syncCollection      = $syncCollection;
     }
     public function sendRules($magentoStoreId)
@@ -167,14 +160,14 @@ class PromoRules
                     $data['path'] = '/ecommerce/stores/' . $mailchimpStoreId . '/promo-rules';
                     $data['operation_id'] = $this->_batchId . '_' . $ruleId;
                     $data['body'] = $promoRulesJson;
-                    $this->_updateSyncData($mailchimpStoreId, $ruleId, $this->_date->gmtDate());
+                    $this->_updateSyncData($mailchimpStoreId, $ruleId);
                 } else {
                     $error = __('Something went wrong when retrieving the information.');
-                    $this->_updateSyncData($mailchimpStoreId, $ruleId, $this->_date->gmtDate(), $error);
+                    $this->_updateSyncData($mailchimpStoreId, $ruleId, $this->_helper->getGmtDate(), $error,0);
                 }
             } else {
                 $error = __('Something went wrong when retrieving the information.');
-                $this->_updateSyncData($mailchimpStoreId, $ruleId, $this->_date->gmtDate(), $error);
+                $this->_updateSyncData($mailchimpStoreId, $ruleId, $this->_helper->getGmtDate(), $error, 0);
             }
         } catch(\Exception $e) {
             $this->_helper->log($e->getMessage());
@@ -262,10 +255,10 @@ class PromoRules
         $this->_helper->saveEcommerceData(
             $storeId,
             $entityId,
+            \Ebizmarts\MailChimp\Helper\Data::IS_PROMO_RULE,
             $sync_delta,
             $sync_error,
-            $sync_modified,
-            \Ebizmarts\MailChimp\Helper\Data::IS_PROMO_RULE
+            $sync_modified
         );
     }
 

--- a/Model/Api/Subscriber.php
+++ b/Model/Api/Subscriber.php
@@ -24,10 +24,6 @@ class Subscriber
      */
     protected $_subscriberCollection;
     /**
-     * @var \Magento\Framework\Stdlib\DateTime\DateTime
-     */
-    protected $_date;
-    /**
      * @var \Magento\Framework\Message\ManagerInterface
      */
     protected $_message;
@@ -42,22 +38,17 @@ class Subscriber
      * @param \Ebizmarts\MailChimp\Helper\Data $helper
      * @param \Magento\Newsletter\Model\ResourceModel\Subscriber\CollectionFactory $subscriberCollection
      * @param \Magento\Newsletter\Model\SubscriberFactory $subscriberFactory
-     * @param \Magento\Customer\Api\CustomerRepositoryInterface $customerRepo
-     * @param \Magento\Customer\Model\CustomerFactory $customerFactory
-     * @param \Magento\Framework\Stdlib\DateTime\DateTime $date
      * @param \Magento\Framework\Message\ManagerInterface $message
      */
     public function __construct(
         \Ebizmarts\MailChimp\Helper\Data $helper,
         \Magento\Newsletter\Model\ResourceModel\Subscriber\CollectionFactory $subscriberCollection,
         \Magento\Newsletter\Model\SubscriberFactory $subscriberFactory,
-        \Magento\Framework\Stdlib\DateTime\DateTime $date,
         \Magento\Framework\Message\ManagerInterface $message
     )
     {
         $this->_helper                  = $helper;
         $this->_subscriberCollection    = $subscriberCollection;
-        $this->_date                    = $date;
         $this->_message                 = $message;
         $this->_subscriberFactory       = $subscriberFactory;
     }
@@ -105,7 +96,7 @@ class Subscriber
                 $subscriberArray[$counter]['operation_id'] = $batchId . '_' . $subscriber->getSubscriberId();
                 $subscriberArray[$counter]['body'] = $subscriberJson;
                 //update subscribers delta
-                $this->_updateSubscriber($listId, $subscriber->getId(), $this->_date->gmtDate(), '', 0);
+                $this->_updateSubscriber($listId, $subscriber->getId());
             }
             $counter++;
         }
@@ -185,11 +176,11 @@ class Subscriber
     {
         $storeId = $subscriber->getStoreId();
         $listId = $this->_helper->getGeneralList($storeId);
-        $this->_updateSubscriber($listId, $subscriber->getId(),$this->_date->gmtDate(),'',1 );
+        $this->_updateSubscriber($listId, $subscriber->getId(),$this->_helper->getGmtDate(),'',1 );
     }
-    protected function _updateSubscriber($listId, $entityId, $sync_delta, $sync_error='', $sync_modified=0)
+    protected function _updateSubscriber($listId, $entityId, $sync_delta = null, $sync_error=null, $sync_modified=null)
     {
-        $this->_helper->saveEcommerceData($listId, $entityId, $sync_delta, $sync_error, $sync_modified,
-            \Ebizmarts\MailChimp\Helper\Data::IS_SUBSCRIBER);
+        $this->_helper->saveEcommerceData($listId, $entityId, \Ebizmarts\MailChimp\Helper\Data::IS_SUBSCRIBER,
+            $sync_delta, $sync_error, $sync_modified);
     }
 }

--- a/Model/Plugin/Newsletter/Save.php
+++ b/Model/Plugin/Newsletter/Save.php
@@ -35,10 +35,6 @@ class Save
      * @var \Ebizmarts\MailChimp\Model\MailChimpInterestGroupFactory
      */
     protected $interestGroupFactory;
-    /**
-     * @var \Magento\Framework\Stdlib\DateTime\DateTime
-     */
-    protected $date;
 
     /**
      * Save constructor.
@@ -46,7 +42,6 @@ class Save
      * @param \Magento\Customer\Model\Session $customerSession
      * @param \Magento\Newsletter\Model\SubscriberFactory $subscriberFactory
      * @param \Ebizmarts\MailChimp\Model\MailChimpInterestGroupFactory $interestGroupFactory
-     * @param \Magento\Framework\Stdlib\DateTime\DateTime $date
      * @param \Magento\Framework\App\Request\Http $request
      */
     public function __construct(
@@ -54,7 +49,6 @@ class Save
         \Magento\Customer\Model\Session $customerSession,
         \Magento\Newsletter\Model\SubscriberFactory $subscriberFactory,
         \Ebizmarts\MailChimp\Model\MailChimpInterestGroupFactory $interestGroupFactory,
-        \Magento\Framework\Stdlib\DateTime\DateTime $date,
         \Magento\Framework\App\Request\Http $request
     )
     {
@@ -63,7 +57,6 @@ class Save
         $this->subscriberFactory    = $subscriberFactory;
         $this->request              = $request;
         $this->interestGroupFactory = $interestGroupFactory;
-        $this->date                 = $date;
     }
     public function afterExecute()
     {
@@ -85,10 +78,10 @@ class Save
                 $interestGroup->setGroupdata(serialize($params));
                 $interestGroup->setSubscriberId($subscriber->getSubscriberId());
                 $interestGroup->setStoreId($subscriber->getStoreId());
-                $interestGroup->setUpdatedAt($this->date->gmtDate());
+                $interestGroup->setUpdatedAt($this->helper->getGmtDate());
                 $interestGroup->getResource()->save($interestGroup);
                 $listId = $this->helper->getGeneralList($subscriber->getStoreId());
-                $this->_updateSubscriber($listId, $subscriber->getId(), $this->date->gmtDate(), '', 1);
+                $this->_updateSubscriber($listId, $subscriber->getId(), $this->helper->getGmtDate(), null, 1);
             } else {
                 $this->subscriberFactory->create()->subscribe($email);
                 $subscriber->loadByEmail($email);
@@ -96,16 +89,16 @@ class Save
                 $interestGroup->setGroupdata(serialize($params));
                 $interestGroup->setSubscriberId($subscriber->getSubscriberId());
                 $interestGroup->setStoreId($subscriber->getStoreId());
-                $interestGroup->setUpdatedAt($this->date->gmtDate());
+                $interestGroup->setUpdatedAt($this->helper->getGmtDate());
                 $interestGroup->getResource()->save($interestGroup);
             }
 
         } catch(\Exception $e) {
         }
     }
-    protected function _updateSubscriber($listId, $entityId, $sync_delta, $sync_error='', $sync_modified=0)
+    protected function _updateSubscriber($listId, $entityId, $sync_delta = null, $sync_error=null, $sync_modified=null)
     {
-        $this->helper->saveEcommerceData($listId, $entityId, $sync_delta, $sync_error, $sync_modified,
-            \Ebizmarts\MailChimp\Helper\Data::IS_SUBSCRIBER);
+        $this->helper->saveEcommerceData($listId, $entityId, \Ebizmarts\MailChimp\Helper\Data::IS_SUBSCRIBER,
+            $sync_delta, $sync_error, $sync_modified);
     }
 }

--- a/Observer/Adminhtml/Customer/SaveAfter.php
+++ b/Observer/Adminhtml/Customer/SaveAfter.php
@@ -27,29 +27,22 @@ class SaveAfter implements \Magento\Framework\Event\ObserverInterface
      * @var \Ebizmarts\MailChimp\Model\MailChimpInterestGroupFactory
      */
     protected $interestGroupFactory;
-    /**
-     * @var \Magento\Framework\Stdlib\DateTime\DateTime
-     */
-    protected $date;
 
     /**
      * SaveAfter constructor.
      * @param \Ebizmarts\MailChimp\Helper\Data $helper
      * @param \Magento\Newsletter\Model\SubscriberFactory $subscriberFactory
      * @param \Ebizmarts\MailChimp\Model\MailChimpInterestGroupFactory $interestGroupFactory
-     * @param \Magento\Framework\Stdlib\DateTime\DateTime $date
      */
     public function __construct(
         \Ebizmarts\MailChimp\Helper\Data $helper,
         \Magento\Newsletter\Model\SubscriberFactory $subscriberFactory,
-        \Ebizmarts\MailChimp\Model\MailChimpInterestGroupFactory $interestGroupFactory,
-        \Magento\Framework\Stdlib\DateTime\DateTime $date
+        \Ebizmarts\MailChimp\Model\MailChimpInterestGroupFactory $interestGroupFactory
     )
     {
         $this->helper               = $helper;
         $this->subscriberFactory    = $subscriberFactory;
         $this->interestGroupFactory = $interestGroupFactory;
-        $this->date                 = $date;
     }
 
     public function execute(\Magento\Framework\Event\Observer $observer)
@@ -77,10 +70,10 @@ class SaveAfter implements \Magento\Framework\Event\ObserverInterface
                     $interestGroup->setGroupdata(serialize($params));
                     $interestGroup->setSubscriberId($subscriber->getSubscriberId());
                     $interestGroup->setStoreId($subscriber->getStoreId());
-                    $interestGroup->setUpdatedAt($this->date->gmtDate());
+                    $interestGroup->setUpdatedAt($this->helper->getGmtDate());
                     $interestGroup->getResource()->save($interestGroup);
                     $listId = $this->helper->getGeneralList($subscriber->getStoreId());
-                    $this->_updateSubscriber($listId, $subscriber->getId(), $this->date->gmtDate(), '', 1);
+                    $this->_updateSubscriber($listId, $subscriber->getId(), $this->helper->getGmtDate(), null, 1);
                 } else {
                     $this->subscriberFactory->create()->subscribe($customer->getEmail());
                     $subscriber->loadByEmail($customer->getEmail());
@@ -88,7 +81,7 @@ class SaveAfter implements \Magento\Framework\Event\ObserverInterface
                     $interestGroup->setGroupdata(serialize($params));
                     $interestGroup->setSubscriberId($subscriber->getSubscriberId());
                     $interestGroup->setStoreId($subscriber->getStoreId());
-                    $interestGroup->setUpdatedAt($this->date->gmtDate());
+                    $interestGroup->setUpdatedAt($this->helper->getGmtDate());
                     $interestGroup->getResource()->save($interestGroup);
                 }
 
@@ -97,10 +90,10 @@ class SaveAfter implements \Magento\Framework\Event\ObserverInterface
             }
         }
     }
-    protected function _updateSubscriber($listId, $entityId, $sync_delta, $sync_error='', $sync_modified=0)
+    protected function _updateSubscriber($listId, $entityId, $sync_delta = null, $sync_error=null, $sync_modified=null)
     {
-        $this->helper->saveEcommerceData($listId, $entityId, $sync_delta, $sync_error, $sync_modified,
-            \Ebizmarts\MailChimp\Helper\Data::IS_SUBSCRIBER);
+        $this->helper->saveEcommerceData($listId, $entityId, \Ebizmarts\MailChimp\Helper\Data::IS_SUBSCRIBER ,
+            $sync_delta, $sync_error, $sync_modified);
     }
 
 }

--- a/Observer/Adminhtml/Product/SaveAfter.php
+++ b/Observer/Adminhtml/Product/SaveAfter.php
@@ -18,18 +18,16 @@ class SaveAfter implements \Magento\Framework\Event\ObserverInterface
      * @var \Ebizmarts\MailChimp\Helper\Data
      */
     protected $helper;
-    /**
-     * @var \Magento\Framework\Stdlib\DateTime\DateTime
-     */
-    protected $date;
 
+    /**
+     * SaveAfter constructor.
+     * @param \Ebizmarts\MailChimp\Helper\Data $helper
+     */
     public function __construct(
-        \Ebizmarts\MailChimp\Helper\Data $helper,
-        \Magento\Framework\Stdlib\DateTime\DateTime $date
+        \Ebizmarts\MailChimp\Helper\Data $helper
     )
     {
         $this->helper               = $helper;
-        $this->date                 = $date;
     }
 
     public function execute(\Magento\Framework\Event\Observer $observer)
@@ -39,19 +37,19 @@ class SaveAfter implements \Magento\Framework\Event\ObserverInterface
          */
         $product = $observer->getProduct();
         $mailchimpStore = $this->helper->getConfigValue(\Ebizmarts\MailChimp\Helper\Data::XML_MAILCHIMP_STORE, $product->getStoreId());
-        $this->_updateProduct($mailchimpStore, $product->getId(), $this->date->gmtDate(), '', 1);
+        $this->_updateProduct($mailchimpStore, $product->getId(), $this->helper->getGmtDate(), '', 1);
 
 
     }
-    protected function _updateProduct($storeId, $entityId, $sync_delta, $sync_error, $sync_modified)
+    protected function _updateProduct($storeId, $entityId, $sync_delta = null, $sync_error = null, $sync_modified= null)
     {
         $this->helper->saveEcommerceData(
             $storeId,
             $entityId,
+            \Ebizmarts\MailChimp\Helper\Data::IS_PRODUCT,
             $sync_delta,
             $sync_error,
-            $sync_modified,
-            \Ebizmarts\MailChimp\Helper\Data::IS_PRODUCT
+            $sync_modified
         );
     }
 }


### PR DESCRIPTION
When a product is synced, the first time in the ecommerce table the batchid contains 0, this value changes when the batch is effectively sent https://github.com/mailchimp/mc-magento2/blob/develop/Cron/Ecommerce.php#L125-L128
Then, when the cron start delete all the entries in ecommerce table who has no batchid https://github.com/mailchimp/mc-magento2/blob/develop/Cron/Ecommerce.php#L115
This method works only for new registers, but no for modified registers
I think the best approach is:

- When a register is synced, put the batchid in the ecommerce table in null (leave the mailchimp_sync_modified and mailchimp_sync_delta unmodified)
- When you are sure that the batch was sent, update the ecommerce table, put the right batchid returned by MailChimp, set the mailchimp_sync_modified to 0 and mailchimp_sync_delta to current date
- When the cron process restart, delete the entries in the ecommerce table with batchid = null and mailchimp_sync_modified = 0 (don't delete the registers with mailchimp_sync_modified = 1)