### PR TITLE
Load subscriber in emulated store

### DIFF
--- a/Block/Adminhtml/Customer/Edit/Tabs/View/Customer.php
+++ b/Block/Adminhtml/Customer/Edit/Tabs/View/Customer.php
@@ -10,6 +10,7 @@
  * @date: 11/29/17 2:49 PM
  * @file: Customer.php
  */
+declare(strict_types=1);
 
 namespace Ebizmarts\MailChimp\Block\Adminhtml\Customer\Edit\Tabs\View;
 
@@ -18,23 +19,35 @@ class Customer extends \Magento\Backend\Block\Template
     /**
      * @var \Ebizmarts\MailChimp\Helper\Data
      */
-    protected $helper;
+    private $helper;
+
     /**
      * @var \Magento\Newsletter\Model\SubscriberFactory
      */
-    protected $subscriberFactory;
+    private $subscriberFactory;
 
     /**
      * @var \Magento\Framework\Registry
      */
-    protected $registry;
+    private $registry;
 
     /**
-     * Customer constructor.
+     * @var \Magento\Store\Model\App\Emulation
+     */
+    private $emulation;
+
+    /**
+     * @var \Magento\Customer\Api\CustomerRepositoryInterface
+     */
+    private $customerRepository;
+
+    /**
      * @param \Magento\Backend\Block\Template\Context $context
      * @param \Ebizmarts\MailChimp\Helper\Data $helper
      * @param \Magento\Newsletter\Model\SubscriberFactory $subscriberFactory
      * @param \Magento\Framework\Registry $registry
+     * @param \Magento\Store\Model\App\Emulation $emulation
+     * @param \Magento\Customer\Api\CustomerRepositoryInterface $customerRepository
      * @param array $data
      */
     public function __construct(
@@ -42,20 +55,29 @@ class Customer extends \Magento\Backend\Block\Template
         \Ebizmarts\MailChimp\Helper\Data $helper,
         \Magento\Newsletter\Model\SubscriberFactory $subscriberFactory,
         \Magento\Framework\Registry $registry,
+        \Magento\Store\Model\App\Emulation $emulation,
+        \Magento\Customer\Api\CustomerRepositoryInterface $customerRepository,
         array $data
     ) {
-    
         parent::__construct($context, $data);
-        $this->helper               = $helper;
-        $this->subscriberFactory    = $subscriberFactory;
-        $this->registry             = $registry;
+
+        $this->helper = $helper;
+        $this->subscriberFactory = $subscriberFactory;
+        $this->registry = $registry;
+        $this->emulation = $emulation;
+        $this->customerRepository = $customerRepository;
     }
 
     public function getInterest()
     {
-        $subscriber = $this->subscriberFactory->create();
         $customerId = $this->registry->registry(\Magento\Customer\Controller\RegistryConstants::CURRENT_CUSTOMER_ID);
+        $customerData = $this->customerRepository->getById($customerId);
+        $subscriber = $this->subscriberFactory->create();
+
+        $this->emulation->startEnvironmentEmulation($customerData->getStoreId());
         $subscriber->loadByCustomerId($customerId);
+        $this->emulation->stopEnvironmentEmulation();
+
         return $this->helper->getSubscriberInterest($subscriber->getSubscriberId(), $subscriber->getStoreId());
     }
 }


### PR DESCRIPTION
### Preconditions
1. Magento CE 2.3.4.
2. mc-magento2 102.3.42.

### Steps to reproduce
1. Setup audience with interest group.
2. Create new magento store, and use created audience with interest group.
2. Create customer account in newly created store, subscribe to newsletter and fill in interest group in my account section.
3. Open customer in admin area and open mailchimp tab.

### Actual and Expected result
#### Expected result:
Interest groups are shown with values selected.

#### Actual result:
Interest groups are shown without selected values.