### PR TITLE
Wrong error message in order grid for magento 2.2

### DIFF
--- a/Ui/Component/Listing/Column/Monkey.php
+++ b/Ui/Component/Listing/Column/Monkey.php
@@ -110,8 +110,13 @@ class Monkey extends Column
                                 $text = __('Synced');
                                 break;
                             case \Ebizmarts\MailChimp\Helper\Data::WAITINGSYNC:
-                                $url = $this->_assetRepository->getUrlWithParams('Ebizmarts_MailChimp::images/waiting.png', $params);
-                                $text = __('Waiting');
+                                if ($syncData->getMailchimpSyncError()) {
+                                    $url = $this->_assetRepository->getUrlWithParams('Ebizmarts_MailChimp::images/never.png', $params);
+                                    $text = __('With error');
+                                } else {
+                                    $url = $this->_assetRepository->getUrlWithParams('Ebizmarts_MailChimp::images/waiting.png', $params);
+                                    $text = __('Waiting');
+                                }
                                 break;
                             case \Ebizmarts\MailChimp\Helper\Data::SYNCERROR:
                                 $url = $this->_assetRepository->getUrlWithParams('Ebizmarts_MailChimp::images/error.png', $params);


### PR DESCRIPTION
- changed icon and message if the error never will be send to Mailchimp
- closes #710 