### PR TITLE
Change cron group id to 'mailchimp'.

### DIFF
--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -13,7 +13,7 @@
  */
  -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
-    <group id="default">
+    <group id="mailchimp">
        <job name="ebizmarts_ecommerce" instance="Ebizmarts\MailChimp\Cron\Ecommerce" method="execute">
             <schedule>*/5 * * * *</schedule>
         </job>


### PR DESCRIPTION
Change the cron group id to 'mailchimp', so it can be specifically addressed or excluded when running the `magento/bin cron:run` command via adding the option `--group mailchimp`.

This wouldn't make much of difference for the general Magento 2 stores, because they keep running the cron:run command without any options, so all cron jobs are handled anyway including the mailchimp cron jobs, but for larger stores, which run long and extensive daily crons in the night, it could make a difference.

E.g. we disable the normal cron process during the daily cron, which is run in the night, because otherwise certain processes would mingled which each other causing them to fail. Having separate cron group ids, would enable us to specifiy explicitly, which cron jobs can still be run or should be excluded in a simple way, without having to mingle to much with the Magento core code by creating Plugins, Observers or Preferences.