### PR TITLE
Fix issue introduced by not selecting all quote fields

### DIFF
--- a/Model/Api/Cart.php
+++ b/Model/Api/Cart.php
@@ -359,7 +359,7 @@ class Cart
         if ($this->_firstDate) {
             $newCarts->addFieldToFilter('created_at', ['gt' => $this->_firstDate]);
         }
-        $newCarts->getSelect()->reset(\Zend_Db_Select::COLUMNS)->columns(['entity_id']);
+        $newCarts->getSelect()->reset(\Zend_Db_Select::COLUMNS)->columns(['entity_id', 'updated_at', 'customer_id', 'customer_email']);
 
         //join with mailchimp_ecommerce_sync_data table to filter by sync data.
         $newCarts->getSelect()->joinLeft(


### PR DESCRIPTION
Added extra fields to the select to fix the error generating on line 382 due to getCustomerEmail() and getUpdatedAt() being empty.