### PR TITLE
Correct wrong Exception import in Helper/Data.php (#2290)

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -14,7 +14,6 @@ namespace Ebizmarts\MailChimp\Helper;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\Exception\ValidatorException;
 use Magento\Store\Model\Store;
-use Symfony\Component\Config\Definition\Exception\Exception;
 use Ebizmarts\MailChimp\Model\MailchimpNotificationFactory as MailchimpNotificationFactory;
 
 class Data extends \Magento\Framework\App\Helper\AbstractHelper


### PR DESCRIPTION
## What
Removes the accidental `use Symfony\Component\Config\Definition\Exception\Exception;` import at the top of `Helper/Data.php`.

## Why
Because `use` statements are file-scoped, that import made every unqualified `Exception` in the file resolve to Symfony's class instead of the global `\Exception`. As a result, the catch-all fallbacks in:

- `deleteStore()`
- `getSubscriberInterest()`

never matched standard exceptions. In particular, the `\InvalidArgumentException("Unable to unserialize value. Error: Syntax error")` thrown by `Json::unserialize` on non-JSON `mailchimp_interest_group.groupdata` would escape the `catch (Exception $e)` and propagate, potentially aborting the `ebizmarts_ecommerce` sync run.

## Fix
Dropping the unused import lets the unqualified `Exception` resolve to the global `\Exception` (the apparent intent), repairing both catch blocks at once. No other references to Symfony's `Exception` exist in the file.

Closes #2290.
