### PR TITLE
Fixed inconsistent check for isSubscriber method.

### DIFF
--- a/Model/Api/Customer.php
+++ b/Model/Api/Customer.php
@@ -186,7 +186,7 @@ class Customer
         $subscriber = $this->subscriberFactory->create();
         $subscriber->loadByEmail($customer->getEmail());
         if ($subscriber->getEmail() == $customer->getEmail()) {
-            if ($subscriber->getStatus() === \Magento\Newsletter\Model\Subscriber::STATUS_SUBSCRIBED) {
+            if ((int)$subscriber->getStatus() === \Magento\Newsletter\Model\Subscriber::STATUS_SUBSCRIBED) {
                 return true;
             }
         }


### PR DESCRIPTION
Forcing status value from subscriber object to be of same type as constant that is checked against.

Reason: The getStatus() from Magento Newsletter ( Subscriber class ) module has specified that the return type of the method is `int` but in fact returns `string`.