### PR TITLE
Fixed code for PHP 8.4

### DIFF
--- a/Model/Config/Backend/ApiKey.php
+++ b/Model/Config/Backend/ApiKey.php
@@ -54,11 +54,11 @@ class ApiKey extends \Magento\Framework\App\Config\Value
         \Magento\Framework\App\Config\ScopeConfigInterface $config,
         \Magento\Framework\App\Cache\TypeListInterface $cacheTypeList,
         \Magento\Config\Model\ResourceModel\Config $resourceConfig,
-        \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
-        \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
         \Magento\Framework\Stdlib\DateTime\DateTime $date,
         \Ebizmarts\MailChimp\Helper\Data $helper,
         \Magento\Store\Model\StoreManager $storeManager,
+        ?\Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
+        ?\Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         $this->_helper          = $helper;

--- a/Model/Config/Backend/MonkeyList.php
+++ b/Model/Config/Backend/MonkeyList.php
@@ -52,11 +52,11 @@ class MonkeyList extends \Magento\Framework\App\Config\Value
         \Magento\Framework\App\Config\ScopeConfigInterface $config,
         \Magento\Framework\App\Cache\TypeListInterface $cacheTypeList,
         \Magento\Config\Model\ResourceModel\Config $resourceConfig,
-        \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
-        \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
         \Magento\Framework\Stdlib\DateTime\DateTime $date,
         \Ebizmarts\MailChimp\Helper\Data $helper,
         \Magento\Store\Model\StoreManager $storeManager,
+        ?\Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
+        ?\Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         $this->_helper          = $helper;

--- a/Model/Config/Backend/MonkeyStore.php
+++ b/Model/Config/Backend/MonkeyStore.php
@@ -61,12 +61,12 @@ class MonkeyStore extends \Magento\Framework\App\Config\Value
         \Magento\Framework\App\Config\ScopeConfigInterface $config,
         \Magento\Framework\App\Cache\TypeListInterface $cacheTypeList,
         \Magento\Config\Model\ResourceModel\Config $resourceConfig,
-        \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
-        \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
         \Magento\Framework\Stdlib\DateTime\DateTime $date,
         \Ebizmarts\MailChimp\Helper\Data $helper,
         SyncHelper $syncHelper,
         \Magento\Store\Model\StoreManager $storeManager,
+        ?\Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
+        ?\Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         $this->_helper          = $helper;

--- a/Model/Config/Backend/VarsMap.php
+++ b/Model/Config/Backend/VarsMap.php
@@ -43,11 +43,11 @@ class VarsMap extends \Magento\Framework\App\Config\Value
         \Magento\Framework\App\Cache\TypeListInterface $cacheTypeList,
         \Ebizmarts\MailChimp\Helper\VarsMap $varsMap,
         \Ebizmarts\MailChimp\Helper\Data $helper,
-        \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
-        \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
+        ?\Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
+        ?\Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
         array $data = []
     ) {
-    
+
         $this->_varsHelper = $varsMap;
         $this->_helper      = $helper;
         parent::__construct($context, $registry, $config, $cacheTypeList, $resource, $resourceCollection, $data);


### PR DESCRIPTION
Branch was created from `develop-2.4` and targets it as well, is that correct?

This PR fixes deprecation problems in PHP 8.4, more specifically:
- https://www.php.net/manual/en/migration84.deprecated.php#migration84.deprecated.core.implicitly-nullable-parameter
- https://www.php.net/manual/en/migration81.incompatible.php#migration81.incompatible.core.optional-before-required

It looks like only the `MonkeyStore` and `VarsMap` backend models are still used, the other 2 got removed from the `system.xml` in 2017 and 2019.
The change to `VarsMap` is backwards compatible, the change to `MonkeyStore` not really due to the change in sort order of arguments (in case devs call its constructor using a preference for example), but I don't see how to fix it otherwise, also chances of this happening are probably very low.
I'll leave it up to you to figure out an alternative solution if you care about backwards compatibility.

Found these problems with [PHPCompatibility phpcs standard](https://github.com/PHPCompatibility/PHPCompatibility) (develop branch):
```
➜ vendor/bin/phpcs --standard=PHPCompatibility --extensions=php --runtime-set testVersion 7.4- .

FILE: mailchimp-mc-magento2/Model/Config/Backend/MonkeyStore.php
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 4 WARNINGS AFFECTING 2 LINES
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 64 | WARNING | Declaring an optional parameter with a non-nullable type and a null default value before a required parameter is deprecated since PHP 8.4 Parameter $resource is optional, while parameter $date is required. The $resource parameter is
    |         | implicitly treated as a required parameter.
 64 | WARNING | Implicitly marking a parameter as nullable is deprecated since PHP 8.4. Update the type to be explicitly nullable instead. Found implicitly nullable parameter: $resource.
 65 | WARNING | Declaring an optional parameter with a non-nullable type and a null default value before a required parameter is deprecated since PHP 8.4 Parameter $resourceCollection is optional, while parameter $date is required. The
    |         | $resourceCollection parameter is implicitly treated as a required parameter.
 65 | WARNING | Implicitly marking a parameter as nullable is deprecated since PHP 8.4. Update the type to be explicitly nullable instead. Found implicitly nullable parameter: $resourceCollection.
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


FILE: mailchimp-mc-magento2/Model/Config/Backend/ApiKey.php
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 4 WARNINGS AFFECTING 2 LINES
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 57 | WARNING | Declaring an optional parameter with a non-nullable type and a null default value before a required parameter is deprecated since PHP 8.4 Parameter $resource is optional, while parameter $date is required. The $resource parameter is
    |         | implicitly treated as a required parameter.
 57 | WARNING | Implicitly marking a parameter as nullable is deprecated since PHP 8.4. Update the type to be explicitly nullable instead. Found implicitly nullable parameter: $resource.
 58 | WARNING | Declaring an optional parameter with a non-nullable type and a null default value before a required parameter is deprecated since PHP 8.4 Parameter $resourceCollection is optional, while parameter $date is required. The
    |         | $resourceCollection parameter is implicitly treated as a required parameter.
 58 | WARNING | Implicitly marking a parameter as nullable is deprecated since PHP 8.4. Update the type to be explicitly nullable instead. Found implicitly nullable parameter: $resourceCollection.
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


FILE: mailchimp-mc-magento2/Model/Config/Backend/MonkeyList.php
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 4 WARNINGS AFFECTING 2 LINES
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 55 | WARNING | Declaring an optional parameter with a non-nullable type and a null default value before a required parameter is deprecated since PHP 8.4 Parameter $resource is optional, while parameter $date is required. The $resource parameter is
    |         | implicitly treated as a required parameter.
 55 | WARNING | Implicitly marking a parameter as nullable is deprecated since PHP 8.4. Update the type to be explicitly nullable instead. Found implicitly nullable parameter: $resource.
 56 | WARNING | Declaring an optional parameter with a non-nullable type and a null default value before a required parameter is deprecated since PHP 8.4 Parameter $resourceCollection is optional, while parameter $date is required. The
    |         | $resourceCollection parameter is implicitly treated as a required parameter.
 56 | WARNING | Implicitly marking a parameter as nullable is deprecated since PHP 8.4. Update the type to be explicitly nullable instead. Found implicitly nullable parameter: $resourceCollection.
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


FILE: mailchimp-mc-magento2/Model/Config/Backend/VarsMap.php
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 2 WARNINGS AFFECTING 2 LINES
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 46 | WARNING | Implicitly marking a parameter as nullable is deprecated since PHP 8.4. Update the type to be explicitly nullable instead. Found implicitly nullable parameter: $resource.
 47 | WARNING | Implicitly marking a parameter as nullable is deprecated since PHP 8.4. Update the type to be explicitly nullable instead. Found implicitly nullable parameter: $resourceCollection.
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Time: 1.2 secs; Memory: 14MB
```