### PR TITLE
PHP 8.1 - Fix optional parameter error - fix #1384

### DIFF
--- a/Cron/Ecommerce.php
+++ b/Cron/Ecommerce.php
@@ -138,7 +138,7 @@ class Ecommerce
                     $storeId
                 );
                 if ($mailchimpStoreId != -1 && $mailchimpStoreId != '') {
-                    $this->_apiResult->processResponses($storeId, true, $mailchimpStoreId);
+                    $this->_apiResult->processResponses($storeId, $mailchimpStoreId);
                     $batchId = $this->_processStore($storeId, $mailchimpStoreId, $listId);
                     if ($batchId) {
                         $connection->update(

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -652,7 +652,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     {
         return $this->_storeManager->getStore($storeId)->getBaseUrl($type, true);
     }
-    public function createStore($listId = null, $storeId)
+    public function createStore($listId, $storeId)
     {
         if ($listId) {
             //generate store id

--- a/Model/Api/Result.php
+++ b/Model/Api/Result.php
@@ -66,7 +66,7 @@ class Result
         $this->_driver              = $driver;
         $this->_curlFactory         = $curlFactory;
     }
-    public function processResponses($storeId, $isMailChimpStoreId = false, $mailchimpStoreId)
+    public function processResponses($storeId, $mailchimpStoreId)
     {
         $collection = $this->_batchCollection->create();
         $collection


### PR DESCRIPTION
With PHP 8.1, fix the following error

```
Deprecated Functionality: Optional parameter $isMailChimpStoreId declared before required parameter $mailchimpStoreId is implicitly treated as a required parameter in /var/www/html/vendor/mailchimp/mc-magento2/Model/Api/Result.php on line 69
```

This parameter does not seem to be used anyway.

`createStore` function does not seem to be used either.

Fix for issue #1384.