### PR TITLE
Get real product types in ecommerce cart

### DIFF
--- a/Model/Api/Cart.php
+++ b/Model/Api/Cart.php
@@ -432,11 +432,11 @@ class Cart
          */
         foreach ($items as $item) {
             $line = [];
-            if ($item->getProductType()=='bundle' || $item->getProductType()=='grouped') {
+            if ($item->getData('product_type') === 'bundle' || $item->getData('product_type') === 'grouped') {
                 continue;
             }
 
-            if ($item->getProductType()==\Magento\ConfigurableProduct\Model\Product\Type\Configurable::TYPE_CODE) {
+            if ($item->getData('product_type') === \Magento\ConfigurableProduct\Model\Product\Type\Configurable::TYPE_CODE) {
                 $variant = null;
                 if ($item->getOptionByCode('simple_product')) {
                     $variant = $item->getOptionByCode('simple_product')->getProduct();


### PR DESCRIPTION
When getProductType is used the product type is resolved from the product and not the quote item, this is unwanted in the case of grouped products, since the quote item would then not have a single simple product.

The following pull request should fix this and make it possible to use grouped products in the abandoned cart connector.