### PR TITLE
Remove deprecated curl_close calls for PHP 8.5 compatibility

### DIFF
--- a/Model/HTTP/Client/Curl.php
+++ b/Model/HTTP/Client/Curl.php
@@ -415,7 +415,6 @@ class Curl implements \Magento\Framework\HTTP\ClientInterface
         if ($err) {
             $this->doError(curl_error($this->_ch));
         }
-        curl_close($this->_ch);
     }
 
     /**
@@ -428,7 +427,6 @@ class Curl implements \Magento\Framework\HTTP\ClientInterface
     public function doError($string)
     {
         //  phpcs:ignore Magento2.Exceptions.DirectThrow
-        curl_close($this->_ch);
         throw new \Exception($string);
     }
 


### PR DESCRIPTION
## Summary

Fixes #2287

`curl_close` was deprecated in PHP 8.5 and has had no effect since PHP 8.0. Since Magento 2.4 requires PHP >= 8.1, the two calls to `curl_close` in `Model/HTTP/Client/Curl.php` have been removed entirely.

## Changes

- `Model/HTTP/Client/Curl.php`: removed `curl_close($this->_ch)` from the `makeRequest` method and the `doError` method.

## Test plan

- [ ] Verify HTTP requests to the MailChimp API complete successfully.
- [ ] Confirm no PHP deprecation warnings are thrown on PHP 8.5.