### PR TITLE
Fix unique type validation in di.xml

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -34,6 +34,7 @@
         <arguments>
             <argument name="collections" xsi:type="array">
                 <item name="mailchimp_errors_grid_data_source" xsi:type="string">Ebizmarts\MailChimp\Model\ResourceModel\MailChimpErrors\Collection</item>
+                <item name="mailchimp_stores_grid_data_source" xsi:type="string">Ebizmarts\MailChimp\Model\ResourceModel\MailChimpStores\Grid\Collection</item>
             </argument>
         </arguments>
     </type>
@@ -43,13 +44,6 @@
             <argument name="resourceModel" xsi:type="string">Ebizmarts\MailChimp\Model\ResourceModel\MailChimpStores</argument>
         </arguments>
     </virtualType>
-    <type name="Magento\Framework\View\Element\UiComponent\DataProvider\CollectionFactory">
-        <arguments>
-            <argument name="collections" xsi:type="array">
-                <item name="mailchimp_stores_grid_data_source" xsi:type="string">Ebizmarts\MailChimp\Model\ResourceModel\MailChimpStores\Grid\Collection</item>
-            </argument>
-        </arguments>
-    </type>
     <type name="Magento\Newsletter\Model\Subscriber">
         <plugin name="mailchimp-subscriber" type="Ebizmarts\MailChimp\Model\Plugin\Subscriber" sortOrder="10"/>
     </type>


### PR DESCRIPTION
This PR fixes unique type validation errors in di.xml file.

**Steps to reproduce:**
1. Install magento 2.2.6 + latest mailchimp module
2. Open PhpStorm and add URN highliter - Howto: https://devdocs.magento.com/guides/v2.2/config-guide/cli/config-cli-subcommands-urn.html
3. Open `vendor/mailchimp/mc-magento2/etc/di.xml` file and see if file validation is success (no underlines near `<"type"... >` lines)