### PR TITLE
Update events.xml

### DIFF
--- a/etc/events.xml
+++ b/etc/events.xml
@@ -24,6 +24,6 @@
         <observer name="mailchimp_product_save_after" instance="\Ebizmarts\MailChimp\Observer\Adminhtml\Product\SaveAfter" />
     </event>
     <event name="newsletter_subscriber_save_before">
-        <observer name="'mailchimp_newsletter_subscriber_save_before" instance="\Ebizmarts\MailChimp\Observer\Subscriber\SaveBefore" />
+        <observer name="mailchimp_newsletter_subscriber_save_before" instance="\Ebizmarts\MailChimp\Observer\Subscriber\SaveBefore" />
     </event>
 </config>


### PR DESCRIPTION
There is an apostrophe in "mailchimp_newsletter_subscriber_save_before" observer name that breaks Magento 2 DOM XML parse.