### PR TITLE
Optimize MailChimp JS block

### DIFF
--- a/Block/Mailchimpjs.php
+++ b/Block/Mailchimpjs.php
@@ -47,8 +47,14 @@ class Mailchimpjs extends \Magento\Framework\View\Element\Template
     {
         $storeId = $this->_storeManager->getStore()->getId();
 
-        $url    = $this->_scopeConfig->getValue(\Ebizmarts\MailChimp\Helper\Data::XML_MAILCHIMP_JS_URL, ScopeInterface::SCOPE_STORES, $storeId);
-        $active = $this->_scopeConfig->getValue(\Ebizmarts\MailChimp\Helper\Data::XML_PATH_ACTIVE, ScopeInterface::SCOPE_STORES, $storeId);
+        $url    = $this->_scopeConfig->getValue(
+			\Ebizmarts\MailChimp\Helper\Data::XML_MAILCHIMP_JS_URL, ScopeInterface::SCOPE_STORES,
+			$storeId
+		);
+        $active = $this->_scopeConfig->getValue(
+			\Ebizmarts\MailChimp\Helper\Data::XML_PATH_ACTIVE, ScopeInterface::SCOPE_STORES,
+			$storeId
+		);
 
         // if we have URL cached or integration is disabled
         // then avoid initialization of Mailchimp Helper and all linked classes (~30 classes)

--- a/Block/Mailchimpjs.php
+++ b/Block/Mailchimpjs.php
@@ -13,12 +13,15 @@
 
 namespace Ebizmarts\MailChimp\Block;
 
+use Magento\Store\Model\ScopeInterface;
+
 class Mailchimpjs extends \Magento\Framework\View\Element\Template
 {
     /**
      * @var \Ebizmarts\MailChimp\Helper\Data
      */
     protected $_helper;
+
     /**
      * @var \Magento\Store\Model\StoreManagerInterface
      */
@@ -35,7 +38,6 @@ class Mailchimpjs extends \Magento\Framework\View\Element\Template
         \Ebizmarts\MailChimp\Helper\Data $helper,
         array $data
     ) {
-    
         parent::__construct($context, $data);
         $this->_helper          = $helper;
         $this->_storeManager    = $context->getStoreManager();
@@ -44,6 +46,17 @@ class Mailchimpjs extends \Magento\Framework\View\Element\Template
     public function getJsUrl()
     {
         $storeId = $this->_storeManager->getStore()->getId();
-        return $this->_helper->getJsUrl($storeId);
+
+        $url    = $this->_scopeConfig->getValue(\Ebizmarts\MailChimp\Helper\Data::XML_MAILCHIMP_JS_URL, ScopeInterface::SCOPE_STORES, $storeId);
+        $active = $this->_scopeConfig->getValue(\Ebizmarts\MailChimp\Helper\Data::XML_PATH_ACTIVE, ScopeInterface::SCOPE_STORES, $storeId);
+
+        // if we have URL cached or integration is disabled
+        // then avoid initialization of Mailchimp Helper and all linked classes (~30 classes)
+        if ($active && !$url) {
+            /* @var \Ebizmarts\MailChimp\Helper\Data */
+            $url    = $this->_helper->getJsUrl($storeId);
+        }
+
+        return $url;
     }
 }

--- a/Block/Mailchimpjs.php
+++ b/Block/Mailchimpjs.php
@@ -47,20 +47,19 @@ class Mailchimpjs extends \Magento\Framework\View\Element\Template
     {
         $storeId = $this->_storeManager->getStore()->getId();
 
-        $url    = $this->_scopeConfig->getValue(
-			\Ebizmarts\MailChimp\Helper\Data::XML_MAILCHIMP_JS_URL, ScopeInterface::SCOPE_STORES,
-			$storeId
-		);
+        $url = $this->_scopeConfig->getValue(
+            \Ebizmarts\MailChimp\Helper\Data::XML_MAILCHIMP_JS_URL, ScopeInterface::SCOPE_STORES,
+            $storeId
+        );
         $active = $this->_scopeConfig->getValue(
-			\Ebizmarts\MailChimp\Helper\Data::XML_PATH_ACTIVE, ScopeInterface::SCOPE_STORES,
-			$storeId
-		);
+            \Ebizmarts\MailChimp\Helper\Data::XML_PATH_ACTIVE, ScopeInterface::SCOPE_STORES,
+            $storeId
+        );
 
         // if we have URL cached or integration is disabled
         // then avoid initialization of Mailchimp Helper and all linked classes (~30 classes)
         if ($active && !$url) {
-            /* @var \Ebizmarts\MailChimp\Helper\Data */
-            $url    = $this->_helper->getJsUrl($storeId);
+            $url = $this->_helper->getJsUrl($storeId);
         }
 
         return $url;

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -11,7 +11,11 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
-    <preference for="Ebizmarts\MailChimp\Helper\Data" type="Ebizmarts\MailChimp\Helper\Data\Proxy" />
+    <type name="Ebizmarts\MailChimp\Block\Mailchimpjs">
+        <arguments>
+            <argument name="helper" xsi:type="object">Ebizmarts\MailChimp\Helper\Data\Proxy</argument> 
+        </arguments> 
+    </type>
     <type name="Magento\Quote\Model\Quote">
         <plugin name="mailchimp-save-quote" type="Ebizmarts\MailChimp\Model\Plugin\Quote" sortOrder="10"/>
     </type>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -11,6 +11,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <preference for="Ebizmarts\MailChimp\Helper\Data" type="Ebizmarts\MailChimp\Helper\Data\Proxy" />
     <type name="Magento\Quote\Model\Quote">
         <plugin name="mailchimp-save-quote" type="Ebizmarts\MailChimp\Model\Plugin\Quote" sortOrder="10"/>
     </type>


### PR DESCRIPTION
Avoid initialization of all classes via Magento DI if JS URL has been already cached.
It saves 3-7ms on every shopping cart page load.