### PR TITLE
Add synchronizable status filter

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -856,7 +856,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     }
     public function loadStores()
     {
-        
+
         $mcUserName = [];
         $connection = $this->_mailChimpStores->getResource()->getConnection();
         $tableName = $this->_mailChimpStores->getResource()->getMainTable();
@@ -1209,6 +1209,10 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
             \Magento\Store\Model\ScopeInterface::SCOPE_STORES,
             $storeId
         );
+    }
+    public function isNewsletterModuleEnabled()
+    {
+        return $this->_moduleManager->isEnabled('Magento_Newsletter');
     }
     public function resyncAllSubscribers($mailchimpList)
     {

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -35,6 +35,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     const XML_PATH_SYNC_DATE         = 'mailchimp/general/mcminsyncdateflag';
     const XML_ECOMMERCE_OPTIN        = 'mailchimp/ecommerce/customer_optin';
     const XML_ECOMMERCE_FIRSTDATE    = 'mailchimp/ecommerce/firstdate';
+    const XML_ECOMMERCE_SYNCHRONIZABLE_STATUSES   = 'mailchimp/ecommerce/synchronizable_order_statuses';
     const XML_ABANDONEDCART_ACTIVE   = 'mailchimp/abandonedcart/active';
     const XML_ABANDONEDCART_FIRSTDATE   = 'mailchimp/abandonedcart/firstdate';
     const XML_ABANDONEDCART_PAGE     = 'mailchimp/abandonedcart/page';
@@ -504,6 +505,15 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     public function getDefaultList($store = null)
     {
         return $this->getConfigValue(self::XML_PATH_LIST, $store);
+    }
+
+    /**
+     * @param null $store
+     * @return string[]|array
+     */
+    public function getSynchronizableOrderStatuses($store = null)
+    {
+        return explode(',', $this->getConfigValue(self::XML_ECOMMERCE_SYNCHRONIZABLE_STATUSES, $store));
     }
 
     /**

--- a/Model/Api/Order.php
+++ b/Model/Api/Order.php
@@ -98,7 +98,7 @@ class Order
         \Ebizmarts\MailChimp\Model\MailChimpSyncEcommerce $chimpSyncEcommerce,
         \Magento\Framework\Url $urlHelper
     ) {
-    
+
         $this->_helper          = $helper;
         $this->_order           = $order;
         $this->_orderCollectionFactory = $orderCollectionFactory;
@@ -227,6 +227,10 @@ class Order
         // filter by first date if exists.
         if ($this->_firstDate) {
             $newOrders->addFieldToFilter('created_at', ['gt' => $this->_firstDate]);
+        }
+        $synchronizableStatuses = $this->_helper->getSynchronizableOrderStatuses($magentoStoreId);
+        if (!empty($synchronizableStatuses)) {
+            $newOrders->addFieldToFilter('status', ['in' => $synchronizableStatuses]);
         }
         $newOrders->getSelect()->joinLeft(
             ['m4m' => $this->_helper->getTableName('mailchimp_sync_ecommerce')],

--- a/Model/Api/Subscriber.php
+++ b/Model/Api/Subscriber.php
@@ -46,7 +46,7 @@ class Subscriber
         \Magento\Newsletter\Model\SubscriberFactory $subscriberFactory,
         \Magento\Framework\Message\ManagerInterface $message
     ) {
-    
+
         $this->_helper                  = $helper;
         $this->_subscriberCollection    = $subscriberCollection;
         $this->_message                 = $message;
@@ -55,6 +55,10 @@ class Subscriber
 
     public function sendSubscribers($storeId, $listId)
     {
+        if (!$this->_helper->isNewsletterModuleEnabled()) {
+            return [];
+        }
+
         //get subscribers
 //        $listId = $this->_helper->getGeneralList($storeId);
         $this->_interest = $this->_helper->getInterest($storeId);

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -207,6 +207,14 @@
                         <field id="*/*/active">1</field>
                     </depends>
                 </field>
+                <field id="synchronizable_order_statuses" translate="label,comment" type="multiselect" sortOrder="140" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Synchronizable order statuses</label>
+                    <comment>Select none if all statuses should be synced.</comment>
+                    <source_model>Magento\Sales\Model\Config\Source\Order\Status</source_model>
+                    <depends>
+                        <field id="*/*/active">1</field>
+                    </depends>
+                </field>
             </group>
             <group id="abandonedcart" translate="label" type="text" sortOrder="130" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Abandoned Cart Configuration</label>


### PR DESCRIPTION
We were missing the ability to control which orders are being synchronized to Mailchimp by their statuses, so we added the ability to do that. 

Also, in one case, our client has the Magento_Newsletter module disabled, but uses Mailchimp. Because of that, the `newsletter_subscriber` table does not exist. This resulted in the synchronzation process crashing. 