### PR TITLE
Fixes and cleanup of a bunch of things phpstan discovered on level 0

### DIFF
--- a/Controller/Adminhtml/Batch/Index.php
+++ b/Controller/Adminhtml/Batch/Index.php
@@ -28,9 +28,9 @@ class Index extends \Magento\Backend\App\Action
         \Magento\Backend\App\Action\Context $context,
         \Magento\Framework\View\Result\PageFactory $resultPageFactory
     ) {
-
         $this->resultPageFactory = $resultPageFactory;
-        return parent::__construct($context);
+
+        parent::__construct($context);
     }
     public function execute()
     {

--- a/Controller/Adminhtml/Cron/Index.php
+++ b/Controller/Adminhtml/Cron/Index.php
@@ -28,9 +28,9 @@ class Index extends \Magento\Backend\App\Action
         \Magento\Backend\App\Action\Context $context,
         \Magento\Framework\View\Result\PageFactory $resultPageFactory
     ) {
-
         $this->resultPageFactory = $resultPageFactory;
-        return parent::__construct($context);
+
+        parent::__construct($context);
     }
     public function execute()
     {

--- a/Controller/Adminhtml/Errors/Index.php
+++ b/Controller/Adminhtml/Errors/Index.php
@@ -28,9 +28,9 @@ class Index extends \Magento\Backend\App\Action
         \Magento\Backend\App\Action\Context $context,
         \Magento\Framework\View\Result\PageFactory $resultPageFactory
     ) {
-
         $this->resultPageFactory = $resultPageFactory;
-        return parent::__construct($context);
+
+        parent::__construct($context);
     }
     public function execute()
     {

--- a/Controller/Adminhtml/Orders/Campaign.php
+++ b/Controller/Adminhtml/Orders/Campaign.php
@@ -50,10 +50,10 @@ class Campaign extends Action
             $campaign = $api->campaigns->get($order->getMailchimpCampaignId());
             $webId = $campaign['web_id'];
             $url = $this->urlBuilder->getUrl('https://admin.mailchimp.com/reports/summary') . "?id=$webId";
-            $this->_redirect($url);
+            return $this->_redirect($url);
         } catch(\Exception $e) {
             $this->messageManager->addErrorMessage($e->getMessage());
-            $this->_redirect($this->urlBuilder->getUrl('sales/order'));
+            return $this->_redirect($this->urlBuilder->getUrl('sales/order'));
         }
     }
     protected function _isAllowed()

--- a/Controller/Adminhtml/Orders/Member.php
+++ b/Controller/Adminhtml/Orders/Member.php
@@ -52,10 +52,10 @@ class Member extends Action
             $member = $api->lists->members->get($listId, hash('md5', strtolower($email)));
             $memberId = $member['contact_id'];
             $url = $this->urlBuilder->getUrl('https://admin.mailchimp.com/audience/contact-profile') . "?contact_id=$memberId";
-            $this->_redirect($url);
+            return $this->_redirect($url);
         } catch(\Exception $e) {
             $this->messageManager->addErrorMessage($e->getMessage());
-            $this->_redirect($this->urlBuilder->getUrl('sales/order'));
+            return $this->_redirect($this->urlBuilder->getUrl('sales/order'));
         }
     }
     protected function _isAllowed()

--- a/Controller/Checkout/Success.php
+++ b/Controller/Checkout/Success.php
@@ -108,7 +108,8 @@ class Success extends \Magento\Framework\App\Action\Action
             $this->_helper->log($e->getMessage());
         }
         $this->messageManager->addSuccessMessage(__('Thanks for sharing your interest with us'));
-        $this->_redirect($this->_helper->getBaserUrl(
+
+        return $this->_redirect($this->_helper->getBaserUrl(
             $order->getStoreId(),
             \Magento\Framework\UrlInterface::URL_TYPE_WEB
         ));

--- a/Setup/Patch/Data/Migrate24.php
+++ b/Setup/Patch/Data/Migrate24.php
@@ -36,6 +36,8 @@ class Migrate24 implements DataPatchInterface, PatchVersionInterface
         $this->moduleDataSetup->getConnection()->query($query);
 
         $this->moduleDataSetup->getConnection()->endSetup();
+
+        return $this;
     }
     public static function getDependencies()
     {

--- a/Setup/Patch/Data/Migrate32.php
+++ b/Setup/Patch/Data/Migrate32.php
@@ -75,6 +75,8 @@ class Migrate32 implements DataPatchInterface, PatchVersionInterface
             }
         }
         $this->moduleDataSetup->getConnection()->endSetup();
+
+        return $this;
     }
     public static function getDependencies()
     {

--- a/Setup/Patch/Data/Migrate35.php
+++ b/Setup/Patch/Data/Migrate35.php
@@ -48,10 +48,10 @@ class Migrate35 implements DataPatchInterface, PatchVersionInterface
          */
         foreach ($configCollection as $config) {
             try {
-                $config->setValue($this->_helper->encrypt($config->getvalue()));
+                $config->setValue($this->helper->encrypt($config->getvalue()));
                 $config->getResource()->save($config);
             } catch (\Exception $e) {
-                $this->_helper->log($e->getMessage());
+                $this->helper->log($e->getMessage());
             }
         }
         $configCollection = $this->configFactory->create();
@@ -64,6 +64,8 @@ class Migrate35 implements DataPatchInterface, PatchVersionInterface
         }
 
         $this->moduleDataSetup->getConnection()->endSetup();
+
+        return $this;
     }
     public static function getDependencies()
     {

--- a/Setup/Patch/Data/Migrate452.php
+++ b/Setup/Patch/Data/Migrate452.php
@@ -89,6 +89,8 @@ class Migrate452 implements DataPatchInterface
         }
 
         $this->moduleDataSetup->getConnection()->endSetup();
+
+        return $this;
     }
 
     public static function getDependencies()

--- a/Ui/Component/Batch/Grid/Column/Batches.php
+++ b/Ui/Component/Batch/Grid/Column/Batches.php
@@ -53,7 +53,7 @@ class Batches extends Column
         array $components = [],
         array $data = []
     ) {
-        $this->_helper = $helper;
+        $this->helper = $helper;
         $this->mailChimpSyncB = $mailChimpSyncB;
         $this->urlBuilder = $urlBuilder;
         parent::__construct($context, $uiComponentFactory, $components, $data);
@@ -96,7 +96,7 @@ class Batches extends Column
     private function getMCStoreNameById($mailchimp_store_id, $magentoStoreId)
     {
         if (!key_exists($mailchimp_store_id, $this->stores)) {
-            $api = $this->_helper->getApi($magentoStoreId);
+            $api = $this->helper->getApi($magentoStoreId);
             $store = $api->ecommerce->stores->get($mailchimp_store_id);
             $this->stores[$mailchimp_store_id] = $store['name'];
         }

--- a/view/frontend/templates/loadquote.phtml
+++ b/view/frontend/templates/loadquote.phtml
@@ -11,11 +11,3 @@
 // Add your template code here ...
 
 ?>
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Discovered with:

- Magento OS 2.4.6-p1
- mailchimp/mc-magento2 version 103.4.53
- [phsptan](https://github.com/phpstan/phpstan) version 1.10.25

I'm working on a Magento upgrade in combination of PHP 8.2, and one of the checks I'm doing is with phpstan to see if the PHP 8.2 deprecated usage for [creation of dynamic properties](https://www.php.net/manual/en/migration82.deprecated.php#migration82.deprecated.core.dynamic-properties) is not occuring in the modules we have installed on the shop.

And indeed, some issues were found in this module (the ones below that mention `Access to an undefined property`).
And while resolving them, I resolved a couple more issues that phpstan found on level 0. Not all have been fixed, I only focussed on the easy ones.

Here's the ones that got fixed:
```
$ /path/to/phpstan analyse --level=0 .

 ------ ------------------------------------------------------------------------------------
  Line   Controller/Adminhtml/Batch/Index.php
 ------ ------------------------------------------------------------------------------------
  33     Result of method Magento\Backend\App\AbstractAction::__construct() (void) is used.
 ------ ------------------------------------------------------------------------------------

 ------ ------------------------------------------------------------------------------------
  Line   Controller/Adminhtml/Cron/Index.php
 ------ ------------------------------------------------------------------------------------
  33     Result of method Magento\Backend\App\AbstractAction::__construct() (void) is used.
 ------ ------------------------------------------------------------------------------------

 ------ ------------------------------------------------------------------------------------
  Line   Controller/Adminhtml/Errors/Index.php
 ------ ------------------------------------------------------------------------------------
  33     Result of method Magento\Backend\App\AbstractAction::__construct() (void) is used.
 ------ ------------------------------------------------------------------------------------

 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   Controller/Adminhtml/Orders/Campaign.php
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  49     Method Ebizmarts\MailChimp\Controller\Adminhtml\Orders\Campaign::execute() should return Magento\Framework\App\ResponseInterface|Magento\Framework\Controller\ResultInterface but return statement is missing.
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   Controller/Adminhtml/Orders/Member.php
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  49     Method Ebizmarts\MailChimp\Controller\Adminhtml\Orders\Member::execute() should return Magento\Framework\App\ResponseInterface|Magento\Framework\Controller\ResultInterface but return statement is missing.
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   Controller/Checkout/Success.php
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  111    Method Ebizmarts\MailChimp\Controller\Checkout\Success::execute() should return Magento\Framework\App\ResponseInterface|Magento\Framework\Controller\ResultInterface but return statement is missing.
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   Setup/Patch/Data/Migrate24.php
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------
  38     Method Ebizmarts\MailChimp\Setup\Patch\Data\Migrate24::apply() should return $this(Ebizmarts\MailChimp\Setup\Patch\Data\Migrate24) but return statement is missing.
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------

 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   Setup/Patch/Data/Migrate32.php
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------
  77     Method Ebizmarts\MailChimp\Setup\Patch\Data\Migrate32::apply() should return $this(Ebizmarts\MailChimp\Setup\Patch\Data\Migrate32) but return statement is missing.
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------

 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   Setup/Patch/Data/Migrate35.php
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------
  51     Access to an undefined property Ebizmarts\MailChimp\Setup\Patch\Data\Migrate35::$_helper.
         💡 Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property
  54     Access to an undefined property Ebizmarts\MailChimp\Setup\Patch\Data\Migrate35::$_helper.
         💡 Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property
  66     Method Ebizmarts\MailChimp\Setup\Patch\Data\Migrate35::apply() should return $this(Ebizmarts\MailChimp\Setup\Patch\Data\Migrate35) but return statement is missing.
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------

 ------ -----------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   Setup/Patch/Data/Migrate452.php
 ------ -----------------------------------------------------------------------------------------------------------------------------------------------------------------------
  91     Method Ebizmarts\MailChimp\Setup\Patch\Data\Migrate452::apply() should return $this(Ebizmarts\MailChimp\Setup\Patch\Data\Migrate452) but return statement is missing.
 ------ -----------------------------------------------------------------------------------------------------------------------------------------------------------------------

 ------ -------------------------------------------------------------------------------------------------------
  Line   Ui/Component/Batch/Grid/Column/Batches.php
 ------ -------------------------------------------------------------------------------------------------------
  56     Access to an undefined property Ebizmarts\MailChimp\Ui\Component\Batch\Grid\Column\Batches::$_helper.
         💡 Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property
  99     Access to an undefined property Ebizmarts\MailChimp\Ui\Component\Batch\Grid\Column\Batches::$_helper.
         💡 Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property
 ------ -------------------------------------------------------------------------------------------------------

 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   view/frontend/templates/loadquote.phtml
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------
  14     File ends with a trailing whitespace. This may cause problems when running the code in the web browser. Remove the closing ?> mark or remove the whitespace.
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------
```

Here's the ones that didn't got fixed:
```
$ /path/to/phpstan analyse --level=0 .

------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   Controller/Adminhtml/Stores/Delete.php
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  22     Method Ebizmarts\MailChimp\Controller\Adminhtml\Stores\Delete::execute() should return Magento\Framework\App\ResponseInterface|Magento\Framework\Controller\ResultInterface but return statement is missing.
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   Controller/Adminhtml/Stores/Save.php
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  21     Method Ebizmarts\MailChimp\Controller\Adminhtml\Stores\Save::execute() should return Magento\Framework\App\ResponseInterface|Magento\Framework\Controller\ResultInterface but return statement is missing.
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

 ------ --------------------------------------------------------------------------------------
  Line   Helper/Data.php
 ------ --------------------------------------------------------------------------------------
  1191   Access to an undefined property Ebizmarts\MailChimp\Helper\Data::$_mailChimpSyncE.
         💡 Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property
  1192   Access to an undefined property Ebizmarts\MailChimp\Helper\Data::$_mailChimpSyncE.
         💡 Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property
  1201   Access to an undefined property Ebizmarts\MailChimp\Helper\Data::$_mailChimpSyncE.
         💡 Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property
  1202   Access to an undefined property Ebizmarts\MailChimp\Helper\Data::$_mailChimpSyncE.
         💡 Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property
 ------ --------------------------------------------------------------------------------------

 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   Model/Config/Backend/VarsMap.php
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  59     Method Ebizmarts\MailChimp\Model\Config\Backend\VarsMap::_afterLoad() should return $this(Ebizmarts\MailChimp\Model\Config\Backend\VarsMap) but return statement is missing.
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

I would strongly recommend to take a look at the left over errors around the missing `$_mailChimpSyncE` member, I think that code will crash as it is currently, but I lack the necessary knowledge to quickly fix this problem. The other problems are probably less important to fix.

While going through the code, I noticed you use `startSetup` and `endSetup` in some of the database migration code, I would strongly recommend to stop doing this, it's considered bad practice. You can see [the reasoning over here](https://community.magento.com/t5/Magento-DevBlog/Mysterious-startSetup-and-endSetup-Methods/ba-p/68483) (written by an Adobe/Magento employee).