### PR TITLE
Remove unneccesary empty comment in db_schema.xml file

### DIFF
--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -39,8 +39,7 @@
         <column xsi:type="int" name="subscriber_id" padding="10" nullable="false" comment="subscriber id"/>
         <column xsi:type="smallint" name="store_id" padding="5" nullable="false" default="0"
                 comment="Store Id"/>
-        <column xsi:type="datetime" name="updated_at" on_update="true" nullable="false" default="CURRENT_TIMESTAMP"
-                comment=""/>
+        <column xsi:type="datetime" name="updated_at" on_update="true" nullable="false" default="CURRENT_TIMESTAMP"/>
         <column xsi:type="text" name="groupdata" nullable="false" comment="data"/>
         <constraint xsi:type="primary" referenceId="PRIMARY">
             <column name="id"/>


### PR DESCRIPTION
This module at the moment causes that `setup:db:status` returns `Declarative Schema is not up to date` message.

It's probably caused because the `db_schema.xml` is configured with empty comment for `updated_at` column. `setup:db:status` when comparing, sees that comment is `null` while `db_schema.xml` defines it should be an empty string.

This PR removes `comment` attribute entirely making `setup:db:status` work as expected.