### PR TITLE
Update db_schema.xml mailchimp_notification

### DIFF
--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -149,7 +149,7 @@
         </constraint>
     </table>
     <table name="mailchimp_notification">
-        <column xsi:type="int" name="id" padding="10" nullable="false" identity="true" comment=""/>
+        <column xsi:type="int" name="id" padding="10" nullable="false" identity="true" comment="Table Id"/>
         <column xsi:type="text" name="notification_data" nullable="false" comment="data of the request"/>
         <column xsi:type="datetime" name="generated_at" on_update="false" nullable="false" default="CURRENT_TIMESTAMP"
                 comment="date of generation"/>


### PR DESCRIPTION
Hi,

A column can not have an empty `comment=""` attribute. It can have no attribute at all, or an attribute with an actual string in it. 
According to the xsd it can, but doing this will keep the database in a perpetual "not up to date"-state.

Can be tested by:
1. Installing latest MC release
2. Running setup upgrade
3. Checking status

```bash
bin/magento setup:db:status
Declarative Schema is not up to date
Run 'setup:upgrade' to update your DB schema and data.
```