### PR TITLE
Prevent exception being thrown when unserializing null value

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -354,7 +354,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         if (!$this->_mapFields) {
             $customerAtt = $this->getCustomerAtts();
             $data = $this->getConfigValue(self::XML_MERGEVARS, $storeId);
-            $data = $this->_serializer->unserialize($data);
+            $data = $this->_serializer->unserialize($data ?? '{}');
             if (is_array($data)) {
                 foreach ($data as $customerFieldId => $mailchimpName) {
                     $this->_mapFields[] = [
@@ -1025,7 +1025,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
 
         $interestGroup = $this->_interestGroupFactory->create();
         $interestGroup->getBySubscriberIdStoreId($subscriberId, $storeId);
-        $groups = $this->_serializer->unserialize($interestGroup->getGroupdata());
+        $groups = $this->_serializer->unserialize($interestGroup->getGroupdata() ?? '{}');
         if (isset($groups['group'])) {
             foreach ($groups['group'] as $key => $value) {
                 if (isset($interest[$key])) {


### PR DESCRIPTION
This change is a fix for #545 - the Magento unserialize function throws an exception when attempting to unserialize a null value. This change replaces null values with empty JSON data to prevent the exception from being thrown and causing the Ecommerce cron job to fall.