### PR TITLE
Adding extra logging on import parts of the Cronjob

### DIFF
--- a/Cron/Ecommerce.php
+++ b/Cron/Ecommerce.php
@@ -170,19 +170,30 @@ class Ecommerce
         $batchArray = [];
         $results = $this->_apiSubscribers->sendSubscribers($storeId, $listId);
         if ($this->_helper->getConfigValue(\Ebizmarts\MailChimp\Helper\Data::XML_PATH_ECOMMERCE_ACTIVE, $storeId)) {
+            $this->_helper->log('Generate Products payload');
             $products = $this->_apiProduct->_sendProducts($storeId);
             $countProducts = count($products);
             $results = array_merge($results, $products);
+            
+            $this->_helper->log('Generate Customers payload');
             $customers = $this->_apiCustomer->sendCustomers($storeId);
             $countCustomers = count($customers);
             $results = array_merge($results, $customers);
+            
+            $this->_helper->log('Generate Orders payload');
             $orders = $this->_apiOrder->sendOrders($storeId);
             $countOrders = count($orders);
             $results = array_merge($results, $orders);
+            
+            $this->_helper->log('Generate Carts payload');
             $carts = $this->_apiCart->createBatchJson($storeId);
             $results = array_merge($results, $carts);
+            
+            $this->_helper->log('Generate Rules payload');
             $rules = $this->_apiPromoRules->sendRules($storeId);
             $results = array_merge($results, $rules);
+            
+            $this->_helper->log('Generate Coupons payload');
             $coupons = $this->_apiPromoCodes->sendCoupons($storeId);
             $results = array_merge($results, $coupons);
         }

--- a/Model/Api/Result.php
+++ b/Model/Api/Result.php
@@ -95,10 +95,6 @@ class Result
             $response = $api->batchOperation->status($batchId);
 
             if (isset($response['status']) && $response['status'] == 'finished') {
-                // Create temporary directory, if that does not exist
-                if (!is_dir($baseDir . DIRECTORY_SEPARATOR . 'var' . DIRECTORY_SEPARATOR . self::MAILCHIMP_TEMP_DIR)) {
-                    mkdir($baseDir . DIRECTORY_SEPARATOR . 'var' . DIRECTORY_SEPARATOR . self::MAILCHIMP_TEMP_DIR);
-                }
                 
                 // get the tar.gz file with the results
                 $fileUrl = urldecode($response['response_body_url']);

--- a/Model/Api/Result.php
+++ b/Model/Api/Result.php
@@ -95,6 +95,11 @@ class Result
             $response = $api->batchOperation->status($batchId);
 
             if (isset($response['status']) && $response['status'] == 'finished') {
+                // Create temporary directory, if that does not exist
+                if (!is_dir($baseDir . DIRECTORY_SEPARATOR . 'var' . DIRECTORY_SEPARATOR . self::MAILCHIMP_TEMP_DIR)) {
+                    mkdir($baseDir . DIRECTORY_SEPARATOR . 'var' . DIRECTORY_SEPARATOR . self::MAILCHIMP_TEMP_DIR);
+                }
+                
                 // get the tar.gz file with the results
                 $fileUrl = urldecode($response['response_body_url']);
                 $fileName = $baseDir . DIRECTORY_SEPARATOR . 'var' . DIRECTORY_SEPARATOR . self::MAILCHIMP_TEMP_DIR . DIRECTORY_SEPARATOR . $batchId;

--- a/Model/Api/Result.php
+++ b/Model/Api/Result.php
@@ -95,7 +95,6 @@ class Result
             $response = $api->batchOperation->status($batchId);
 
             if (isset($response['status']) && $response['status'] == 'finished') {
-                
                 // get the tar.gz file with the results
                 $fileUrl = urldecode($response['response_body_url']);
                 $fileName = $baseDir . DIRECTORY_SEPARATOR . 'var' . DIRECTORY_SEPARATOR . self::MAILCHIMP_TEMP_DIR . DIRECTORY_SEPARATOR . $batchId;


### PR DESCRIPTION
Adding extra logging on import parts of the Cronjob.

There is a bit lack of visibility around execution of the sync process.
Would be awesome to see where the sync spends more time and helps to diagnose, if the sync stuck somewhere due to some reason.

E.g. Reasons:
- Payload was not able to generate due to M2 Core issue and failed with warning or fatal error
- You can see how much time been spent on specific part e.g. products, orders and etc. It helped me to diagnose that cart generation was taking about 20 minutes to generate due to some slow SQL query