### PR TITLE
Fix incorrect import in Webhook controller

### DIFF
--- a/Controller/WebHook/Index.php
+++ b/Controller/WebHook/Index.php
@@ -20,7 +20,7 @@ use Magento\Framework\App\Action\Context;
 use Magento\Framework\App\CsrfAwareActionInterface;
 use Magento\Framework\App\Request\InvalidRequestException;
 use Magento\Framework\App\RequestInterface;
-use Zend\Db\Adapter\Driver\ResultInterface;
+use Magento\Framework\Controller\ResultInterface;
 
 class Index extends Action implements CsrfAwareActionInterface
 {


### PR DESCRIPTION
As part of https://github.com/mailchimp/mc-magento2/issues/921 was fixed issue, but imported incorrect interface. Imported `Zend\Db\Adapter\Driver\ResultInterface` while code 
https://github.com/mailchimp/mc-magento2/blob/244adc13cde4e2ed79e50858a637d61f7d8516e4/Controller/WebHook/Index.php#L84
will return instance of `Magento\Framework\Controller\ResultInterface`.

This is not introduces any issues to production, but it leads to bad development expirience while looking at the code, for instance you'll not have / will have incorrect autocomplete.

I think it was just small mistake, my PR just fixes it.