### PR TITLE
fix decodeArrayFieldValue error

### DIFF
--- a/Helper/VarsMap.php
+++ b/Helper/VarsMap.php
@@ -45,7 +45,7 @@ class VarsMap extends \Magento\Framework\App\Helper\AbstractHelper
     }
     public function makeStorableArrayFieldValue($value)
     {
-        $value = $this->decodeArrayFieldValue($value);
+        $value = is_array($value) ? $this->decodeArrayFieldValue($value) : $value;
         $value = $this->serializeValue($value);
         return $value;
     }


### PR DESCRIPTION
Magento 2.2.2
mc-magento: 1.0.28

Argument 1 passed to Ebizmarts\MailChimp\Helper\VarsMap::decodeArrayFieldValue() must be of the type array, string given, called in /var/www/app/code/Ebizmarts/MailChimp/Helper/VarsMap.php on line 48 and defined in /var/www/app/code/Ebizmarts/MailChimp/Helper/VarsMap.php:73

This issue appear when I run setup:upgrade (for old versions too)