### PR TITLE
Fix deadlock in SaveBefore observer by reordering lock acquisition

### DIFF
--- a/Observer/Customer/SaveBefore.php
+++ b/Observer/Customer/SaveBefore.php
@@ -54,6 +54,16 @@ class SaveBefore implements \Magento\Framework\Event\ObserverInterface
         $storeId  = $customer->getStoreId();
         $websiteId = $customer->getWebsiteId();
         if ($this->_helper->getConfigValue(\Ebizmarts\MailChimp\Helper\Data::XML_PATH_ACTIVE)) {
+            // Mark subscriber before customer to match the cron lock-acquisition order
+            // (IS_SUBSCRIBER first, then IS_CUSTOMER) and prevent deadlocks.
+            $subscriber = $this->subscriberFactory->create();
+            $subscriber->loadBySubscriberEmail($customer->getEmail(), $websiteId);
+            if ($subscriber->getEmail() == $customer->getEmail()) {
+                $this->syncHelper->markRegisterAsModified(
+                    $subscriber->getId(),
+                    \Ebizmarts\MailChimp\Helper\Data::IS_SUBSCRIBER
+                );
+            }
             if ($this->_helper->getConfigValue(\Ebizmarts\MailChimp\Helper\Data::XML_PATH_ECOMMERCE_ACTIVE)) {
                 $mailchimpStoreId = $this->_helper->getConfigValue(
                     \Ebizmarts\MailChimp\Helper\Data::XML_MAILCHIMP_STORE,
@@ -66,14 +76,6 @@ class SaveBefore implements \Magento\Framework\Event\ObserverInterface
                     null,
                     null,
                     1
-                );
-            }
-            $subscriber = $this->subscriberFactory->create();
-            $subscriber->loadBySubscriberEmail($customer->getEmail(), $websiteId);
-            if ($subscriber->getEmail() == $customer->getEmail()) {
-                $this->syncHelper->markRegisterAsModified(
-                    $subscriber->getId(),
-                    \Ebizmarts\MailChimp\Helper\Data::IS_SUBSCRIBER
                 );
             }
         }


### PR DESCRIPTION
## Summary

Fixes #2292

The ecommerce cron job processes entities in the following order: `IS_SUBSCRIBER` first, then `IS_CUSTOMER`. However, the `SaveBefore` observer was acquiring locks in the opposite order (`IS_CUSTOMER` then `IS_SUBSCRIBER`). When both processes run concurrently, this creates a classic ABBA deadlock on the `mailchimp_sync_ecommerce` table.

The fix reorders the observer so that the subscriber record is marked as modified before the customer record, matching the cron job's lock-acquisition sequence and eliminating the deadlock condition.

## Changes

- `Observer/Customer/SaveBefore.php`: moved subscriber marking logic ahead of customer marking logic.

## Test plan

- [ ] Save a customer that has an associated subscriber and verify both records are marked as modified correctly.
- [ ] Run the ecommerce cron job concurrently with customer saves and confirm no deadlock errors occur in the database logs.