### PR TITLE
Spelling error in status sent to mailchimp. For magento 2.3. closes #574

### DIFF
--- a/Model/Api/Order.php
+++ b/Model/Api/Order.php
@@ -19,9 +19,9 @@ class Order
 {
     const BATCH_LIMIT = 50;
     const PAID = 'paid';
-    const PARTIALLY_PAID = 'parially_paid';
+    const PARTIALLY_PAID = 'partially_paid';
     const SHIPPED = 'shipped';
-    const PARTIALLY_SHIPPED = 'parially_shipped';
+    const PARTIALLY_SHIPPED = 'partially_shipped';
     const PENDING = 'pending';
     const REFUNDED = 'refunded';
     const PARTIALLY_REFUNDED = 'partially_refunded';


### PR DESCRIPTION
Fixed statuses "partially_shipped" and "partially_paid".