### PR TITLE
Missing customer fields mapping 2.1 - closes #553 for Magento 2.1

### DIFF
--- a/Block/Adminhtml/System/Config/Form/Field/MailchimpMap.php
+++ b/Block/Adminhtml/System/Config/Form/Field/MailchimpMap.php
@@ -64,7 +64,7 @@ class MailchimpMap extends \Magento\Framework\View\Element\Html\Select
 
         $api = $this->_helper->getApi($storeId);
         try {
-            $merge = $api->lists->mergeFields->getAll($this->_helper->getConfigValue(\Ebizmarts\MailChimp\Helper\Data::XML_PATH_LIST, $storeId, $scope), null, null, 100);
+            $merge = $api->lists->mergeFields->getAll($this->_helper->getConfigValue(\Ebizmarts\MailChimp\Helper\Data::XML_PATH_LIST, $storeId, $scope), null, null, \Ebizmarts\MailChimp\Helper\Data::MAX_MERGEFIELDS);
             foreach ($merge['merge_fields'] as $item) {
                 $ret[$item['tag']] = $item['tag'] . ' (' . $item['name'] . ' : ' . $item['type'] . ')';
             }

--- a/Block/Adminhtml/System/Config/Form/Field/MailchimpMap.php
+++ b/Block/Adminhtml/System/Config/Form/Field/MailchimpMap.php
@@ -64,7 +64,7 @@ class MailchimpMap extends \Magento\Framework\View\Element\Html\Select
 
         $api = $this->_helper->getApi($storeId);
         try {
-            $merge = $api->lists->mergeFields->getAll($this->_helper->getConfigValue(\Ebizmarts\MailChimp\Helper\Data::XML_PATH_LIST, $storeId, $scope));
+            $merge = $api->lists->mergeFields->getAll($this->_helper->getConfigValue(\Ebizmarts\MailChimp\Helper\Data::XML_PATH_LIST, $storeId, $scope), null, null, 100);
             foreach ($merge['merge_fields'] as $item) {
                 $ret[$item['tag']] = $item['tag'] . ' (' . $item['name'] . ' : ' . $item['type'] . ')';
             }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -73,6 +73,8 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     const QUO_MOD       = "QuoteModified";
     const QUO_NEW       = "QuoteNew";
 
+    const MAX_MERGEFIELDS = 100;
+
     protected $counters = [];
     /**
      * @var \Magento\Store\Model\StoreManagerInterface


### PR DESCRIPTION
- Added the field count in the function _getAll as 4 parameter inside public function _getMailchimpTags, so now at the configuration settings of the extension we will be able to see all the mergefields from Mailchimp in Magento.