### PR TITLE
spelling error status sent to mailchimp. closes #574

### DIFF
--- a/Model/Api/Order.php
+++ b/Model/Api/Order.php
@@ -19,9 +19,9 @@ class Order
 {
     const BATCH_LIMIT = 50;
     const PAID = 'paid';
-    const PARTIALLY_PAID = 'parially_paid';
+    const PARTIALLY_PAID = 'partially_paid';
     const SHIPPED = 'shipped';
-    const PARTIALLY_SHIPPED = 'parially_shipped';
+    const PARTIALLY_SHIPPED = 'partially_shipped';
     const PENDING = 'pending';
     const REFUNDED = 'refunded';
     const PARTIALLY_REFUNDED = 'partially_refunded';


### PR DESCRIPTION
fixed statuses "partially_shipped" and "partially_paid"