### PR TITLE
Closes #2288 for Magento 2.4

### DIFF
--- a/Controller/Adminhtml/Ecommerce/Getaccountdetails.php
+++ b/Controller/Adminhtml/Ecommerce/Getaccountdetails.php
@@ -59,7 +59,7 @@ class Getaccountdetails extends Action
         $scopeId = $param['scopeId'];
         try {
             if ($encrypt == 3) {
-                $api = $this->_helper->getApi($this->_storeManager->getStore()->getId());
+                $api = $this->_helper->getApi($scopeId, $scope);
             } else {
                 $api = $this->_helper->getApiByApiKey($apiKey, $encrypt);
             }

--- a/Cron/Ecommerce.php
+++ b/Cron/Ecommerce.php
@@ -128,8 +128,8 @@ class Ecommerce
         foreach ($this->_storeManager->getStores() as $storeId => $val) {
             if ($this->_helper->getConfigValue(\Ebizmarts\MailChimp\Helper\Data::XML_PATH_ACTIVE, $storeId)) {
                 if (!$this->_ping($storeId)) {
-                    $this->_helper->log('MailChimp is not available');
-                    return;
+                    $this->_helper->log("MailChimp is not available for store $storeId, skipping");
+                    continue;
                 }
                 $this->_storeManager->setCurrentStore($storeId);
                 $listId = $this->_helper->getGeneralList($storeId);

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -646,7 +646,11 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     public function getMCMinSyncDateFlag($storeId = null)
     {
         $syncDate = $this->getConfigValue(self::XML_PATH_IS_SYNC, $storeId);
-        if ($syncDate=='') {
+        // When a per-Mailchimp-store flag has been written under issync/<mailchimpStoreId>
+        // at default scope, this path resolves to an array for any store with no scalar
+        // override of its own. Such a store has not recorded a completion date, so treat
+        // it as "not yet synced" instead of returning the array to the callers.
+        if (is_array($syncDate) || $syncDate === null || $syncDate == '') {
             $syncDate = '1900-01-01';
         }
         return $syncDate;


### PR DESCRIPTION
## Description

Fixes #2288.

When configuring Mailchimp on an additional **website scope** with an API Key belonging to a **different Mailchimp account**, selecting the Mailchimp Store showed an **"Invalid API Key"** message next to *Account Details* and left the **Mailchimp List dropdown empty**. The empty list id was then persisted, breaking the subscriber/interest sync for that store.

## Root cause

In `Controller/Adminhtml/Ecommerce/Getaccountdetails.php`, when the API Key field is masked (`******`), the front-end sends `encrypt = 3` together with the `scope`/`scopeId` being edited. The `encrypt == 3` branch resolved the API from the **admin store** instead of that scope:

    $api = $this->_helper->getApi($this->_storeManager->getStore()->getId());

In an admin request `getStore()` returns the admin store (id `0`), so the key is read at the **default scope** — never the website scope being configured. On the default scope that key is either the first account's key or empty (when Mailchimp is disabled at default), so the lookup against the second account's store fails with "Invalid API Key".

## Fix

Resolve the API from the scope passed by the front-end, consistent with the rest of the controller and the `MonkeyStore`/`MonkeyList` source models:

    $api = $this->_helper->getApi($scopeId, $scope);

## Affected file

- `Controller/Adminhtml/Ecommerce/Getaccountdetails.php`

## Testing

- Magento Open Source 2.4.5-p4, multi-website install with each website on a different Mailchimp account.
- In the second website scope (key already saved, field shows `******`), selecting the Mailchimp Store now populates Account Details and the Mailchimp List dropdown from the correct account; no "Invalid API Key".