### PR TITLE
Technical error when clicked on mailchimp column in customer grid

### DIFF
--- a/view/adminhtml/ui_component/customer_listing.xml
+++ b/view/adminhtml/ui_component/customer_listing.xml
@@ -5,6 +5,7 @@
             <settings>
                 <label translate="true">Mailchimp</label>
                 <bodyTmpl>ui/grid/cells/html</bodyTmpl>
+                 <sortable>false</sortable>
             </settings>
         </column>
     </columns>


### PR DESCRIPTION
### Fixed Issues
Fixed: https://github.com/mailchimp/mc-magento2/issues/1855

### Description
When we click on mailchimp column in the customer listing grid it throws an error stating “Something went wrong with processing the default view and we have restored the filter to its original state”. And the grid does not load.

### Error screenshot
![image](https://github.com/mailchimp/mc-magento2/assets/124759210/0d0563b0-2a56-49ae-8f0c-2873856e2206)

### Manual testing scenarios
1. Clean shop with install sample data
2. Install “mailchimp/mc-magento2” module.
3. Go to Customers->All Customers.
4. Now click on Mailchimp column in the customer grid to sort it.
