### PR TITLE
Move observer to frontend scope to avoid breaking CLI orders

### DIFF
--- a/etc/events.xml
+++ b/etc/events.xml
@@ -14,9 +14,6 @@
     <event name="sales_model_service_quote_submit_before">
         <observer name="mailchimp_sales_model_service_quote_submit_before" instance="\Ebizmarts\MailChimp\Observer\Sales\Order\SubmitBefore" />
     </event>
-    <event name="sales_model_service_quote_submit_success">
-        <observer name="mailchimp_sales_model_service_quote_submit_after" instance="\Ebizmarts\MailChimp\Observer\Sales\Order\SubmitAfter" />
-    </event>
     <event name="customer_save_before">
         <observer name="mailchimp_customer_save_before" instance="\Ebizmarts\MailChimp\Observer\Customer\SaveBefore" />
     </event>

--- a/etc/frontend/events.xml
+++ b/etc/frontend/events.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+    <event name="sales_model_service_quote_submit_success">
+        <observer name="mailchimp_sales_model_service_quote_submit_after" instance="\Ebizmarts\MailChimp\Observer\Sales\Order\SubmitAfter" />
+    </event>
+</config>


### PR DESCRIPTION
This is issue #378.

PR moves mailchimp_sales_model_service_quote_submit_after observer to frontend scope to avoid throwing cookie error on CLI.