### PR TITLE
Wrong error message in order grid for Magento 2 1

### DIFF
--- a/Ui/Component/Listing/Column/Monkey.php
+++ b/Ui/Component/Listing/Column/Monkey.php
@@ -109,8 +109,13 @@ class Monkey extends Column
                                 $text = __('Synced');
                                 break;
                             case \Ebizmarts\MailChimp\Helper\Data::WAITINGSYNC:
-                                $url = $this->_assetRepository->getUrlWithParams('Ebizmarts_MailChimp::images/waiting.png', $params);
-                                $text = __('Waiting');
+                                if () {
+                                    $url = $this->_assetRepository->getUrlWithParams('Ebizmarts_MailChimp::images/never.png', $params);
+                                    $text = __('With error');
+                                } else {
+                                    $url = $this->_assetRepository->getUrlWithParams('Ebizmarts_MailChimp::images/waiting.png', $params);
+                                    $text = __('Waiting');
+                                }
                                 break;
                             case \Ebizmarts\MailChimp\Helper\Data::SYNCERROR:
                                 $url = $this->_assetRepository->getUrlWithParams('Ebizmarts_MailChimp::images/error.png', $params);

--- a/Ui/Component/Listing/Column/Monkey.php
+++ b/Ui/Component/Listing/Column/Monkey.php
@@ -109,7 +109,7 @@ class Monkey extends Column
                                 $text = __('Synced');
                                 break;
                             case \Ebizmarts\MailChimp\Helper\Data::WAITINGSYNC:
-                                if () {
+                                if ($syncData->getMailchimpSyncError()) {
                                     $url = $this->_assetRepository->getUrlWithParams('Ebizmarts_MailChimp::images/never.png', $params);
                                     $text = __('With error');
                                 } else {


### PR DESCRIPTION
- changed icon and message if the error never will be send to Mailchimp for Magento 2.1
- closes #710