### PR TITLE
Issue345: Ensure variable active is assigned

### DIFF
--- a/Model/Config/Backend/ApiKey.php
+++ b/Model/Config/Backend/ApiKey.php
@@ -70,6 +70,7 @@ class ApiKey extends \Magento\Framework\App\Config\Value
 
     public function beforeSave()
     {
+        $active = null;
         $generalData = $this->getData();
         $data = $this->getData('groups');
         $found = 0;


### PR DESCRIPTION
Ensures that the variable active is assigned before it's used, allowing the empty check later to work correctly and config be set using env.php

Resolves https://github.com/mailchimp/mc-magento2/issues/345 