### PR TITLE
[2.3] Group entities by id to prevent duplicate errors

### DIFF
--- a/Model/Api/Customer.php
+++ b/Model/Api/Customer.php
@@ -102,6 +102,7 @@ class Customer
         $collection->getSelect()->where("m4m.mailchimp_sync_delta IS null ".
             "OR (m4m.mailchimp_sync_delta > '".$this->_helper->getMCMinSyncDateFlag().
             "' and m4m.mailchimp_sync_modified = 1)");
+        $collection->getSelect()->group('e.entity_id');
         $collection->getSelect()->limit(self::MAX);
         $counter = 0;
         $customerArray = [];

--- a/Model/Api/Product.php
+++ b/Model/Api/Product.php
@@ -137,6 +137,7 @@ class Product
         $collection->getSelect()->where("m4m.mailchimp_sync_delta IS null OR (m4m.mailchimp_sync_delta > '".
             $this->_helper->getMCMinSyncDateFlag().
             "' and m4m.mailchimp_sync_modified = 1)");
+        $collection->getSelect()->group('e.entity_id');
         $collection->getSelect()->limit(self::MAX);
         foreach ($collection as $item) {
             /**


### PR DESCRIPTION
When 2 entries exists with the same ID, Magento will throw an Exception which errors the cronjob `ebizmarts_ecommerce`

>  Item (Magento\Catalog\Model\Product\Interceptor) with the same ID "xx" already exists.

Grouping by id will only load the entity once.
(Not sure why duplicate entries exist, but I ran into this with both products and customers)