### PR TITLE
Prevent jQuery UI compat mode in campaign catcher JS

### DIFF
--- a/view/frontend/web/js/campaigncatcher.js
+++ b/view/frontend/web/js/campaigncatcher.js
@@ -10,7 +10,7 @@
 define(
     [
         'jquery',
-        'jquery/ui',
+        'jquery-ui-modules/widget',
         'mage/cookies'
     ],
     function ($) {


### PR DESCRIPTION
Prevents the below console warning in Magento from being thrown.

```
Fallback to JQueryUI Compat activated. Your store is missing a dependency for a jQueryUI widget. Identifying and addressing the dependency will drastically improve the performance of your site.
```

This loads the entire JQueryUI library as opposed to just the widget which is required by the script, since this is on the default handle if Mailchimp is enabled it's affecting the front end performance of all pages.

The change was brought about in Magento 2.3.3 to allow you to load smaller parts of the UI lib here: https://github.com/magento/magento2/commit/fc7059fd5f9ef058338a3291817ae03ea471da03 - so this may induce a BC break for 2.3.1 and 2.3.2.

