### PR TITLE
Patches are not removed after the module uninstallation

### DIFF
--- a/Setup/Patch/Data/Migrate24.php
+++ b/Setup/Patch/Data/Migrate24.php
@@ -4,8 +4,9 @@ namespace Ebizmarts\MailChimp\Setup\Patch\Data;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
 use Magento\Framework\Setup\Patch\PatchVersionInterface;
+use Magento\Framework\Setup\Patch\PatchRevertableInterface;
 
-class Migrate24 implements DataPatchInterface, PatchVersionInterface
+class Migrate24 implements DataPatchInterface, PatchVersionInterface, PatchRevertableInterface
 {
     /**
      * @var ModuleDataSetupInterface
@@ -51,5 +52,16 @@ class Migrate24 implements DataPatchInterface, PatchVersionInterface
     {
         return '1.0.24';
     }
+
+    /**
+     * Revert data changes
+     *
+     * @return bool
+     */
+    public function revert()
+    {
+        return true;
+    }
+
 }
 

--- a/Setup/Patch/Data/Migrate32.php
+++ b/Setup/Patch/Data/Migrate32.php
@@ -6,8 +6,9 @@ use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
 use Magento\Framework\Setup\Patch\PatchVersionInterface;
 use Ebizmarts\MailChimp\Model\ResourceModel\MailChimpWebhookRequest\CollectionFactory;
+use Magento\Framework\Setup\Patch\PatchRevertableInterface;
 
-class Migrate32 implements DataPatchInterface, PatchVersionInterface
+class Migrate32 implements DataPatchInterface, PatchVersionInterface, PatchRevertableInterface
 {
     /**
      * @var ModuleDataSetupInterface
@@ -90,5 +91,16 @@ class Migrate32 implements DataPatchInterface, PatchVersionInterface
     {
         return '1.2.32';
     }
+
+    /**
+     * Revert data changes
+     *
+     * @return bool
+     */
+    public function revert()
+    {
+        return true;
+    }
+
 }
 

--- a/Setup/Patch/Data/Migrate35.php
+++ b/Setup/Patch/Data/Migrate35.php
@@ -6,8 +6,9 @@ use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
 use Magento\Framework\Setup\Patch\PatchVersionInterface;
 use Magento\Config\Model\ResourceModel\Config\Data\CollectionFactory as ConfigFactory;
+use Magento\Framework\Setup\Patch\PatchRevertableInterface;
 
-class Migrate35 implements DataPatchInterface, PatchVersionInterface
+class Migrate35 implements DataPatchInterface, PatchVersionInterface, PatchRevertableInterface
 {
     /**
      * @var ModuleDataSetupInterface
@@ -79,5 +80,16 @@ class Migrate35 implements DataPatchInterface, PatchVersionInterface
     {
         return '102.3.35';
     }
+
+    /**
+     * Revert data changes
+     *
+     * @return bool
+     */
+    public function revert()
+    {
+        return true;
+    }
+
 }
 


### PR DESCRIPTION
### Preconditions (*)
Tested in this versions:
1. Module's version: 103.4.72
2. Magento's version: 2.4.6-p6
### Issue Description (*)
As per standard rule of magento, whenever we uninstall the module, all the database tables and data patches associated with that module should be removed. However, in this module after uninstalling the module, I can see that only database tables are removed, the data patches associated with the module are not removed.
### Steps to reproduce (*)

1. Install the Ebizmarts_MailChimp module.
2. Disable the module and run the setup:upgrade command.
3. Enable the module and then run the uninstall command.
4. Check the patch_list table to verify that data patches are not removed (refer to screenshot-1).

### Screenshot-1
<img width="891" height="693" alt="image" src="https://github.com/user-attachments/assets/ede95d36-9460-4619-be0d-d55e24fed21e" />

### Expected result (*)
The data patches should be removed along with the database tables from the database during module uninstallation.
### Actual result (*)
The data patches were not removed along with the database tables from the database during module uninstallation.
### Additional Information (*)
This behavior occurs due to the failure of data patches to revert correctly when the module is uninstalled. It happens because the revert method has not been implemented in the following files. Once you add the revert method then the issue will be resolved.
### File Names (*)
1.mailchimp/mc-magento2/Setup/Patch/Data/Migrate24.php
2.mailchimp/mc-magento2/Setup/Patch/Data/Migrate32.php
3.mailchimp/mc-magento2/Setup/Patch/Data/Migrate35.php

