### PR TITLE
Bugfix for issue 583: BadMethodCallException on first run of bin/magento setup:install: 'Missing required argument $name of Ezbizmarts\MailChimp\Model\Logger.'

### DIFF
--- a/Model/Logger/Logger.php
+++ b/Model/Logger/Logger.php
@@ -13,6 +13,15 @@ namespace Ebizmarts\MailChimp\Model\Logger;
 
 class Logger extends \Monolog\Logger
 {
+    /**
+     * @param string             $name       The logging channel
+     * @param HandlerInterface[] $handlers   Optional stack of handlers, the first one in the array is called first, etc.
+     * @param callable[]         $processors Optional array of processors
+     */
+    public function __construct($name = 'mailchimp', array $handlers = array(), array $processors = array())
+    {
+        parent::__construct($name, $handlers, $processors);
+    }
 
     public function mailchimpLog($message, $file)
     {


### PR DESCRIPTION
See: https://github.com/mailchimp/mc-magento2/issues/583