### PR TITLE
Deprecated Functionality: abs(): Passing null to parameter

### DIFF
--- a/Block/Adminhtml/System/Config/CreateAbandonedCart.php
+++ b/Block/Adminhtml/System/Config/CreateAbandonedCart.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Ebizmarts_MailChimp Magento JS component
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Block\Adminhtml\System\Config;
+
+class CreateAbandonedCart extends \Magento\Config\Block\System\Config\Form\Field
+{
+    protected $_template    = 'system/config/create_abandonedcart_automation.phtml';
+
+    private $_url     = "https://admin.mailchimp.com/#/create-campaign/explore/abandonedCart";
+
+    protected function _getElementHtml(\Magento\Framework\Data\Form\Element\AbstractElement $element)
+    {
+        $originalData = $element->getOriginalData();
+
+        $label = $originalData['button_label'];
+
+        $this->addData([
+            'button_label' => __($label),
+            'button_url'   => $this->authorizeRequestUrl(),
+            'html_id' => $element->getHtmlId(),
+        ]);
+        return parent::_toHtml();
+        ;
+    }
+    public function authorizeRequestUrl()
+    {
+        return $this->_url;
+    }
+}

--- a/Block/Adminhtml/System/Config/Fieldset/Hint.php
+++ b/Block/Adminhtml/System/Config/Fieldset/Hint.php
@@ -78,4 +78,26 @@ class Hint extends \Magento\Backend\Block\Template implements
             return false;
         }
     }
+    public function getScope()
+    {
+        $params = $this->getRequest()->getParams();
+        $scope = 'default';
+        if (isset($params['website'])) {
+            $scope = 'website';
+        } elseif (isset($params['store'])) {
+            $scope = 'store';
+        }
+        return $scope;
+    }
+    public function getScopeId()
+    {
+        $params = $this->getRequest()->getParams();
+        $scopeId = 0;
+        if (isset($params['website'])) {
+            $scopeId = $params['website'];
+        } elseif (isset($params['store'])) {
+            $scopeId = $params['store'];
+        }
+        return $scopeId;
+    }
 }

--- a/Block/Adminhtml/System/Config/Form/Field/VarsMap.php
+++ b/Block/Adminhtml/System/Config/Form/Field/VarsMap.php
@@ -42,12 +42,14 @@ class VarsMap extends \Magento\Framework\View\Element\Html\Select
         $ret['default_shipping##city']    = __('Shipping City');
         $ret['default_shipping##state']   = __('Shipping State');
         $ret['default_shipping##telephone']   = __('Shipping Telephone');
+        $ret['default_shipping##company']   = __('Shipping Company');
 
         $ret['default_billing##zip']      = __('Billing Zip Code');
         $ret['default_billing##country']  = __('Billing Country');
         $ret['default_billing##city']     = __('Billing City');
         $ret['default_billing##state']    = __('Billing State');
-        $ret['default_billing##telephone']    = __('Billing Telephone');
+        $ret['default_billing##telephone']   = __('Billing Telephone');
+        $ret['default_billing##company']   = __('Billing Company');
 
         return $ret;
     }

--- a/Block/Adminhtml/System/Config/ResyncProducts.php
+++ b/Block/Adminhtml/System/Config/ResyncProducts.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: gonzalo
+ * Date: 3/12/18
+ * Time: 2:12 PM
+ */
+namespace Ebizmarts\MailChimp\Block\Adminhtml\System\Config;
+
+class ResyncProducts extends \Magento\Config\Block\System\Config\Form\Field
+{
+    /**
+     * @var \Ebizmarts\MailChimp\Helper\Data
+     */
+    private $_helper;
+
+    /**
+     * ResetErrors constructor.
+     * @param \Magento\Backend\Block\Template\Context $context
+     * @param \Ebizmarts\MailChimp\Helper\Data $helper
+     * @param array $data
+     */
+    public function __construct(
+        \Magento\Backend\Block\Template\Context $context,
+        \Ebizmarts\MailChimp\Helper\Data $helper,
+        array $data = []
+    ) {
+
+        $this->_helper = $helper;
+        parent::__construct($context, $data);
+    }
+
+    protected function _construct()
+    {
+        parent::_construct();
+        $this->setTemplate('system/config/resyncproducts.phtml');
+    }
+
+    protected function _getElementHtml(\Magento\Framework\Data\Form\Element\AbstractElement $element)
+    {
+        $originalData = $element->getOriginalData();
+        $this->addData(
+            [
+                'button_label' => __($originalData['button_label']),
+                'html_id' => $element->getHtmlId(),
+            ]
+        );
+        return $this->_toHtml();
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Change Log
 
+## [102.3.44](https://github.com/mailchimp/mc-magento2/tree/102.3.44)
+
+[Full Changelog](https://github.com/mailchimp/mc-magento2/compare/102.3.43...102.3.44)
+
+**Implemented enhancements:**
+
+- Add option in the error grid to link to the register with error [\#1279](https://github.com/mailchimp/mc-magento2/issues/1279)
+
+**Fixed bugs:**
+
+- Incorrect image url with some extensions \(p.e. cloudinary extension\) [\#1288](https://github.com/mailchimp/mc-magento2/issues/1288)
+- Modify order totals to $0 when order is cancelled [\#1272](https://github.com/mailchimp/mc-magento2/issues/1272)
+- Typo at https://github.com/mailchimp/mc-magento2/blob/develop-2.3/Model/Api/Order.php\#L29 [\#1249](https://github.com/mailchimp/mc-magento2/issues/1249)
+- Deleting error records causes database lockup [\#1242](https://github.com/mailchimp/mc-magento2/issues/1242)
+- Change the echo with helper-\>log in https://github.com/mailchimp/mc-magento2/blob/develop-2.3/Observer/Adminhtml/Product/ImportAfter.php\#L40 [\#1228](https://github.com/mailchimp/mc-magento2/issues/1228)
+- ImportAfter observer is throwing exceptions if the \_store column is not present in the import data [\#1224](https://github.com/mailchimp/mc-magento2/issues/1224)
+- Error retrieving the response of a batch from mailchimp [\#1204](https://github.com/mailchimp/mc-magento2/issues/1204)
+- Avoid duplicate entries in the stores grid [\#1217](https://github.com/mailchimp/mc-magento2/issues/1217)
+- Unable to create a new Mailchimp Store in admin [\#1208](https://github.com/mailchimp/mc-magento2/issues/1208)
+
 ## [102.3.43](https://github.com/mailchimp/mc-magento2/tree/102.3.43)
 
 [Full Changelog](https://github.com/mailchimp/mc-magento2/compare/102.3.42...102.3.43)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Change Log
 
+## [102.3.43](https://github.com/mailchimp/mc-magento2/tree/102.3.43)
+
+[Full Changelog](https://github.com/mailchimp/mc-magento2/compare/102.3.42...102.3.43)
+
+**Implemented enhancements:**
+
+- Add a button in the admin to resync all products [\#1184](https://github.com/mailchimp/mc-magento2/issues/1184)
+- Missing indexes on mailchimp\_errors [\#1162](https://github.com/mailchimp/mc-magento2/issues/1162)
+- Ignore modified items when flagging store as synced [\#1140](https://github.com/mailchimp/mc-magento2/issues/1140)
+- Only fetch specific columns from sales\_order [\#1134](https://github.com/mailchimp/mc-magento2/issues/1134)
+- Error table never getting cleaned up [\#1107](https://github.com/mailchimp/mc-magento2/issues/1107)
+
+**Fixed bugs:**
+
+- Change the low value for date sync to a valid one [\#1192](https://github.com/mailchimp/mc-magento2/issues/1192)
+- Exclude the bundle and grouped products for the product collection [\#1191](https://github.com/mailchimp/mc-magento2/issues/1191)
+- The product image url don't contain the secure url if Use Secure URLs on Storefront is ON [\#1179](https://github.com/mailchimp/mc-magento2/issues/1179)
+- Mark products as modified when use import products from the admin [\#1167](https://github.com/mailchimp/mc-magento2/issues/1167)
+- Issue with "Magento Always Manage Emails" when Unsubscribing from a Customer Account [\#1157](https://github.com/mailchimp/mc-magento2/issues/1157)
+- errors in cron related to ebizmarts\_webhooks [\#1152](https://github.com/mailchimp/mc-magento2/issues/1152)
+- Ecommerce order send loop [\#1112](https://github.com/mailchimp/mc-magento2/issues/1112)
+- Allow more than 10 interest inside a group [\#1103](https://github.com/mailchimp/mc-magento2/issues/1103)
+- observer name that breaks Magento 2 DOM XML [\#1102](https://github.com/mailchimp/mc-magento2/issues/1102)
+- CSP Whitelist Support [\#1097](https://github.com/mailchimp/mc-magento2/issues/1097)
+- Infinite loop on customer account creation if email present in newsletter subscribers list [\#1090](https://github.com/mailchimp/mc-magento2/issues/1090)
+- Ecommerce Cron error "Requested country is not available." [\#1084](https://github.com/mailchimp/mc-magento2/issues/1084)
+- Subscribing for a second time does not work. [\#1078](https://github.com/mailchimp/mc-magento2/issues/1078)
+
 ## [102.3.42](https://github.com/mailchimp/mc-magento2/tree/102.3.42)
 
 [Full Changelog](https://github.com/mailchimp/mc-magento2/compare/102.3.41...102.3.42)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Change Log
 
+## [102.3.45](https://github.com/mailchimp/mc-magento2/tree/102.3.45)
+
+[Full Changelog](https://github.com/mailchimp/mc-magento2/compare/102.3.44...102.3.45)
+
+**Implemented enhancements:**
+
+- Query optimization for ecommerce table [\#1391](https://github.com/mailchimp/mc-magento2/issues/1391)
+- Add the possibility  to send the company as a merge field [\#1369](https://github.com/mailchimp/mc-magento2/issues/1369)
+- Make uninstall [\#1347](https://github.com/mailchimp/mc-magento2/issues/1347)
+- Performance Issue During Product Import [\#1309](https://github.com/mailchimp/mc-magento2/issues/1309)
+
+**Fixed bugs:**
+
+- Subscribers are not added to mailchimp [\#1359](https://github.com/mailchimp/mc-magento2/issues/1359)
+- The sync fails when an order contains a deleted product [\#1330](https://github.com/mailchimp/mc-magento2/issues/1330)
+- Problem syncing country with customer address [\#1329](https://github.com/mailchimp/mc-magento2/issues/1329)
+- Chimpstatic wrong url when change the mailchimp store [\#1322](https://github.com/mailchimp/mc-magento2/issues/1322)
+- Error creating the webhook, wrong webhook url [\#1316](https://github.com/mailchimp/mc-magento2/issues/1316)
+
 ## [102.3.44](https://github.com/mailchimp/mc-magento2/tree/102.3.44)
 
 [Full Changelog](https://github.com/mailchimp/mc-magento2/compare/102.3.43...102.3.44)

--- a/Controller/Adminhtml/Ecommerce/CreateWebhook.php
+++ b/Controller/Adminhtml/Ecommerce/CreateWebhook.php
@@ -47,7 +47,7 @@ class CreateWebhook extends \Magento\Backend\App\Action
         \Ebizmarts\MailChimp\Helper\Data $helper,
         \Magento\Config\Model\ResourceModel\Config $config
     ) {
-    
+
         parent::__construct($context);
         $this->resultJsonFactory    = $resultJsonFactory;
         $this->helper               = $helper;
@@ -61,11 +61,14 @@ class CreateWebhook extends \Magento\Backend\App\Action
         $params = $this->getRequest()->getParams();
         $apiKey = $params['apikey'];
         $listId = $params['listId'];
+        $scope = $params['scope'];
+        $scopeId = $params['scopeId'];
+
         if ($apiKey=='******') {
-            $apiKey = $this->helper->getApiKey($this->storeManager->getStore()->getId());
+            $apiKey = $this->helper->getApiKey($scopeId, $scope);
         }
 
-        $return = $this->helper->createWebHook($apiKey, $listId);
+        $return = $this->helper->createWebHook($apiKey, $listId, $scope, $scopeId);
         if (isset($return['message'])) {
             $valid = 0;
             $message = $return['message'];

--- a/Controller/Adminhtml/Ecommerce/GetInterest.php
+++ b/Controller/Adminhtml/Ecommerce/GetInterest.php
@@ -69,7 +69,7 @@ class GetInterest extends Action
                     $api = $this->_helper->getApiByApiKey($apiKey, $encrypt);
                 }
 
-                $result = $api->lists->interestCategory->getAll($list);
+                $result = $api->lists->interestCategory->getAll($list, null, null, 200);
                 if (is_array($result['categories']) && count($result['categories'])) {
                     $rc = $result['categories'];
                 }

--- a/Controller/Adminhtml/Ecommerce/Getaccountdetails.php
+++ b/Controller/Adminhtml/Ecommerce/Getaccountdetails.php
@@ -81,9 +81,9 @@ class Getaccountdetails extends Action
                     $options['total_orders'] = ['label' => __('Total orders:'), 'value' => $totalOrders['total_items']];
                     $totalCarts = $api->ecommerce->carts->getAll($store, 'total_items');
                     $options['total_carts'] = ['label' => __('Total Carts:'), 'value' => $totalCarts['total_items']];
-                    $options['notsaved'] = ['label' => __('This MailChimp account is not connected to Magento.'), 'value' => ''];
+                    $options['notsaved'] = ['label' => __('Ecommerce disabled, save configuration to enable.'), 'value' => ''];
                 } else {
-                    $options['nostore'] = ['label' => __('This MailChimp account is not connected to Magento.'), 'value' => ''];
+                    $options['nostore'] = ['label' => __('Ecommerce disabled, only subscribers will be synchronized (your orders, products,etc will be not synchronized).'), 'value' => ''];
                 }
             }
         } catch (\Mailchimp_Error $e) {

--- a/Controller/Adminhtml/Ecommerce/ResyncProducts.php
+++ b/Controller/Adminhtml/Ecommerce/ResyncProducts.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * mc-magento2 Magento Component
+ *
+ * @category Ebizmarts
+ * @package mc-magento2
+ * @author Ebizmarts Team <info@ebizmarts.com>
+ * @copyright Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @date: 2/21/17 5:07 PM
+ * @file: ResetLocalErrors.php
+ */
+
+namespace Ebizmarts\MailChimp\Controller\Adminhtml\Ecommerce;
+
+use Magento\Framework\Controller\Result\JsonFactory;
+use Magento\Framework\Exception\ValidatorException;
+use Symfony\Component\Config\Definition\Exception\Exception;
+
+class ResyncProducts extends \Magento\Backend\App\Action
+{
+    /**
+     * @var JsonFactory
+     */
+    protected $resultJsonFactory;
+    /**
+     * @var \Ebizmarts\MailChimp\Helper\Data
+     */
+    protected $helper;
+    /**
+     * @var \Magento\Store\Model\StoreManagerInterface
+     */
+    protected $storeManager;
+
+    /**
+     * ResetLocalErrors constructor.
+     * @param \Magento\Backend\App\Action\Context $context
+     * @param JsonFactory $resultJsonFactory
+     * @param \Magento\Store\Model\StoreManagerInterface $storeManagerInterface
+     * @param \Ebizmarts\MailChimp\Helper\Data $helper
+     */
+    public function __construct(
+        \Magento\Backend\App\Action\Context $context,
+        JsonFactory $resultJsonFactory,
+        \Magento\Store\Model\StoreManagerInterface $storeManagerInterface,
+        \Ebizmarts\MailChimp\Helper\Data $helper
+    ) {
+    
+        parent::__construct($context);
+        $this->resultJsonFactory    = $resultJsonFactory;
+        $this->helper               = $helper;
+        $this->storeManager         = $storeManagerInterface;
+    }
+
+    public function execute()
+    {
+        $valid = 1;
+        $message = '';
+        $params = $this->getRequest()->getParams();
+        if (isset($params['website'])) {
+            $mailchimpStore = $this->helper->getConfigValue(
+                \Ebizmarts\MailChimp\Helper\Data::XML_MAILCHIMP_STORE,
+                $params['website'],
+                'website'
+            );
+        } elseif (isset($params['store'])) {
+            $mailchimpStore = $this->helper->getConfigValue(
+                \Ebizmarts\MailChimp\Helper\Data::XML_MAILCHIMP_STORE,
+                $params['store'],
+                'store'
+            );
+        } else {
+            $mailchimpStore = $this->helper->getConfigValue(
+                \Ebizmarts\MailChimp\Helper\Data::XML_MAILCHIMP_STORE,
+                $this->storeManager->getStore()
+            );
+        }
+
+        $resultJson = $this->resultJsonFactory->create();
+        try {
+            $this->helper->resyncProducts($mailchimpStore);
+        } catch (ValidatorException $e) {
+            $valid = 0;
+            $message = $e->getMessage();
+        }
+        return $resultJson->setData([
+            'valid' => (int)$valid,
+            'message' => $message,
+        ]);
+    }
+    protected function _isAllowed()
+    {
+        return $this->_authorization->isAllowed('Ebizmarts_MailChimp::config_mailchimp');
+    }
+}

--- a/Controller/Adminhtml/Stores.php
+++ b/Controller/Adminhtml/Stores.php
@@ -36,7 +36,7 @@ class Stores extends Action
     /**
      * @var \Ebizmarts\MailChimp\Helper\Data
      */
-    protected $_helper;
+    protected $_mhelper;
 
     /**
      * Stores constructor.
@@ -58,7 +58,7 @@ class Stores extends Action
         $this->_coreRegistry            = $registry;
         $this->_resultPageFactory       = $resultPageFactory;
         $this->_mailchimpStoresFactory  = $storesFactory;
-        $this->_helper                  = $helper;
+        $this->_mhelper                  = $helper;
     }
     public function execute()
     {

--- a/Controller/Adminhtml/Stores/Delete.php
+++ b/Controller/Adminhtml/Stores/Delete.php
@@ -23,13 +23,13 @@ class Delete extends \Ebizmarts\MailChimp\Controller\Adminhtml\Stores
             $storeModel = $this->_mailchimpStoresFactory->create();
             $storeModel->getResource()->load($storeModel, $storeId);
             try {
-                $api = $this->_helper->getApiByApiKey($storeModel->getApikey(), true);
+                $api = $this->_mhelper->getApiByApiKey($storeModel->getApikey(), true);
                 $api->ecommerce->stores->delete($storeModel->getStoreid());
                 $this->messageManager->addSuccess(__('You deleted the store.'));
                 return $resultRedirect->setPath('mailchimp/stores');
             } catch (\Mailchimp_Error $e) {
                 $this->messageManager->addError(__('Store could not be deleted.'.$e->getMessage()));
-                $this->_helper->log($e->getFriendlyMessage());
+                $this->_mhelper->log($e->getFriendlyMessage());
                 return $resultRedirect->setPath('mailchimp/stores/edit', ['id'=>$storeId]);
             }
         }

--- a/Controller/Adminhtml/Stores/Get.php
+++ b/Controller/Adminhtml/Stores/Get.php
@@ -23,7 +23,7 @@ class Get extends Action
     /**
      * @var \Ebizmarts\MailChimp\Helper\Data
      */
-    protected $_helper;
+    protected $_mhelper;
     /**
      * @var ResultFactory
      */
@@ -41,7 +41,7 @@ class Get extends Action
 
         parent::__construct($context);
         $this->_resultFactory       = $context->getResultFactory();
-        $this->_helper                  = $helper;
+        $this->_mhelper                  = $helper;
     }
     public function execute()
     {
@@ -49,7 +49,7 @@ class Get extends Action
         $apiKey = $param['apikey'];
         $encrypt = $param['encrypt'];
         try {
-            $api = $this->_helper->getApiByApiKey($apiKey, $encrypt);
+            $api = $this->_mhelper->getApiByApiKey($apiKey, $encrypt);
             $stores = $api->ecommerce->stores->get(null, null, null, self::MAX_STORES);
             $result = [];
             $result['valid'] = 1;
@@ -70,7 +70,7 @@ class Get extends Action
                 }
             }
         } catch (\Mailchimp_Error $e) {
-            $this->_helper->log($e->getFriendlyMessage());
+            $this->_mhelper->log($e->getFriendlyMessage());
             $result['valid'] = 0;
             $result['errormsg'] = $e->getTitle();
         }

--- a/Controller/Adminhtml/Stores/Index.php
+++ b/Controller/Adminhtml/Stores/Index.php
@@ -18,7 +18,7 @@ class Index extends Stores
 {
     public function execute()
     {
-        $this->_helper->loadStores();
+        $this->_mhelper->loadStores();
         $page = $this->_resultPageFactory->create();
         $page->getConfig()->getTitle()->prepend(__('Mailchimp Stores'));
         return $page;

--- a/Controller/Adminhtml/Stores/Save.php
+++ b/Controller/Adminhtml/Stores/Save.php
@@ -42,14 +42,14 @@ class Save extends \Ebizmarts\MailChimp\Controller\Adminhtml\Stores
                 }
             } catch (\Mailchimp_Error $e) {
                 $this->messageManager->addErrorMessage(__('Store could not be saved.'.$e->getMessage()));
-                $this->_helper->log($e->getFriendlyMessage());
+                $this->_mhelper->log($e->getFriendlyMessage());
                 return $resultRedirect->setPath('mailchimp/stores/edit', ['id'=>$storeId]);
             }
         }
     }
     protected function _updateMailchimp($formData)
     {
-        $api = $this->_helper->getApiByApiKey($formData['apikey'], true);
+        $api = $this->_mhelper->getApiByApiKey($formData['apikey'], true);
         // set the address
         $address = [];
         $address['address1']    = $formData['address_address_one'];
@@ -86,7 +86,7 @@ class Save extends \Ebizmarts\MailChimp\Controller\Adminhtml\Stores
                 $is_sync
             );
         } else {
-            $date = $this->_helper->getDateMicrotime();
+            $date = $this->_mhelper->getDateMicrotime();
             $mailchimpStoreId = hash('md5', $name. '_' . $date);
             //$mailchimpStoreId = md5($name. '_' . $date);
             $is_sync = true;

--- a/Cron/BatchesClean.php
+++ b/Cron/BatchesClean.php
@@ -61,7 +61,6 @@ class BatchesClean
             $tableName = $this->mailChimpSyncBatches->getResource()->getMainTable();
             $select = $connection->select();
             $select->from($tableName, ['batch_id']);
-            $select->where('status IN("completed","canceled") and ( date_add(modified_date, interval 1 month) < now() OR modified_date IS NULL)');
             $existingBatchIds = $connection->fetchCol($select);
             $connection = $this->mailChimpErrors->getResource()->getConnection();
             $tableName = $this->mailChimpErrors->getResource()->getMainTable();

--- a/Cron/BatchesClean.php
+++ b/Cron/BatchesClean.php
@@ -44,19 +44,6 @@ class BatchesClean
     }
     public function execute()
     {
-
-        try {
-            $connection = $this->mailChimpErrors->getResource()->getConnection();
-            $tableName  = $this->mailChimpErrors->getResource()->getMainTable();
-            $tableNameBatches = $this->mailChimpSyncBatches->getResource()->getMainTable();
-            $quoteInto = $connection->quoteInto(
-                "batch_id IN (SELECT batch_id FROM $tableNameBatches WHERE status IN('completed','canceled') AND ( date_add(modified_date, interval ? month) < now() OR modified_date IS NULL)) OR batch_id NOT IN(SELECT batch_id FROM $tableNameBatches)",
-                1
-            );
-            $connection->delete($tableName, $quoteInto);
-        } catch (\Exception $e) {
-            $this->helper->log($e->getMessage());
-        }
         try {
             $connection = $this->mailChimpSyncBatches->getResource()->getConnection();
             $tableName = $this->mailChimpSyncBatches->getResource()->getMainTable();
@@ -65,6 +52,26 @@ class BatchesClean
                 1
             );
             $connection->delete($tableName, $quoteInto);
+        } catch (\Exception $e) {
+            $this->helper->log($e->getMessage());
+        }
+
+        try {
+            $connection = $this->mailChimpSyncBatches->getResource()->getConnection();
+            $tableName = $this->mailChimpSyncBatches->getResource()->getMainTable();
+            $select = $connection->select();
+            $select->from($tableName, ['batch_id']);
+            $select->where('status IN("completed","canceled") and ( date_add(modified_date, interval 1 month) < now() OR modified_date IS NULL)');
+            $existingBatchIds = $connection->fetchCol($select);
+            $connection = $this->mailChimpErrors->getResource()->getConnection();
+            $tableName = $this->mailChimpErrors->getResource()->getMainTable();
+            if ($existingBatchIds) {
+                $connection->delete($tableName, [
+                    'batch_id NOT IN (?)' => $existingBatchIds,
+                ]);
+            } else {
+                $connection->delete($tableName);
+            }
         } catch (\Exception $e) {
             $this->helper->log($e->getMessage());
         }

--- a/Cron/Ecommerce.php
+++ b/Cron/Ecommerce.php
@@ -277,7 +277,7 @@ class Ecommerce
         } else {
             $this->_helper->log("Nothing to sync for store $storeId");
         }
-        $countTotal = $countCustomers + $countProducts + $countOrders;
+        $countTotal = $this->_helper->getTotalNewItemsSent();
         $syncing = $this->_helper->getMCMinSyncing($storeId);
         if ($countTotal == 0 && $syncing) {
             $this->_helper->saveConfigValue(

--- a/Cron/Webhook.php
+++ b/Cron/Webhook.php
@@ -349,9 +349,11 @@ class Webhook
             $listId =$this->_helper->getDefaultList($storeId);
             $api = $this->_helper->getApi($storeId);
             $interestsCat = $api->lists->interestCategory->getAll($listId, null, null, 200);
-            foreach ($interestsCat['categories'] as $cat) {
-                $interests = $api->lists->interestCategory->interests->getAll($listId,$cat['id'], null, null, 200);
-                $this->groups = array_merge_recursive($this->groups, $interests['interests']);
+            if (isset($interestsCat['categories'])) {
+                foreach ($interestsCat['categories'] as $cat) {
+                    $interests = $api->lists->interestCategory->interests->getAll($listId, $cat['id'], null, null, 200);
+                    $this->groups = array_merge_recursive($this->groups, $interests['interests']);
+                }
             }
         }
     }

--- a/Cron/Webhook.php
+++ b/Cron/Webhook.php
@@ -348,9 +348,9 @@ class Webhook
             }
             $listId =$this->_helper->getDefaultList($storeId);
             $api = $this->_helper->getApi($storeId);
-            $interestsCat = $api->lists->interestCategory->getAll($listId);
+            $interestsCat = $api->lists->interestCategory->getAll($listId, null, null, 200);
             foreach ($interestsCat['categories'] as $cat) {
-                $interests = $api->lists->interestCategory->interests->getAll($listId,$cat['id']);
+                $interests = $api->lists->interestCategory->interests->getAll($listId,$cat['id'], null, null, 200);
                 $this->groups = array_merge_recursive($this->groups, $interests['interests']);
             }
         }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -899,6 +899,8 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
                 $chimpSyncEcommerce->setRelatedId($entityId);
                 if ($modified!==null) {
                     $chimpSyncEcommerce->setMailchimpSyncModified($modified);
+                } else {
+                    $chimpSyncEcommerce->setMailchimpSyncModified(0);
                 }
                 if ($date) {
                     $chimpSyncEcommerce->setMailchimpSyncDelta($date);

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -705,6 +705,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         $mapFields = $this->getMapFields($storeId);
         if (is_array($mapFields)) {
             foreach ($mapFields as $map) {
+                $value = null;
                 if (strpos($map['customer_field'], '##') !== false) {
                     $parts = explode('##', $map['customer_field']);
                     $attributeCode = $parts[0];

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -208,10 +208,15 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      * @var \Magento\Framework\Serialize\Serializer\Json
      */
     protected $_serializer;
+    /**
+     * @var \Magento\Directory\Model\CountryFactory
+     */
+    protected $countryFactory;
 
     private $customerAtt    = null;
     private $addressAtt     = null;
     private $_mapFields     = null;
+
     /**
      * Data constructor.
      * @param \Magento\Framework\App\Helper\Context $context
@@ -242,6 +247,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      * @param \Magento\Framework\Serialize\Serializer\Json $serializer
      * @param \Magento\Framework\App\DeploymentConfig $deploymentConfig
      * @param \Magento\Framework\Stdlib\DateTime\DateTime $date
+     * @param \Magento\Directory\Model\CountryFactory $countryFactory
      */
     public function __construct(
         \Magento\Framework\App\Helper\Context $context,
@@ -271,7 +277,8 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         \Ebizmarts\MailChimp\Model\MailChimpInterestGroupFactory $interestGroupFactory,
         \Magento\Framework\Serialize\Serializer\Json $serializer,
         \Magento\Framework\App\DeploymentConfig $deploymentConfig,
-        \Magento\Framework\Stdlib\DateTime\DateTime $date
+        \Magento\Framework\Stdlib\DateTime\DateTime $date,
+        \Magento\Directory\Model\CountryFactory $countryFactory
     ) {
 
         $this->_storeManager  = $storeManager;
@@ -304,6 +311,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         $this->_serializer              = $serializer;
         $this->_deploymentConfig        = $deploymentConfig;
         $this->_date                    = $date;
+        $this->countryFactory           = $countryFactory;
         parent::__construct($context);
     }
 
@@ -761,7 +769,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
                 $addressData["zip"] = $address->getPostcode();
             }
             if ($address->getCountry()) {
-                $country = $this->_countryInformation->getCountryInfo($address->getCountryId());
+                $country = $this->_countryFactory->create()->loadByCode($address->getCountryId());
                 $addressData["country"] = $country->getFullNameLocale();
             }
             if ($address->getTelephone()) {

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -638,6 +638,10 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
             $this->_mailChimpSyncE->markAllAsModified($registerId, $type);
         }
     }
+    public function markAllAsModifiedByIds($mailchimpStoreId, $ids, $type)
+    {
+        $this>$this->_mailChimpSyncE->markAllAsModifiedByIds($mailchimpStoreId, $ids, $type);
+    }
     public function getMCStoreName($storeId)
     {
         return $this->_storeManager->getStore($storeId)->getFrontendName();

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1279,6 +1279,19 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     {
         return $this->counters;
     }
+    public function getTotalNewItemsSent()
+    {
+        $totalAmount = 0;
+        $itemArray = [self::ORD_NEW, self::SUB_NEW, self::PRO_NEW, self::CUS_NEW, self::QUO_NEW];
+
+        foreach ($itemArray as $item) {
+            if (array_key_exists($item, $this->counters)) {
+                $totalAmount += $this->counters[$item];
+            }
+        }
+
+        return $totalAmount;
+    }
     public function serialize($data)
     {
         return $this->_serializer->serialize($data);

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -416,11 +416,13 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
                 'default_shipping##city',
                 'default_shipping##state',
                 'default_shipping##telephone',
+                'default_shipping##company',
                 'default_billing##zip',
                 'default_billing##country',
                 'default_billing##city',
                 'default_billing##state',
-                'default_billing##telephone'
+                'default_billing##telephone',
+                'default_billing##company'
             ];
 
             foreach($elements as $item) {
@@ -709,9 +711,13 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
                     $fieldName = $parts[1];
                     $customerAddress = $customer->getPrimaryAddress($attributeCode);
                     if ($customerAddress !== false) {
-                        $addressData = $this->_getAddressValues($customerAddress);
-                        if (!empty($addressData[$fieldName])) {
-                            $value = $addressData[$fieldName];
+                        if ($fieldName!='company') {
+                            $addressData = $this->_getAddressValues($customerAddress);
+                            if (!empty($addressData[$fieldName])) {
+                                $value = $addressData[$fieldName];
+                            }
+                        } else {
+                            $value = $customerAddress->getCompany();
                         }
                     }
                 }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -769,7 +769,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
                 $addressData["zip"] = $address->getPostcode();
             }
             if ($address->getCountry()) {
-                $country = $this->_countryFactory->create()->loadByCode($address->getCountryId());
+                $country = $this->countryFactory->create()->loadByCode($address->getCountryId());
                 $addressData["country"] = $country->getFullNameLocale();
             }
             if ($address->getTelephone()) {

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -212,6 +212,10 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      * @var \Magento\Directory\Model\CountryFactory
      */
     protected $countryFactory;
+    /**
+     * @var \Magento\Framework\Locale\Resolver
+     */
+    protected $resolver;
 
     private $customerAtt    = null;
     private $addressAtt     = null;
@@ -248,6 +252,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      * @param \Magento\Framework\App\DeploymentConfig $deploymentConfig
      * @param \Magento\Framework\Stdlib\DateTime\DateTime $date
      * @param \Magento\Directory\Model\CountryFactory $countryFactory
+     * @param \Magento\Framework\Locale\Resolver $resolver
      */
     public function __construct(
         \Magento\Framework\App\Helper\Context $context,
@@ -278,7 +283,8 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         \Magento\Framework\Serialize\Serializer\Json $serializer,
         \Magento\Framework\App\DeploymentConfig $deploymentConfig,
         \Magento\Framework\Stdlib\DateTime\DateTime $date,
-        \Magento\Directory\Model\CountryFactory $countryFactory
+        \Magento\Directory\Model\CountryFactory $countryFactory,
+        \Magento\Framework\Locale\Resolver $resolver
     ) {
 
         $this->_storeManager  = $storeManager;
@@ -312,6 +318,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         $this->_deploymentConfig        = $deploymentConfig;
         $this->_date                    = $date;
         $this->countryFactory           = $countryFactory;
+        $this->resolver                 = $resolver;
         parent::__construct($context);
     }
 
@@ -770,7 +777,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
             }
             if ($address->getCountry()) {
                 $country = $this->countryFactory->create()->loadByCode($address->getCountryId());
-                $addressData["country"] = $country->getFullNameLocale();
+                $addressData["country"] = $country->getName($this->resolver->getLocale());
             }
             if ($address->getTelephone()) {
                 $addressData['telephone'] = $address->getTelephone();

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -644,7 +644,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     }
     public function getBaserUrl($storeId, $type)
     {
-        return $this->_storeManager->getStore($storeId)->getBaseUrl($type);
+        return $this->_storeManager->getStore($storeId)->getBaseUrl($type, true);
     }
     public function createStore($listId = null, $storeId)
     {

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -934,6 +934,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     {
 
         $mcUserName = [];
+        $allStores = [];
         $connection = $this->_mailChimpStores->getResource()->getConnection();
         $tableName = $this->_mailChimpStores->getResource()->getMainTable();
         $connection->truncateTable($tableName);
@@ -956,7 +957,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
             }
 
             foreach ($apiStores['stores'] as $store) {
-                if ($store['platform']!=self::PLATFORM) {
+                if ($store['platform']!=self::PLATFORM||array_key_exists($store['list_id'],$allStores)) {
                     continue;
                 }
                 if (isset($store['connected_site'])) {
@@ -964,6 +965,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
                 } else {
                     $name = $store['name'].' (Warning: not connected)';
                 }
+                $allStores['list_id'] = $store['list_id'];
                 $mstore = $this->_mailChimpStoresFactory->create();
                 $mstore->setApikey($this->_encryptor->encrypt(trim($apiKey)));
                 $mstore->setStoreid($store['id']);

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1333,6 +1333,16 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
             "type = '" . self::IS_SUBSCRIBER . "' and mailchimp_store_id = '$mailchimpList'"
         );
     }
+    public function resyncProducts($mailchimpList)
+    {
+        $connection = $this->_mailChimpSyncE->getResource()->getConnection();
+        $tableName = $this->_mailChimpSyncE->getResource()->getMainTable();
+        $connection->update(
+            $tableName,
+            ['mailchimp_sync_modified' => 1],
+            "type = '" . self::IS_PRODUCT . "' and mailchimp_store_id = '$mailchimpList'"
+        );
+    }
     public function decrypt($value)
     {
         return $this->_encryptor->decrypt($value);

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1061,7 +1061,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         return $key;
     }
 
-    public function createWebHook($apikey, $listId)
+    public function createWebHook($apikey, $listId, $scope=null, $scopeId=null)
     {
         $events = [
             'subscribe' => true,
@@ -1079,6 +1079,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         try {
             $api = $this->getApiByApiKey($apikey);
             $hookUrl = $this->_getUrl(\Ebizmarts\MailChimp\Controller\WebHook\Index::WEBHOOK__PATH, [
+                '_scope' => $scopeId,
                 'wkey' => $this->getWebhooksKey(),
                 '_nosid' => true,
                 '_secure' => true]);

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1173,7 +1173,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         try {
             $api = $this->getApi($storeId);
             $listId = $this->getConfigValue(self::XML_PATH_LIST, $storeId);
-            $allInterest = $api->lists->interestCategory->getAll($listId);
+            $allInterest = $api->lists->interestCategory->getAll($listId, null, null, 200);
             if (is_array($allInterest) &&
                 array_key_exists('categories', $allInterest) &&
                 is_array($allInterest['categories'])) {
@@ -1184,7 +1184,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
                     }
                 }
                 foreach ($interest as $interestId) {
-                    $mailchimpInterest = $api->lists->interestCategory->interests->getAll($listId, $interestId);
+                    $mailchimpInterest = $api->lists->interestCategory->interests->getAll($listId, $interestId, null, null, 200);
                     foreach ($mailchimpInterest['interests'] as $mi) {
                         $rc[$mi['category_id']]['category'][$mi['display_order']] =
                             ['id' => $mi['id'], 'name' => $mi['name'], 'checked' => false];

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -872,7 +872,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
                 $chimpSyncEcommerce->setMailchimpStoreId($storeId);
                 $chimpSyncEcommerce->setType($type);
                 $chimpSyncEcommerce->setRelatedId($entityId);
-                if ($modified) {
+                if ($modified!==null) {
                     $chimpSyncEcommerce->setMailchimpSyncModified($modified);
                 }
                 if ($date) {

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -678,7 +678,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     {
         $syncDate = $this->getConfigValue(self::XML_PATH_SYNC_DATE, $storeId);
         if ($syncDate=='') {
-            $syncDate = '0000-00-00';
+            $syncDate = '1900-01-01';
         }
         return $syncDate;
     }

--- a/Model/Api/Cart.php
+++ b/Model/Api/Cart.php
@@ -146,6 +146,8 @@ class Cart
         // get only the converted quotes
         $convertedCarts->addFieldToFilter('store_id', ['eq' => $magentoStoreId]);
         $convertedCarts->addFieldToFilter('is_active', ['eq' => 0]);
+        $convertedCarts->getSelect()->reset(\Zend_Db_Select::COLUMNS)->columns(['entity_id']);
+
         //join with mailchimp_ecommerce_sync_data table to filter by sync data.
         $convertedCarts->getSelect()->joinLeft(
             ['m4m' => $this->_helper->getTableName('mailchimp_sync_ecommerce')],
@@ -223,6 +225,8 @@ class Cart
         $modifiedCarts->addFieldToFilter('is_active', ['eq'=>1]);
         // select carts for the current Magento store id
         $modifiedCarts->addFieldToFilter('store_id', ['eq' => $magentoStoreId]);
+        $modifiedCarts->getSelect()->reset(\Zend_Db_Select::COLUMNS)->columns(['entity_id']);
+
         //join with mailchimp_ecommerce_sync_data table to filter by sync data.
         $modifiedCarts->getSelect()->joinLeft(
             ['m4m' => $this->_helper->getTableName('mailchimp_sync_ecommerce')],
@@ -237,7 +241,6 @@ class Cart
         );
         // limit the collection
         $modifiedCarts->getSelect()->limit(self::BATCH_LIMIT);
-
         /**
          * @var $cart \Magento\Quote\Model\Quote
          */
@@ -356,6 +359,8 @@ class Cart
         if ($this->_firstDate) {
             $newCarts->addFieldToFilter('created_at', ['gt' => $this->_firstDate]);
         }
+        $newCarts->getSelect()->reset(\Zend_Db_Select::COLUMNS)->columns(['entity_id']);
+
         //join with mailchimp_ecommerce_sync_data table to filter by sync data.
         $newCarts->getSelect()->joinLeft(
             ['m4m' => $this->_helper->getTableName('mailchimp_sync_ecommerce')],
@@ -365,7 +370,6 @@ class Cart
         );
         // be sure that the quotes are already in mailchimp and not deleted
         $newCarts->getSelect()->where("m4m.mailchimp_sync_delta IS NULL");
-
         // limit the collection
         $newCarts->getSelect()->limit(self::BATCH_LIMIT);
         /**

--- a/Model/Api/Cart.php
+++ b/Model/Api/Cart.php
@@ -79,7 +79,7 @@ class Cart
         \Magento\Sales\Model\ResourceModel\Order\CollectionFactory $orderCollectionFactory,
         \Magento\Framework\Url $urlHelper
     ) {
-    
+
         $this->_helper                  = $helper;
         $this->_quoteCollection         = $quoteColletcion;
         $this->_customerFactory         = $customerFactory;
@@ -632,7 +632,7 @@ class Cart
                  * @var $country \Magento\Directory\Model\Country
                  */
                 $country = $this->_countryFactory->create()->loadByCode($billingAddress->getCountryId());
-                $address['shipping_address']['country'] = $country->getName();
+                $address['shipping_address']['country'] = $country->getName('en_US');
                 $address['shipping_address']['country_code'] = $billingAddress->getCountryId();
             }
 

--- a/Model/Api/Customer.php
+++ b/Model/Api/Customer.php
@@ -73,7 +73,7 @@ class Customer
         \Magento\Customer\Model\Address $address,
         \Magento\Newsletter\Model\SubscriberFactory $subscriberFactory
     ) {
-    
+
         $this->_helper              = $helper;
         $this->_collection          = $collection;
         $this->_orderCollection     = $orderCollection;
@@ -246,7 +246,7 @@ class Customer
                  * @var $country \Magento\Directory\Model\Country
                  */
                 $country = $this->_countryFactory->create()->loadByCode($address->getCountryId());
-                $customerAddress["country"] = $country->getName();
+                $customerAddress["country"] = $country->getName('en_US');
                 $customerAddress["country_code"] = $address->getCountryId();
             }
             if (count($customerAddress)) {

--- a/Model/Api/Customer.php
+++ b/Model/Api/Customer.php
@@ -279,7 +279,10 @@ class Customer
             \Ebizmarts\MailChimp\Helper\Data::IS_CUSTOMER,
             $sync_delta,
             $sync_error,
-            $sync_modified
+            $sync_modified,
+            null,
+            null,
+            \Ebizmarts\MailChimp\Helper\Data::WAITINGSYNC
         );
     }
 }

--- a/Model/Api/Customer.php
+++ b/Model/Api/Customer.php
@@ -93,6 +93,7 @@ class Customer
         $listId = $this->_helper->getConfigValue(\Ebizmarts\MailChimp\Helper\Data::XML_PATH_LIST, $storeId);
         $collection = $this->_collection->create();
         $collection->addFieldToFilter('store_id', ['eq'=>$storeId]);
+        $collection->getSelect()->reset(\Zend_Db_Select::COLUMNS)->columns(['entity_id','store_id']);
         $collection->getSelect()->joinLeft(
             ['m4m' => $this->_helper->getTableName('mailchimp_sync_ecommerce')],
             "m4m.related_id = e.entity_id and m4m.type = '".\Ebizmarts\MailChimp\Helper\Data::IS_CUSTOMER.

--- a/Model/Api/Order.php
+++ b/Model/Api/Order.php
@@ -564,6 +564,11 @@ class Order
             ['neq' => \Magento\Sales\Model\Order::STATE_CANCELED],
             ['neq' => \Magento\Sales\Model\Order::STATE_CLOSED]])
             ->addAttributeToFilter('customer_email', ['eq' => $order->getCustomerEmail()]);
+        
+        $orderCollection
+            ->getSelect()
+            ->reset(\Zend_Db_Select::COLUMNS)
+            ->columns(['grand_total', 'total_refunded', 'total_canceled']);
 
         $totalOrders = 0;
         $totalAmountSpent = 0;

--- a/Model/Api/Order.php
+++ b/Model/Api/Order.php
@@ -159,6 +159,7 @@ class Order
         $modifiedOrders = $this->_getCollection();
         // select orders for the current Magento store id
         $modifiedOrders->addFieldToFilter('store_id', ['eq' => $magentoStoreId]);
+        $modifiedOrders->addFieldToSelect(['store_id','created_at']);
         //join with mailchimp_ecommerce_sync_data table to filter by sync data.
         $modifiedOrders->getSelect()->joinLeft(
             ['m4m' => $this->_helper->getTableName('mailchimp_sync_ecommerce')],
@@ -238,6 +239,7 @@ class Order
         $newOrders = $this->_getCollection();
         // select carts for the current Magento store id
         $newOrders->addFieldToFilter('store_id', ['eq' => $magentoStoreId]);
+        $newOrders->addFieldToSelect(['store_id','created_at']);
         // filter by first date if exists.
         if ($this->_firstDate) {
             $newOrders->addFieldToFilter('created_at', ['gt' => $this->_firstDate]);

--- a/Model/Api/Order.php
+++ b/Model/Api/Order.php
@@ -426,7 +426,7 @@ class Order
                     "product_variant_id" => $variant,
                     "quantity" => (int)$item->getQtyOrdered(),
                     "price" => $item->getPrice(),
-                    "discount" => abs($item->getDiscountAmount())
+                    "discount" => abs((float) $item->getDiscountAmount())
                 ];
             }
         }
@@ -701,7 +701,7 @@ class Order
 
                         $promo = [[
                             'code' => $couponCode,
-                            'amount_discounted' => abs($amountDiscounted),
+                            'amount_discounted' => abs((float) $amountDiscounted),
                             'type' => $type
                         ]];
                     }

--- a/Model/Api/Order.php
+++ b/Model/Api/Order.php
@@ -371,7 +371,7 @@ class Order
         } else {
             $data['order_total'] = $order->getGrandTotal();
             $data['tax_total'] = $order->getTaxAmount();
-            $data['discount_total'] = abs($order->getDiscountAmount());
+            $data['discount_total'] = abs((float) $order->getDiscountAmount());
             $data['shipping_total'] = $order->getShippingAmount();
         }
 

--- a/Model/Api/Order.php
+++ b/Model/Api/Order.php
@@ -26,7 +26,7 @@ class Order
     const PENDING = 'pending';
     const REFUNDED = 'refunded';
     const PARTIALLY_REFUNDED = 'partially_refunded';
-    const CANCELED = 'canceled';
+    const CANCELED = 'cancelled';
     const COMPLETE = 'complete';
 
     protected $_api = null;
@@ -110,7 +110,7 @@ class Order
         \Magento\SalesRule\Model\RuleRepository $ruleRepository,
         \Magento\Framework\Url $urlHelper
     ) {
-    
+
         $this->_helper          = $helper;
         $this->_order           = $order;
         $this->_orderCollectionFactory = $orderCollectionFactory;
@@ -564,7 +564,7 @@ class Order
             ['neq' => \Magento\Sales\Model\Order::STATE_CANCELED],
             ['neq' => \Magento\Sales\Model\Order::STATE_CLOSED]])
             ->addAttributeToFilter('customer_email', ['eq' => $order->getCustomerEmail()]);
-        
+
         $orderCollection
             ->getSelect()
             ->reset(\Zend_Db_Select::COLUMNS)

--- a/Model/Api/Order.php
+++ b/Model/Api/Order.php
@@ -513,7 +513,7 @@ class Order
              * @var $country \Magento\Directory\Model\Country
              */
             $country = $this->_countryFactory->create()->loadByCode($billingAddress->getCountryId());
-            $address["country"] = $data['billing_address']['country'] = $country->getName();
+            $address["country"] = $data['billing_address']['country'] = $country->getName('en_US');
             $address["country_code"] = $data['billing_address']['country_code'] = $billingAddress->getCountryId();
         }
         if (count($address)) {
@@ -570,7 +570,7 @@ class Order
                  * @var $country \Magento\Directory\Model\Country
                  */
                 $country = $this->_countryFactory->create()->loadByCode($shippingAddress->getCountryId());
-                $data['shipping_address']["country"] = $country->getName();
+                $data['shipping_address']["country"] = $country->getName('en_US');
                 $data['shipping_address']["country_code"] = $shippingAddress->getCountryId();
             }
             if ($shippingAddress->getCompany()) {

--- a/Model/Api/Order.php
+++ b/Model/Api/Order.php
@@ -331,10 +331,6 @@ class Order
             $data['landing_site'] = $order->getMailchimpLandingPage();
         }
         $data['currency_code'] = $order->getOrderCurrencyCode();
-        $data['order_total'] = $order->getGrandTotal();
-        $data['tax_total'] = $order->getTaxAmount();
-        $data['discount_total'] = abs($order->getDiscountAmount());
-        $data['shipping_total'] = $order->getShippingAmount();
         $dataPromo = $this->_getPromoData($order);
         if ($dataPromo !== null) {
             $data['promos'] = $dataPromo;
@@ -365,6 +361,15 @@ class Order
             if ($orderCancelDate) {
                 $data['cancelled_at_foreign'] = $orderCancelDate;
             }
+            $data['order_total'] = 0;
+            $data['tax_total'] = 0;
+            $data['discount_total'] = 0;
+            $data['shipping_total'] = 0;
+        } else {
+            $data['order_total'] = $order->getGrandTotal();
+            $data['tax_total'] = $order->getTaxAmount();
+            $data['discount_total'] = abs($order->getDiscountAmount());
+            $data['shipping_total'] = $order->getShippingAmount();
         }
 
         $data['lines'] = [];

--- a/Model/Api/Product.php
+++ b/Model/Api/Product.php
@@ -400,7 +400,7 @@ class Product
         } else {
             $parent = $this->_getParent($product->getId(), $magentoStoreId);
             if ($parent && $parent->getImage() && $parent->getImage()!='no_selection') {
-                $filePath = 'catalog/product'.ltrim($parent->getImage(), '/');
+                $filePath = 'catalog/product/'.ltrim($parent->getImage(), '/');
                 $data["image_url"] = $this->_helper->getBaserUrl($magentoStoreId, \Magento\Framework\UrlInterface::URL_TYPE_MEDIA).$filePath;
             }
         }

--- a/Model/Api/Product.php
+++ b/Model/Api/Product.php
@@ -393,21 +393,15 @@ class Product
         $data["url"] = $product->getProductUrl();
         $data["image_url"] = '';
         if ($product->getImage() && $product->getImage()!='no_selection') {
-            $filePath = 'catalog/product'.$product->getImage();
-            $data["image_url"] = $this->_helper->getBaserUrl(
-                $magentoStoreId,
-                \Magento\Framework\UrlInterface::URL_TYPE_MEDIA
-            ).$filePath;
+            $filePath = 'catalog/product/'.ltrim($product->getImage(), '/');
+            $data["image_url"] = $this->_helper->getBaserUrl($magentoStoreId, \Magento\Framework\UrlInterface::URL_TYPE_MEDIA).$filePath;
         } elseif ($this->_parentImage) {
             $data['image_url'] = $this->_parentImage;
         } else {
             $parent = $this->_getParent($product->getId(), $magentoStoreId);
             if ($parent && $parent->getImage() && $parent->getImage()!='no_selection') {
-                $filePath = 'catalog/product'.$parent->getImage();
-                $data["image_url"] = $this->_helper->getBaserUrl(
-                    $magentoStoreId,
-                    \Magento\Framework\UrlInterface::URL_TYPE_MEDIA
-                ).$filePath;
+                $filePath = 'catalog/product'.ltrim($parent->getImage(), '/');
+                $data["image_url"] = $this->_helper->getBaserUrl($magentoStoreId, \Magento\Framework\UrlInterface::URL_TYPE_MEDIA).$filePath;
             }
         }
         $data["published_at_foreign"] = "";

--- a/Model/Api/Product.php
+++ b/Model/Api/Product.php
@@ -551,34 +551,40 @@ class Product
         $data = [];
         $batchId = \Ebizmarts\MailChimp\Helper\Data::IS_PRODUCT . '_' . $this->_helper->getGmtTimeStamp();
         $items = $order->getAllVisibleItems();
+
         foreach ($items as $item) {
             //@todo get from the store not the default
-            $product = $this->_productRepository->getById($item->getProductId(), false, $magentoStoreId);
-            $productSyncData = $this->_chimpSyncEcommerce->create()->getByStoreIdType(
-                $mailchimpStoreId,
-                $product->getId(),
-                \Ebizmarts\MailChimp\Helper\Data::IS_PRODUCT
-            );
-            if ($product->getId()!=$item->getProductId() || (
-                    $product->getTypeId() != \Magento\Catalog\Model\Product\Type::TYPE_SIMPLE &&
-                    $product->getTypeId() != \Magento\Catalog\Model\Product\Type::TYPE_VIRTUAL &&
-                    $product->getTypeId() != \Magento\ConfigurableProduct\Model\Product\Type\Configurable::TYPE_CODE &&
-                    $product->getTypeId() != "downloadable")) {
-                $this->_helper->log('The product with id ['.$product->getId().
-                    '] is not supported ['.$product->getTypeId().']');
-                continue;
-            }
-            if ($productSyncData->getMailchimpSyncModified() &&
-                $productSyncData->getMailchimpSyncDelta() > $this->_helper->getMCMinSyncDateFlag()) {
-                $data = array_merge(
-                    $data,
-                    $this->_buildOldProductRequest($product, $batchId, $mailchimpStoreId, $magentoStoreId)
+            try {
+                $product = $this->_productRepository->getById($item->getProductId(), false, $magentoStoreId);
+                $productSyncData = $this->_chimpSyncEcommerce->create()->getByStoreIdType(
+                    $mailchimpStoreId,
+                    $product->getId(),
+                    \Ebizmarts\MailChimp\Helper\Data::IS_PRODUCT
                 );
-                $this->_updateProduct($mailchimpStoreId, $product->getId());
-            } elseif (!$productSyncData->getMailchimpSyncDelta() ||
-                $productSyncData->getMailchimpSyncDelta() < $this->_helper->getMCMinSyncDateFlag()) {
-                $data[] = $this->_buildNewProductRequest($product, $mailchimpStoreId, $magentoStoreId);
-                $this->_updateProduct($mailchimpStoreId, $product->getId());
+                if ($product->getId() != $item->getProductId() || (
+                        $product->getTypeId() != \Magento\Catalog\Model\Product\Type::TYPE_SIMPLE &&
+                        $product->getTypeId() != \Magento\Catalog\Model\Product\Type::TYPE_VIRTUAL &&
+                        $product->getTypeId() != \Magento\ConfigurableProduct\Model\Product\Type\Configurable::TYPE_CODE &&
+                        $product->getTypeId() != "downloadable")) {
+                    $this->_helper->log('The product with id [' . $product->getId() .
+                        '] is not supported [' . $product->getTypeId() . ']');
+                    continue;
+                }
+                if ($productSyncData->getMailchimpSyncModified() &&
+                    $productSyncData->getMailchimpSyncDelta() > $this->_helper->getMCMinSyncDateFlag()) {
+                    $data = array_merge(
+                        $data,
+                        $this->_buildOldProductRequest($product, $batchId, $mailchimpStoreId, $magentoStoreId)
+                    );
+                    $this->_updateProduct($mailchimpStoreId, $product->getId());
+                } elseif (!$productSyncData->getMailchimpSyncDelta() ||
+                    $productSyncData->getMailchimpSyncDelta() < $this->_helper->getMCMinSyncDateFlag()) {
+                    $data[] = $this->_buildNewProductRequest($product, $mailchimpStoreId, $magentoStoreId);
+                    $this->_updateProduct($mailchimpStoreId, $product->getId());
+                }
+            } catch(\Exception $e) {
+                $this->_helper->log($e->getMessage());
+                $this->_helper->log("Skip product [".$item->getProductId()."]");
             }
         }
         return $data;

--- a/Model/Api/Product.php
+++ b/Model/Api/Product.php
@@ -129,6 +129,7 @@ class Product
         $collection = $this->_getCollection();
         $collection->addFieldToFilter("type_id", ["nin"=>[\Magento\Catalog\Model\Product\Type::TYPE_BUNDLE, "grouped"]]);
         $collection->addStoreFilter($magentoStoreId);
+        $collection->getSelect()->reset(\Zend_Db_Select::COLUMNS)->columns(['entity_id']);
         $collection->getSelect()->joinLeft(
             ['m4m' => $this->_helper->getTableName('mailchimp_sync_ecommerce')],
             "m4m.related_id = e.entity_id and m4m.type = '".\Ebizmarts\MailChimp\Helper\Data::IS_PRODUCT.
@@ -139,6 +140,7 @@ class Product
             $this->_helper->getMCMinSyncDateFlag().
             "' and m4m.mailchimp_sync_modified = 1)");
         $collection->getSelect()->limit(self::MAX);
+
         foreach ($collection as $item) {
             /**
              * @var $product \Magento\Catalog\Model\Product

--- a/Model/Api/Product.php
+++ b/Model/Api/Product.php
@@ -127,6 +127,7 @@ class Product
         );
         $this->_markSpecialPrices($magentoStoreId, $mailchimpStoreId);
         $collection = $this->_getCollection();
+        $collection->addFieldToFilter("type_id", ["nin"=>[\Magento\Catalog\Model\Product\Type::TYPE_BUNDLE, "grouped"]]);
         $collection->addStoreFilter($magentoStoreId);
         $collection->getSelect()->joinLeft(
             ['m4m' => $this->_helper->getTableName('mailchimp_sync_ecommerce')],

--- a/Model/Api/Result.php
+++ b/Model/Api/Result.php
@@ -129,7 +129,9 @@ class Result
                     $this->_driver->createDirectory($baseDir . DIRECTORY_SEPARATOR . 'var' . DIRECTORY_SEPARATOR . self::MAILCHIMP_TEMP_DIR);
                 }
                 // get the tar.gz file with the results
-                $fileUrl = urldecode($response['response_body_url']);
+                // for AWS S3 use urldecode, for google drive use without urldecode
+                // $fileUrl = urldecode($response['response_body_url']);
+                $fileUrl = $response['response_body_url'];
                 $fileName = $baseDir . DIRECTORY_SEPARATOR . 'var' . DIRECTORY_SEPARATOR .
                     self::MAILCHIMP_TEMP_DIR . DIRECTORY_SEPARATOR . $batchId;
                 $fd = $this->_driver->fileOpen($fileName . '.tar.gz', 'w');

--- a/Model/Api/Result.php
+++ b/Model/Api/Result.php
@@ -220,8 +220,16 @@ class Result
                             $error,
                             \Ebizmarts\MailChimp\Helper\Data::SYNCERROR
                         );
-                        $mailchimpErrors->setType($response->type);
-                        $mailchimpErrors->setTitle($response->title);
+                        if (property_exists($response, 'type')){
+                            $mailchimpErrors->setType($response->type);
+                        } else {
+                            $mailchimpErrors->setType('Unknown');
+                        }
+                        if (property_exists($response, 'title')){
+                            $mailchimpErrors->setTitle($response->title);
+                        } else {
+                            $mailchimpErrors->setTitle('Unknown');
+                        }
                         $mailchimpErrors->setStatus($item->status_code);
                         $mailchimpErrors->setErrors($errorDetails);
                         $mailchimpErrors->setRegtype($type);

--- a/Model/Api/Subscriber.php
+++ b/Model/Api/Subscriber.php
@@ -123,7 +123,7 @@ class Subscriber
         if ($mergeVars) {
             $data["merge_fields"] = $mergeVars;
         }
-        $data["status_if_new"] = $this->_getMCStatus($subscriber->getStatus(), $storeId);
+        $data["status_if_new"] = $data["status"] = $this->_getMCStatus($subscriber->getStatus(), $storeId);
         $interest = $this->_getInterest($subscriber);
         if (count($interest)) {
             $data['interests'] = $interest;

--- a/Model/Api/Subscriber.php
+++ b/Model/Api/Subscriber.php
@@ -46,7 +46,7 @@ class Subscriber
         \Magento\Newsletter\Model\SubscriberFactory $subscriberFactory,
         \Magento\Framework\Message\ManagerInterface $message
     ) {
-    
+
         $this->_helper                  = $helper;
         $this->_subscriberCollection    = $subscriberCollection;
         $this->_message                 = $message;
@@ -140,8 +140,10 @@ class Subscriber
             $this->_interest
         );
         foreach ($interest as $i) {
-            foreach ($i['category'] as $key => $value) {
-                $rc[$value['id']] = $value['checked'];
+            if (array_key_exists('category', $i)) {
+                foreach ($i['category'] as $key => $value) {
+                    $rc[$value['id']] = $value['checked'];
+                }
             }
         }
         return $rc;

--- a/Model/Config/Backend/MonkeyStore.php
+++ b/Model/Config/Backend/MonkeyStore.php
@@ -71,6 +71,7 @@ class MonkeyStore extends \Magento\Framework\App\Config\Value
 
     public function beforeSave()
     {
+        $this->_helper->log(__METHOD__);
         $data = $this->getData('groups');
         $found = 0;
         $newListId = null;
@@ -112,14 +113,17 @@ class MonkeyStore extends \Magento\Framework\App\Config\Value
                 $this->getScopeId(),
                 $this->getScope()
             );
-            $this->_helper->saveJsUrl($this->getScopeId(),$this->getScope(),$this->getValue());
-
             foreach ($this->_storeManager->getStores() as $storeId => $val) {
                 $mstoreId = $this->_helper->getConfigValue(
                     \Ebizmarts\MailChimp\Helper\Data::XML_MAILCHIMP_STORE,
                     $storeId
                 );
                 if ($mstoreId == $mailchimpStore) {
+                    $this->_helper->deleteConfig(
+                        \Ebizmarts\MailChimp\Helper\Data::XML_MAILCHIMP_JS_URL,
+                        $storeId,
+                        'stores'
+                    );
                     $found++;
                 }
                 $listId = $this->_helper->getConfigValue(\Ebizmarts\MailChimp\Helper\Data::XML_PATH_LIST, $storeId);

--- a/Model/Config/Backend/MonkeyStore.php
+++ b/Model/Config/Backend/MonkeyStore.php
@@ -71,7 +71,6 @@ class MonkeyStore extends \Magento\Framework\App\Config\Value
 
     public function beforeSave()
     {
-        $this->_helper->log(__METHOD__);
         $data = $this->getData('groups');
         $found = 0;
         $newListId = null;

--- a/Model/Config/Source/Details.php
+++ b/Model/Config/Source/Details.php
@@ -126,9 +126,9 @@ class Details implements \Magento\Framework\Option\ArrayInterface
                         [['label' => 'Total List Subscribers', 'value' => $this->_options['list_subscribers']]]
                     );
                 }
-                $ret = array_merge($ret, [['label' => 'Ecommerce Data uploaded to MailChimp', 'value' => '']]);
                 if (isset($this->_options['store_exists']) && $this->_options['store_exists']) {
                     $ret = array_merge($ret, [
+                        ['label' => 'Ecommerce Data uploaded to MailChimp', 'value' => ''],
                         ['label' => '  Total Customers', 'value' => $this->_options['total_customers']],
                         ['label' => '  Total Products', 'value' => $this->_options['total_products']],
                         ['label' => '  Total Orders', 'value' => $this->_options['total_orders']],
@@ -145,7 +145,7 @@ class Details implements \Magento\Framework\Option\ArrayInterface
                     }
                 } else {
                     $ret = array_merge($ret, [
-                        ['label'=>'This MailChimp account is not connected to Magento.','value'=>'']
+                        ['label'=>'Ecommerce disabled, only subscribers will be synchronized (your orders, products,etc will be not synchronized).','value'=>'']
                     ]);
                 }
             }

--- a/Model/Config/Source/Interest.php
+++ b/Model/Config/Source/Interest.php
@@ -40,7 +40,10 @@ class Interest implements \Magento\Framework\Option\ArrayInterface
         if ($helper->getApiKey($storeId, $scope)) {
             try {
                 $this->options = $helper->getApi($storeId, $scope)->lists->interestCategory->getAll(
-                    $helper->getConfigValue(\Ebizmarts\MailChimp\Helper\Data::XML_PATH_LIST, $storeId, $scope)
+                    $helper->getConfigValue(\Ebizmarts\MailChimp\Helper\Data::XML_PATH_LIST, $storeId, $scope),
+                    null,
+                    null,
+                    200
                 );
             } catch (\Mailchimp_Error $e) {
                 $helper->log($e->getFriendlyMessage());

--- a/Model/MailChimpSyncEcommerce.php
+++ b/Model/MailChimpSyncEcommerce.php
@@ -45,4 +45,8 @@ class MailChimpSyncEcommerce extends \Magento\Framework\Model\AbstractModel
     {
         $this->getResource()->deleteAllByBatchid($this, $batchId);
     }
+    public function markAllAsModifiedByIds($mailchimpStoreId, $ids, $type)
+    {
+        $this->getResource()->markAllAsModifiedByIds($this, $mailchimpStoreId, $ids, $type);
+    }
 }

--- a/Model/Plugin/Subscriber.php
+++ b/Model/Plugin/Subscriber.php
@@ -66,9 +66,11 @@ class Subscriber
         \Magento\Newsletter\Model\Subscriber $subscriber,
         $customerId
     ) {
-
         $storeId = $this->getStoreIdFromSubscriber($subscriber);
         if ($this->_helper->getConfigValue(\Ebizmarts\MailChimp\Helper\Data::XML_PATH_ACTIVE, $storeId)) {
+            if (!$this->_helper->getConfigValue(\Ebizmarts\MailChimp\Helper\Data::XML_MAGENTO_MAIL, $storeId)) {
+                $subscriber->setImportMode(true);
+            }
             $subscriber->loadByCustomerId($customerId);
             if ($subscriber->isSubscribed()) {
                 $api = $this->_helper->getApi($storeId);
@@ -199,10 +201,11 @@ class Subscriber
     public function beforeUnsubscribe(
         \Magento\Newsletter\Model\Subscriber $subscriber
     ) {
-
         $storeId = $this->getStoreIdFromSubscriber($subscriber);
         if ($this->_helper->getConfigValue(\Ebizmarts\MailChimp\Helper\Data::XML_PATH_ACTIVE, $storeId)) {
-            $api = $this->_helper->getApi($storeId);
+            if (!$this->_helper->getConfigValue(\Ebizmarts\MailChimp\Helper\Data::XML_MAGENTO_MAIL, $storeId)) {
+                $subscriber->setImportMode(true);
+            }            $api = $this->_helper->getApi($storeId);
             try {
                 $md5HashEmail = hash('md5', strtolower($subscriber->getSubscriberEmail()));
                 $api->lists->members->update(
@@ -215,7 +218,6 @@ class Subscriber
                 $this->_helper->log($e->getFriendlyMessage());
             }
         }
-        return null;
     }
 
     /**

--- a/Model/ResourceModel/MailChimpSyncEcommerce.php
+++ b/Model/ResourceModel/MailChimpSyncEcommerce.php
@@ -80,4 +80,14 @@ class   MailChimpSyncEcommerce extends AbstractDb
         $connection->delete($this->getTable('mailchimp_sync_ecommerce'), ['batch_id = ?' => $batchId]);
         return $this;
     }
+    public function markAllAsModifiedByIds(\Ebizmarts\MailChimp\Model\MailChimpSyncEcommerce $chimp, $mailchimpStore, $ids, $type)
+    {
+        $connection = $this->getConnection();
+        $connection->update(
+            $this->getTable('mailchimp_sync_ecommerce'),
+            ['mailchimp_sync_modified'=>1],
+            ['related_id in (?)'=> $ids, 'type = ?'=>$type, 'mailchimp_store_id = ?'=>$mailchimpStore]
+        );
+        return $this;
+    }
 }

--- a/Model/ResourceModel/MailChimpSyncEcommerce.php
+++ b/Model/ResourceModel/MailChimpSyncEcommerce.php
@@ -16,7 +16,7 @@ namespace Ebizmarts\MailChimp\Model\ResourceModel;
 use Magento\Framework\DB\Select;
 use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
 
-class MailChimpSyncEcommerce extends AbstractDb
+class   MailChimpSyncEcommerce extends AbstractDb
 {
     protected function _construct()
     {

--- a/Observer/Adminhtml/Product/DeleteAfter.php
+++ b/Observer/Adminhtml/Product/DeleteAfter.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Ebizmarts\MailChimp\Observer\Adminhtml\Product;
+
+use Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\ConfigurableFactory;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable;
+
+
+class DeleteAfter implements ObserverInterface
+{
+    /**
+     * @var \Ebizmarts\MailChimp\Helper\Data
+     */
+    protected $helper;
+    /**
+     * @var Configurable
+     */
+    protected $configurable;
+
+    /**
+     * @param \Ebizmarts\MailChimp\Helper\Data $helper
+     * @param Configurable $configurable
+     */
+    public function __construct(
+        \Ebizmarts\MailChimp\Helper\Data $helper,
+        Configurable $configurable
+
+    ) {
+        $this->helper               = $helper;
+        $this->configurable         = $configurable;
+    }
+    function execute(Observer $observer)
+    {
+        $product = $observer->getProduct();
+        $mailchimpStore = $this->helper->getConfigValue(
+            \Ebizmarts\MailChimp\Helper\Data::XML_MAILCHIMP_STORE,
+            $product->getStoreId()
+        );
+        if ($product->getTypeId() == \Magento\Catalog\Model\Product\Type::TYPE_SIMPLE) {
+            $parents = $this->configurable->getParentIdsByChild($product->getId());
+            if (is_array($parents)) {
+                foreach ($parents as $parentid) {
+                    $this->_updateProduct($parentid);
+                }
+            } elseif ($parents) {
+                $this->_updateProduct($parents);
+            }
+        }
+        $this->_updateProduct($product->getId());
+    }
+    protected function _updateProduct($entityId)
+    {
+        $this->helper->markEcommerceAsDeleted($entityId, \Ebizmarts\MailChimp\Helper\Data::IS_PRODUCT);
+    }
+
+}

--- a/Observer/Adminhtml/Product/ImportAfter.php
+++ b/Observer/Adminhtml/Product/ImportAfter.php
@@ -37,7 +37,7 @@ class ImportAfter implements \Magento\Framework\Event\ObserverInterface
                 $this->_updateProduct($pro->getStoreId(), $pro->getId(), null,null,1);
             }
         } catch (\Exception $e) {
-            echo $e->getMessage();
+            $this->helper->log($e->getMessage());
         }
     }
     protected function _updateProduct(

--- a/Observer/Adminhtml/Product/ImportAfter.php
+++ b/Observer/Adminhtml/Product/ImportAfter.php
@@ -30,7 +30,11 @@ class ImportAfter implements \Magento\Framework\Event\ObserverInterface
             $bunch = $observer->getBunch();
             foreach ($bunch as $product) {
                 $sku = $product['sku'];
-                $storeId = $product['_store'];
+                if (key_exists('_store', $product)) {
+                    $storeId = $product['_store'];
+                } else {
+                    $storeId = 0;
+                }
                 $pro = $this->productRepository->get($sku, false,$storeId);
                 $id = $pro->getId();
                 $storeId = $pro->getStoreId();

--- a/Observer/Adminhtml/Product/ImportAfter.php
+++ b/Observer/Adminhtml/Product/ImportAfter.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Ebizmarts\MailChimp\Observer\Adminhtml\Product;
+
+use Magento\Framework\Event\Observer;
+
+class ImportAfter implements \Magento\Framework\Event\ObserverInterface
+{
+    /**
+     * @var \Ebizmarts\MailChimp\Helper\Data
+     */
+    protected $helper;
+    protected $productRepository;
+
+    /**
+     * ImportAfter constructor.
+     * @param \Ebizmarts\MailChimp\Helper\Data $helper
+     */
+    public function __construct(
+        \Ebizmarts\MailChimp\Helper\Data $helper,
+        \Magento\Catalog\Model\ProductRepository $productRepository
+    )
+    {
+        $this->helper = $helper;
+        $this->productRepository = $productRepository;
+    }
+    public function execute(Observer $observer)
+    {
+        try {
+            $bunch = $observer->getBunch();
+            foreach ($bunch as $product) {
+                $sku = $product['sku'];
+                $storeId = $product['_store'];
+                $pro = $this->productRepository->get($sku, false,$storeId);
+                $id = $pro->getId();
+                $storeId = $pro->getStoreId();
+                $this->_updateProduct($pro->getStoreId(), $pro->getId(), null,null,1);
+            }
+        } catch (\Exception $e) {
+            echo $e->getMessage();
+        }
+    }
+    protected function _updateProduct(
+        $storeId,
+        $entityId,
+        $sync_delta = null,
+        $sync_error = null,
+        $sync_modified = null
+    ) {
+        $mailchimpStoreId = $this->helper->getConfigValue(
+            \Ebizmarts\MailChimp\Helper\Data::XML_MAILCHIMP_STORE,
+            $storeId
+        );
+        $this->helper->saveEcommerceData(
+            $mailchimpStoreId,
+            $entityId,
+            \Ebizmarts\MailChimp\Helper\Data::IS_PRODUCT,
+            $sync_delta,
+            $sync_error,
+            $sync_modified
+        );
+    }
+}

--- a/Observer/Subscriber/SaveAfter.php
+++ b/Observer/Subscriber/SaveAfter.php
@@ -14,7 +14,7 @@ namespace Ebizmarts\MailChimp\Observer\Subscriber;
 
 use Magento\Framework\Event\Observer;
 
-class SaveBefore implements \Magento\Framework\Event\ObserverInterface
+class SaveAfter implements \Magento\Framework\Event\ObserverInterface
 {
     /**
      * @var \Ebizmarts\MailChimp\Model\MailChimpSyncEcommerce

--- a/Observer/Subscriber/SaveBefore.php
+++ b/Observer/Subscriber/SaveBefore.php
@@ -62,10 +62,11 @@ class SaveBefore implements \Magento\Framework\Event\ObserverInterface
         $subscriber = $observer->getSubscriber();
         $subscriberOld = $factory->loadByCustomerId($subscriber->getCustomerId());
 
-        if ($this->_helper->isMailChimpEnabled($subscriberOld->getStoreId())&&$subscriber->getEmail()!=$subscriberOld->getEmail()) {
+        if ($this->_helper->isMailChimpEnabled($subscriberOld->getStoreId()) && $subscriber->getEmail() != $subscriberOld->getEmail()) {
             $api = $this->_helper->getApi($subscriberOld->getStoreId());
             $mergeVars = $this->_helper->getMergeVarsBySubscriber($subscriberOld, $subscriberOld->getEmail());
             $status = 'unsubscribed';
+
             try {
                 $md5HashEmail = hash('md5', strtolower($subscriberOld->getEmail()));
                 $return = $api->lists->members->addOrUpdate(
@@ -81,11 +82,13 @@ class SaveBefore implements \Magento\Framework\Event\ObserverInterface
                     $subscriberOld->getEmail(),
                     $status
                 );
+
             } catch (\Mailchimp_Error $e) {
                 $this->_helper->log($e->getFriendlyMessage());
             }
 
         }
+
         $this->_subscriberApi->update($subscriber);
     }
 }

--- a/Setup/Uninstall.php
+++ b/Setup/Uninstall.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Ebizmarts\MailChimp\Setup;
+
+use Magento\Framework\Setup\ModuleContextInterface;
+use Magento\Framework\Setup\SchemaSetupInterface;
+use Magento\Framework\Setup\UninstallInterface;
+
+class Uninstall implements UninstallInterface
+{
+    public function uninstall(SchemaSetupInterface $setup, ModuleContextInterface $context)
+    {
+        $tables = [
+            'mailchimp_sync_batches',
+            'mailchimp_errors',
+            'mailchimp_sync_ecommerce',
+            'mailchimp_stores',
+            'mailchimp_webhook_request',
+            'mailchimp_interest_group'
+        ];
+        $tablesFields = [
+            'sales_order' => [
+                'mailchimp_abandonedcart_flag',
+                'mailchimp_campaign_id',
+                'mailchimp_landing_page',
+                'mailchimp_flag'
+            ],
+            'quote' => [
+                'mailchimp_abandonedcart_flag',
+                'mailchimp_campaign_id',
+                'mailchimp_landing_page'
+            ],
+            'sales_order_grid' => [
+                'mailchimp_flag'
+            ]
+        ];
+        $installer = $setup;
+        $installer->startSetup();
+        $connection = $installer->getConnection();
+        foreach ($tables as $table) {
+            $connection->dropTable($setup->getTable($table));
+        }
+        foreach($tablesFields as $table => $columnArray) {
+            foreach($columnArray as $column) {
+                $connection->dropColumn( $setup->getTable($table), $column);
+            }
+        }
+
+        $installer->endSetup();
+    }
+}

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -546,5 +546,17 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 ['store_id','regtype','original_id']
             );
         }
+        if (version_compare($context->getVersion(), '102.3.45') < 0) {
+            $connection->addIndex(
+                $setup->getTable('mailchimp_sync_ecommerce'),
+                $connection->getIndexName($setup->getTable('mailchimp_sync_ecommerce'), 'mailchimp_sync_delta', 'index'),
+                'mailchimp_sync_delta'
+            );
+            $connection->addIndex(
+                $setup->getTable('mailchimp_sync_ecommerce'),
+                $connection->getIndexName($setup->getTable('mailchimp_sync_ecommerce'), 'mailchimp_sync_modified', 'index'),
+                'mailchimp_sync_modified'
+            );
+        }
     }
 }

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -539,5 +539,12 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 ]
             );
         }
+        if (version_compare($context->getVersion(), '102.3.43') < 0) {
+            $connection->addIndex(
+                $setup->getTable('mailchimp_errors'),
+                $connection->getIndexName($setup->getTable('mailchimp_errors'), ['store_id','regtype','original_id'], 'index'),
+                ['store_id','regtype','original_id']
+            );
+        }
     }
 }

--- a/Ui/Component/Errors/Grid/Column/Batch.php
+++ b/Ui/Component/Errors/Grid/Column/Batch.php
@@ -47,14 +47,46 @@ class Batch extends Column
     {
         if (isset($dataSource['data']['items'])) {
             foreach ($dataSource['data']['items'] as &$item) {
-                $item[$this->getData('name')]['batch_id'] = [
-                    'href' => $this->urlBuilder->getUrl(
-                        'mailchimp/errors/getresponse',
-                        ['id' => $item['id']]
-                    ),
-                    'label' => $item['batch_id'],
-                    'hidden' => false,
-                ];
+                $edit = false;
+                switch($item['regtype']) {
+                    case \Ebizmarts\MailChimp\Helper\Data::IS_CUSTOMER:
+                        $label = 'Edit customer';
+                        $url = 'customer/index/edit';
+                        $id = 'id';
+                        $edit = true;
+                        break;
+                    case \Ebizmarts\MailChimp\Helper\Data::IS_ORDER:
+                        $label = 'Edit order';
+                        $url = 'sales/order/view';
+                        $id = 'order_id';
+                        $edit = true;
+                        break;
+                    case \Ebizmarts\MailChimp\Helper\Data::IS_PRODUCT:
+                        $label = 'Edit product';
+                        $url = 'catalog/product/edit';
+                        $id = 'id';
+                        $edit = true;
+                        break;
+                }
+                $item[$this->getData('name')] = [
+                    'download' => [
+                        'href' => $this->urlBuilder->getUrl(
+                            'mailchimp/errors/getresponse',
+                            ['id' => $item['id']]
+                        ),
+                        'label' => 'Download Response'
+                    ]
+                    ];
+                if ($edit) {
+                    $item[$this->getData('name')]['edit'] =
+                    [
+                        'href' => $this->urlBuilder->getUrl(
+                            $url,
+                            [$id => $item['original_id']]
+                        ),
+                        'label' => $label
+                    ];
+                }
             }
         }
 

--- a/Ui/Component/Listing/Column/Customers.php
+++ b/Ui/Component/Listing/Column/Customers.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Ebizmarts\MailChimp\Ui\Component\Listing\Column;
+
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\View\Element\UiComponent\ContextInterface;
+use Magento\Framework\View\Element\UiComponentFactory;
+use \Magento\Ui\Component\Listing\Columns\Column;
+use Magento\Customer\Model\CustomerFactory;
+
+class Customers extends Column
+{
+    /**
+     * @var RequestInterface
+     */
+    protected $_requestInterface;
+    /**
+     * @var \Magento\Framework\View\Asset\Repository
+     */
+    protected $_assetRepository;
+    /**
+     * @var CustomerFactory
+     */
+    protected $_customerFactory;
+    /**
+     * @var \Ebizmarts\MailChimp\Helper\Data
+     */
+    protected $_helper;
+    /**
+     * @var \Ebizmarts\MailChimp\Model\MailChimpErrorsFactory
+     */
+    protected $_mailChimpErrorsFactory;
+
+    /**
+     * @param ContextInterface $context
+     * @param UiComponentFactory $uiComponentFactory
+     * @param RequestInterface $requestInterface
+     * @param \Magento\Framework\View\Asset\Repository $assetRepository
+     * @param CustomerFactory $customerFactory
+     * @param \Ebizmarts\MailChimp\Helper\Data $helper
+     * @param \Ebizmarts\MailChimp\Model\MailChimpErrorsFactory $mailChimpErrorsFactory
+     * @param array $components
+     * @param array $data
+     */
+    public function __construct(
+        ContextInterface $context,
+        UiComponentFactory $uiComponentFactory,
+        RequestInterface $requestInterface,
+        \Magento\Framework\View\Asset\Repository $assetRepository,
+        CustomerFactory $customerFactory,
+        \Ebizmarts\MailChimp\Helper\Data $helper,
+        \Ebizmarts\MailChimp\Model\MailChimpErrorsFactory $mailChimpErrorsFactory,
+        array $components = [],
+        array $data = [])
+    {
+        $this->_requestInterface = $requestInterface;
+        $this->_assetRepository = $assetRepository;
+        $this->_customerFactory = $customerFactory;
+        $this->_helper          = $helper;
+        $this->_mailChimpErrorsFactory = $mailChimpErrorsFactory;
+        parent::__construct($context, $uiComponentFactory, $components, $data);
+    }
+
+    public function prepareDataSource(array $dataSource)
+    {
+        if (isset($dataSource['data']['items'])) {
+            $params = ['_secure' => $this->_requestInterface->isSecure()];
+            foreach ($dataSource['data']['items'] as & $item) {
+                /**
+                 * @var $customer \Magento\Customer\Model\Customer
+                 */
+                $customer = $this->_customerFactory->create()->load($item['entity_id']);
+                $params = ['_secure' => $this->_requestInterface->isSecure()];
+                $alt = '';
+                if ($this->_helper->getConfigValue(\Ebizmarts\MailChimp\Helper\Data::XML_PATH_ACTIVE, $customer->getStoreId())) {
+                    $mailchimpStoreId = $this->_helper->getConfigValue(
+                        \Ebizmarts\MailChimp\Helper\Data::XML_MAILCHIMP_STORE,
+                        $customer->getStoreId()
+                    );
+                    $syncData = $this->_helper->getChimpSyncEcommerce(
+                        $mailchimpStoreId,
+                        $customer->getId(),
+                        \Ebizmarts\MailChimp\Helper\Data::IS_CUSTOMER
+                    );
+                    if (!$syncData || $syncData->getMailchimpStoreId() != $mailchimpStoreId ||
+                        $syncData->getRelatedId() != $customer->getId() ||
+                        $syncData->getType() != \Ebizmarts\MailChimp\Helper\Data::IS_CUSTOMER) {
+                        $url = $this->_assetRepository->getUrlWithParams(
+                            'Ebizmarts_MailChimp::images/no.png',
+                            $params
+                        );
+                        $text = __('Syncing');
+                    } else {
+                        $sync = $syncData->getMailchimpSent();
+                        switch ($sync) {
+                            case \Ebizmarts\MailChimp\Helper\Data::SYNCED:
+                                $url = $this->_assetRepository->getUrlWithParams(
+                                    'Ebizmarts_MailChimp::images/yes.png',
+                                    $params
+                                );
+                                $text = __('Synced');
+                                $alt = $syncData->getMailchimpSyncDelta();
+                                break;
+                            case \Ebizmarts\MailChimp\Helper\Data::WAITINGSYNC:
+                                $url = $this->_assetRepository->getUrlWithParams(
+                                    'Ebizmarts_MailChimp::images/waiting.png',
+                                    $params
+                                );
+                                $text = __('Waiting');
+                                $alt = $syncData->getMailchimpSyncDelta();
+                                break;
+                            case \Ebizmarts\MailChimp\Helper\Data::SYNCERROR:
+                                $url = $this->_assetRepository->getUrlWithParams(
+                                    'Ebizmarts_MailChimp::images/error.png',
+                                    $params
+                                );
+                                $text = __('Error');
+                                $orderError = $this->_getError($customer->getId(), $customer->getStoreId());
+                                if ($orderError) {
+                                    $alt = $orderError->getErrors();
+                                }
+                                break;
+                            case \Ebizmarts\MailChimp\Helper\Data::NEEDTORESYNC:
+                                $url = $this->_assetRepository->getUrlWithParams(
+                                    'Ebizmarts_MailChimp::images/resync.png',
+                                    $params
+                                );
+                                $text = __('Resyncing');
+                                $alt = $syncData->getMailchimpSyncDelta();
+                                break;
+                            case \Ebizmarts\MailChimp\Helper\Data::NOTSYNCED:
+                                $url = $this->_assetRepository->getUrlWithParams(
+                                    'Ebizmarts_MailChimp::images/never.png',
+                                    $params
+                                );
+                                $text = __('With error');
+                                $alt = $syncData->getMailchimpSyncError();
+                                break;
+                            default:
+                                $url = $this->_assetRepository->getUrlWithParams(
+                                    'Ebizmarts_MailChimp::images/error.png',
+                                    $params
+                                );
+                                $text = __('Error');
+                        }
+
+                    }
+
+                }
+                $item['mailchimp_sync'] =
+                    "<div style='width: 100%;margin: 0 auto;text-align: center'><div><img src='".$url."' style='border: none; width: 5rem; text-align: center; max-width: 100%' title='$alt' /></div><div>$text</div></div>";
+            }
+        }
+        return $dataSource;
+    }
+    private function _getError($customerId, $storeId)
+    {
+        /**
+         * @var $error \Ebizmarts\MailChimp\Model\MailChimpErrors
+         */
+        $error = $this->_mailChimpErrorsFactory->create();
+        return $error->getByStoreIdType($storeId, $customerId, \Ebizmarts\MailChimp\Helper\Data::IS_CUSTOMER);
+    }
+
+}

--- a/Ui/Component/Listing/Column/Customers.php
+++ b/Ui/Component/Listing/Column/Customers.php
@@ -115,9 +115,9 @@ class Customers extends Column
                                     $params
                                 );
                                 $text = __('Error');
-                                $orderError = $this->_getError($customer->getId(), $customer->getStoreId());
-                                if ($orderError) {
-                                    $alt = $orderError->getErrors();
+                                $customerError = $this->_getError($customer->getId(), $customer->getStoreId());
+                                if ($customerError) {
+                                    $alt = $customerError->getErrors();
                                 }
                                 break;
                             case \Ebizmarts\MailChimp\Helper\Data::NEEDTORESYNC:

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   },
   "description": "Connect MailChimp with Magento",
   "type": "magento2-module",
-  "version": "102.3.43",
+  "version": "dev-Issue1208-2.3",
   "authors": [
     {
       "name": "Ebizmarts Corp",
@@ -24,7 +24,7 @@
     "forum": "http://ebizmarts.com/forums/view/6"
   },
   "require" : {
-    "magento/framework": "102.0.*||103.0.*",
+    "magento/framework": "103.0.*",
     "ebizmarts/mailchimp-lib": ">=3.0.27",
     "ext-json": "*"
   }

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   },
   "description": "Connect MailChimp with Magento",
   "type": "magento2-module",
-  "version": "dev-Issue1208-2.3",
+  "version": "102.3.43",
   "authors": [
     {
       "name": "Ebizmarts Corp",
@@ -24,7 +24,7 @@
     "forum": "http://ebizmarts.com/forums/view/6"
   },
   "require" : {
-    "magento/framework": "103.0.*",
+    "magento/framework": "102.0.*||103.0.*",
     "ebizmarts/mailchimp-lib": ">=3.0.27",
     "ext-json": "*"
   }

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   },
   "description": "Connect MailChimp with Magento",
   "type": "magento2-module",
-  "version": "102.3.42",
+  "version": "102.3.43",
   "authors": [
     {
       "name": "Ebizmarts Corp",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   },
   "require" : {
     "magento/framework": "102.0.*",
-    "ebizmarts/mailchimp-lib": ">=3.0.27",
+    "ebizmarts/mailchimp-lib": ">=3.0.35",
     "ext-json": "*"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   },
   "description": "Connect MailChimp with Magento",
   "type": "magento2-module",
-  "version": "102.3.43",
+  "version": "102.3.44",
   "authors": [
     {
       "name": "Ebizmarts Corp",

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   },
   "description": "Connect MailChimp with Magento",
   "type": "magento2-module",
-  "version": "102.3.44",
+  "version": "102.3.45",
   "authors": [
     {
       "name": "Ebizmarts Corp",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "forum": "http://ebizmarts.com/forums/view/6"
   },
   "require" : {
-    "magento/framework": "102.0.*||103.0.*",
+    "magento/framework": "102.0.*",
     "ebizmarts/mailchimp-lib": ">=3.0.27",
     "ext-json": "*"
   }

--- a/etc/adminhtml/events.xml
+++ b/etc/adminhtml/events.xml
@@ -15,4 +15,7 @@
     <event name="adminhtml_customer_save_after">
         <observer name="mailchimp_adminhtml_customer_save_after" instance="\Ebizmarts\MailChimp\Observer\Adminhtml\Customer\SaveAfter" />
     </event>
+    <event name="catalog_product_delete_after">
+        <observer name="mailchimp_product_delete_after" instance="\Ebizmarts\MailChimp\Observer\Adminhtml\Product\DeleteAfter" />
+    </event>
 </config>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -221,7 +221,7 @@
                     <label>Enabled</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="firstdate" translate="label" type="date" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="firstdate" translate="label" type="date" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>First Date</label>
                     <frontend_model>Ebizmarts\MailChimp\Block\Adminhtml\System\Config\Date</frontend_model>
                     <depends>
@@ -239,6 +239,14 @@
                     <label>Save Email to the Quote before place Order</label>
                     <comment>Select No to prevent saving customer Email to the quote before Order was placed</comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <depends>
+                        <field id="*/*/active">1</field>
+                    </depends>
+                </field>
+                <field id="create_abandonedcart_automation" translate="label" sortOrder="60" showInDefault="1" showInStore="1" showInWebsite="1">
+                    <attribute type="button_label">Create Abandoned Cart Automation</attribute>
+                    <frontend_model>Ebizmarts\MailChimp\Block\Adminhtml\System\Config\CreateAbandonedCart</frontend_model>
+                    <comment>Must be logged in to MailChimp's website previously to see the automation wizard, re-open if not</comment>
                     <depends>
                         <field id="*/*/active">1</field>
                     </depends>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -207,6 +207,13 @@
                         <field id="*/*/active">1</field>
                     </depends>
                 </field>
+                <field id="resync_products" translate="button_label" type="button" sortOrder="130" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <button_label>Resync all products</button_label>
+                    <frontend_model>Ebizmarts\MailChimp\Block\Adminhtml\System\Config\ResyncProducts</frontend_model>
+                    <depends>
+                        <field id="*/*/active">1</field>
+                    </depends>
+                </field>
             </group>
             <group id="abandonedcart" translate="label" type="text" sortOrder="130" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Abandoned Cart Configuration</label>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -23,7 +23,7 @@
     <event name="catalog_product_save_after">
         <observer name="mailchimp_product_save_after" instance="\Ebizmarts\MailChimp\Observer\Adminhtml\Product\SaveAfter" />
     </event>
-    <event name="newsletter_subscriber_save_before">
-        <observer name="mailchimp_newsletter_subscriber_save_before" instance="\Ebizmarts\MailChimp\Observer\Subscriber\SaveBefore" />
+    <event name="newsletter_subscriber_save_after">
+        <observer name="mailchimp_newsletter_subscriber_save_after" instance="\Ebizmarts\MailChimp\Observer\Subscriber\SaveAfter" />
     </event>
 </config>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -26,4 +26,7 @@
     <event name="newsletter_subscriber_save_after">
         <observer name="mailchimp_newsletter_subscriber_save_after" instance="\Ebizmarts\MailChimp\Observer\Subscriber\SaveAfter" />
     </event>
+    <event name="catalog_product_import_bunch_save_after">
+        <observer name="mailchimp_product_import" instance="\Ebizmarts\MailChimp\Observer\Adminhtml\Product\ImportAfter"/>
+    </event>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -11,7 +11,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Ebizmarts_MailChimp" setup_version="102.3.44">
+    <module name="Ebizmarts_MailChimp" setup_version="102.3.45">
         <sequence>
             <module name="Magento_Newsletter"/>
             <module name="Magento_Sales"/>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -11,7 +11,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Ebizmarts_MailChimp" setup_version="102.3.43">
+    <module name="Ebizmarts_MailChimp" setup_version="102.3.44">
         <sequence>
             <module name="Magento_Newsletter"/>
             <module name="Magento_Sales"/>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -11,7 +11,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Ebizmarts_MailChimp" setup_version="102.3.42">
+    <module name="Ebizmarts_MailChimp" setup_version="102.3.43">
         <sequence>
             <module name="Magento_Newsletter"/>
             <module name="Magento_Sales"/>

--- a/view/adminhtml/templates/system/config/create_abandonedcart_automation.phtml
+++ b/view/adminhtml/templates/system/config/create_abandonedcart_automation.phtml
@@ -1,0 +1,5 @@
+<div class="actions actions-get-apikey">
+    <button onclick="javascript:window.open('<?php echo $this->authorizeRequestUrl() ?>', 'apiwizard','toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=yes, resizable=yes, ,left=100, top=100, width=800, height=600'); return false;" class="action-get-apikey" type="button" id="<?php echo $block->getHtmlId() ?>">
+        <span><?php echo $block->escapeHtml($block->getButtonLabel()) ?></span>
+    </button>
+</div>

--- a/view/adminhtml/templates/system/config/fieldset/hint.phtml
+++ b/view/adminhtml/templates/system/config/fieldset/hint.phtml
@@ -17,7 +17,10 @@
      "createWebhookUrl": "<?php echo $this->getUrl('mailchimp/ecommerce/createWebhook');?>",
      "getInterestUrl": "<?php echo $this->getUrl('mailchimp/ecommerce/getInterest');?>",
      "resyncSubscribersUrl": "<?php echo $this->getUrl('mailchimp/ecommerce/resyncSubscribers');?>",
-     "resyncProductsUrl": "<?php echo $this->getUrl('mailchimp/ecommerce/resyncProducts');?>"}}'>
+     "resyncProductsUrl": "<?php echo $this->getUrl('mailchimp/ecommerce/resyncProducts');?>",
+     "scope": "<?php echo $this->getScope();?>",
+     "scopeId": "<?php echo $this->getScopeId(); ?>"
+    }}'>
 </div>
 <div style="background:#EAF0EE;border:1px solid #CCCCCC;margin-bottom:10px;padding:11px 0 0 10px;">
     <h4>

--- a/view/adminhtml/templates/system/config/fieldset/hint.phtml
+++ b/view/adminhtml/templates/system/config/fieldset/hint.phtml
@@ -16,7 +16,8 @@
      "storeGridUrl": "<?php echo $this->getUrl('mailchimp/stores/index');?>",
      "createWebhookUrl": "<?php echo $this->getUrl('mailchimp/ecommerce/createWebhook');?>",
      "getInterestUrl": "<?php echo $this->getUrl('mailchimp/ecommerce/getInterest');?>",
-     "resyncSubscribersUrl": "<?php echo $this->getUrl('mailchimp/ecommerce/resyncSubscribers');?>"}}'>
+     "resyncSubscribersUrl": "<?php echo $this->getUrl('mailchimp/ecommerce/resyncSubscribers');?>",
+     "resyncProductsUrl": "<?php echo $this->getUrl('mailchimp/ecommerce/resyncProducts');?>"}}'>
 </div>
 <div style="background:#EAF0EE;border:1px solid #CCCCCC;margin-bottom:10px;padding:11px 0 0 10px;">
     <h4>

--- a/view/adminhtml/templates/system/config/resyncproducts.phtml
+++ b/view/adminhtml/templates/system/config/resyncproducts.phtml
@@ -1,0 +1,6 @@
+<div class="actions actions-resync-products">
+    <div id="validation_result" class="message-validation hidden"></div>
+    <button class="action-resync-products" type="button" id="<?php echo $block->getHtmlId() ?>">
+        <span><?php echo $block->escapeHtml($block->getButtonLabel()) ?></span>
+    </button>
+</div>

--- a/view/adminhtml/ui_component/customer_listing.xml
+++ b/view/adminhtml/ui_component/customer_listing.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <columns name="customer_columns">
+        <column name="mailchimp_sync" class="\Ebizmarts\MailChimp\Ui\Component\Listing\Column\Customers" sorOrder="40">
+            <settings>
+                <label translate="true">Mailchimp</label>
+                <bodyTmpl>ui/grid/cells/html</bodyTmpl>
+            </settings>
+        </column>
+    </columns>
+</listing>

--- a/view/adminhtml/ui_component/customer_listing.xml
+++ b/view/adminhtml/ui_component/customer_listing.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
     <columns name="customer_columns">
-        <column name="mailchimp_sync" class="\Ebizmarts\MailChimp\Ui\Component\Listing\Column\Customers" sorOrder="40">
+        <column name="mailchimp_sync" class="\Ebizmarts\MailChimp\Ui\Component\Listing\Column\Customers" sortOrder="40">
             <settings>
                 <label translate="true">Mailchimp</label>
                 <bodyTmpl>ui/grid/cells/html</bodyTmpl>

--- a/view/adminhtml/ui_component/mailchimp_errors_grid.xml
+++ b/view/adminhtml/ui_component/mailchimp_errors_grid.xml
@@ -117,7 +117,7 @@
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
                     <item name="indexField" xsi:type="string">id</item>
-                    <item name="label" xsi:type="string" translate="true">Download Response</item>
+                    <item name="label" xsi:type="string" translate="true">Action</item>
                 </item>
             </argument>
         </actionsColumn>

--- a/view/adminhtml/web/js/configapikey.js
+++ b/view/adminhtml/web/js/configapikey.js
@@ -23,7 +23,9 @@ define(
                 "createWebhookUrl": "",
                 "getInterestUrl": "",
                 "resyncSubscribersUrl": "",
-                "resyncProductsUrl": ""
+                "resyncProductsUrl": "",
+                "scope": "",
+                "scopeId": ""
             },
 
             _init: function () {
@@ -89,9 +91,11 @@ define(
             },
             _createWebhook: function (apiKey, listId) {
                 var createWebhookUrl = this.options.createWebhookUrl;
+                var scope = this.options.scope;
+                var scopeId = this.options.scopeId;
                 $.ajax({
                     url: createWebhookUrl,
-                    data: {'form_key': window.FORM_KEY, 'apikey': apiKey, 'listId': listId},
+                    data: {'form_key': window.FORM_KEY, 'apikey': apiKey, 'listId': listId, 'scope': scope, 'scopeId': scopeId},
                     type: 'GET',
                     dataType: 'json',
                     showLoader: true

--- a/view/adminhtml/web/js/configapikey.js
+++ b/view/adminhtml/web/js/configapikey.js
@@ -22,7 +22,8 @@ define(
                 "storeGridUrl": "",
                 "createWebhookUrl": "",
                 "getInterestUrl": "",
-                "resyncSubscribersUrl": ""
+                "resyncSubscribersUrl": "",
+                "resyncProductsUrl": ""
             },
 
             _init: function () {
@@ -48,6 +49,10 @@ define(
                     var mailchimpStoreId = $('#mailchimp_general_monkeystore').find(':selected').val();
                     self._resyncSubscribers(mailchimpStoreId);
                 });
+                $('#mailchimp_ecommerce_resync_products').click(function () {
+                    var mailchimpStoreId = $('#mailchimp_general_monkeystore').find(':selected').val();
+                    self._resyncProducts(mailchimpStoreId);
+                });
 
             },
             _resyncSubscribers: function (mailchimpStoreId) {
@@ -63,6 +68,22 @@ define(
                         alert({content: 'Error: can\'t resync your subscribers'});
                     } else if (data.valid == 1) {
                         alert({content: 'All subscribers marked for resync'});
+                    }
+                });
+            },
+            _resyncProducts: function (mailchimpStoreId) {
+                var resyncProductsUrl = this.options.resyncProductsUrl;
+                $.ajax({
+                    url: resyncProductsUrl,
+                    data: {'form_key': window.FORM_KEY, 'mailchimpStoreId': mailchimpStoreId},
+                    type: 'GET',
+                    dataType: 'json',
+                    showLoader: true
+                }).done(function (data) {
+                    if (data.valid == 0) {
+                        alert({content: 'Error: can\'t resync your products'});
+                    } else if (data.valid == 1) {
+                        alert({content: 'All products marked for resync'});
                     }
                 });
             },


### PR DESCRIPTION
Fix issue appearing in logs and preventing cron running when using PHP 8.1 Deprecated Functionality: abs(): Passing null to parameter #1 ($num) of type int|float is deprecated in vendor/mailchimp/mc-magento2/Model/Api/Order.php on line 374