### PR TITLE
Fix PHP 8.5 deprecated usage, for Magento 2.4. Closes #2287

### DIFF
--- a/Model/HTTP/Client/Curl.php
+++ b/Model/HTTP/Client/Curl.php
@@ -415,7 +415,10 @@ class Curl implements \Magento\Framework\HTTP\ClientInterface
         if ($err) {
             $this->doError(curl_error($this->_ch));
         }
-        curl_close($this->_ch);
+
+        if (PHP_VERSION_ID < 80000) {
+            curl_close($this->_ch);
+        }
     }
 
     /**
@@ -427,8 +430,11 @@ class Curl implements \Magento\Framework\HTTP\ClientInterface
      */
     public function doError($string)
     {
+        if (PHP_VERSION_ID < 80000) {
+            curl_close($this->_ch);
+        }
+
         //  phpcs:ignore Magento2.Exceptions.DirectThrow
-        curl_close($this->_ch);
         throw new \Exception($string);
     }
 


### PR DESCRIPTION
This fix is only needed for the Magento 2.4 branch, since no Magento 2.3.x or older versions supported PHP 8.x or higher.
Older Magento 2.4.x versions still supported PHP 7.4, so we can't remove the 2 `curl_close` calls. So I've wrapped them in a check to see which PHP version executes the code.

See #2287 for the details

