### PR TITLE
Success unsubscription, if subscribe again doesn't send confirm subscription emails for magento2.2

### DIFF
--- a/Model/Plugin/Subscriber.php
+++ b/Model/Plugin/Subscriber.php
@@ -108,6 +108,11 @@ class Subscriber
                     $api = $this->_helper->getApi($storeId);
                     $isSubscribeOwnEmail = $this->_customerSession->isLoggedIn()
                         && $this->_customerSession->getCustomerDataObject()->getEmail() == $subscriber->getSubscriberEmail();
+
+                    if ($subscriber->getSubscriberEmail() && $subscriber->getStatus() == \Magento\Newsletter\Model\Subscriber::STATUS_UNSUBSCRIBED && $this->_helper->isDoubleOptInEnabled($storeId)) {
+                        $isSubscribeOwnEmail = false;
+                    }
+
                     if ($this->_helper->isDoubleOptInEnabled($storeId) && !$isSubscribeOwnEmail) {
                         $status = 'pending';
                     } else {


### PR DESCRIPTION
- Check if the subscriber have the status unsubscribed and double opt-in is enabled
- closes #696