### PR TITLE
Prevent "Unable to unserialize value" exception

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1025,26 +1025,29 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
 
         $interestGroup = $this->_interestGroupFactory->create();
         $interestGroup->getBySubscriberIdStoreId($subscriberId, $storeId);
-        $groups = $this->unserialize($interestGroup->getGroupdata());
-        if (isset($groups['group'])) {
-            foreach ($groups['group'] as $key => $value) {
-                if (isset($interest[$key])) {
-                    if (is_array($value)) {
-                        foreach ($value as $groupId) {
-                            foreach ($interest[$key]['category'] as $gkey => $gvalue) {
-                                if ($gvalue['id'] == $groupId) {
-                                    $interest[$key]['category'][$gkey]['checked'] = true;
-                                } elseif (!isset($interest[$key]['category'][$gkey]['checked'])) {
-                                    $interest[$key]['category'][$gkey]['checked'] = false;
+        $serialized = $interestGroup->getGroupdata();
+        if($serialized) {
+            $groups = $this->unserialize($serialized);
+            if (isset($groups['group'])) {
+                foreach ($groups['group'] as $key => $value) {
+                    if (isset($interest[$key])) {
+                        if (is_array($value)) {
+                            foreach ($value as $groupId) {
+                                foreach ($interest[$key]['category'] as $gkey => $gvalue) {
+                                    if ($gvalue['id'] == $groupId) {
+                                        $interest[$key]['category'][$gkey]['checked'] = true;
+                                    } elseif (!isset($interest[$key]['category'][$gkey]['checked'])) {
+                                        $interest[$key]['category'][$gkey]['checked'] = false;
+                                    }
                                 }
                             }
-                        }
-                    } else {
-                        foreach ($interest[$key]['category'] as $gkey => $gvalue) {
-                            if ($gvalue['id'] == $value) {
-                                $interest[$key]['category'][$gkey]['checked'] = true;
-                            } else {
-                                $interest[$key]['category'][$gkey]['checked'] = false;
+                        } else {
+                            foreach ($interest[$key]['category'] as $gkey => $gvalue) {
+                                if ($gvalue['id'] == $value) {
+                                    $interest[$key]['category'][$gkey]['checked'] = true;
+                                } else {
+                                    $interest[$key]['category'][$gkey]['checked'] = false;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
"Unable to unserialize value" exception is thrown in case of `$interestGroup->getGroupdata()` has no data.

I've just added this validation:
```
        $serialized = $interestGroup->getGroupdata();
        if($serialized) {
            $groups = $this->_serializer->unserialize($serialized);
            ...
        }
```