### PR TITLE
Fix Custom Fields Mapping

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -676,6 +676,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         $mapFields = $this->getMapFields($storeId);
         if (is_array($mapFields)) {
             foreach ($mapFields as $map) {
+                $value = null;
                 if (strpos($map['customer_field'], '##') !== false) {
                     $parts = explode('##', $map['customer_field']);
                     $attributeCode = $parts[0];


### PR DESCRIPTION
**Preconditions**

  1. Magento 2.4.2-p1.
  2. mc-magento 103.4.44.
  3. Create Customer Fields inside Mailchimp Audience and Mapping with Magento.
  <img width="1308" alt="Captura de Tela 2022-06-13 às 22 52 02" src="https://user-images.githubusercontent.com/23405617/173476507-d81f0357-1e19-446b-8572-0454c950722f.png">

**Steps to reproduce**

  1. Create a new customer account on your Magento website without filling the custom fields.

**Actual and Expected results**

  Expected result:
  
  Mailchimp module will sync the customer and leave the custom fields empty.
  
  Actual result:
  
  Mailchimp module syncs the customer,  but the custom fields will be filled with the last field that had a value.
  
  <img width="1045" alt="Captura de Tela 2022-06-13 às 23 00 23" src="https://user-images.githubusercontent.com/23405617/173477613-bfcbc4d1-f485-43ed-90d4-5a507317c3b1.png">
  
