### PR TITLE
Closes #2288 for Magento 2.3

### DIFF
--- a/Controller/Adminhtml/Ecommerce/Getaccountdetails.php
+++ b/Controller/Adminhtml/Ecommerce/Getaccountdetails.php
@@ -59,7 +59,7 @@ class Getaccountdetails extends Action
         $scopeId = $param['scopeId'];
         try {
             if ($encrypt == 3) {
-                $api = $this->_helper->getApi($this->_storeManager->getStore()->getId());
+                $api = $this->_helper->getApi($scopeId, $scope);
             } else {
                 $api = $this->_helper->getApiByApiKey($apiKey, $encrypt);
             }

--- a/Cron/Ecommerce.php
+++ b/Cron/Ecommerce.php
@@ -128,8 +128,8 @@ class Ecommerce
         foreach ($this->_storeManager->getStores() as $storeId => $val) {
             if ($this->_helper->getConfigValue(\Ebizmarts\MailChimp\Helper\Data::XML_PATH_ACTIVE, $storeId)) {
                 if (!$this->_ping($storeId)) {
-                    $this->_helper->log('MailChimp is not available');
-                    return;
+                    $this->_helper->log("MailChimp is not available for store $storeId, skipping");
+                    continue;
                 }
                 $this->_storeManager->setCurrentStore($storeId);
                 $listId = $this->_helper->getGeneralList($storeId);

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -700,7 +700,11 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     public function getMCMinSyncDateFlag($storeId = null)
     {
         $syncDate = $this->getConfigValue(self::XML_PATH_IS_SYNC, $storeId);
-        if ($syncDate=='') {
+        // When a per-Mailchimp-store flag has been written under issync/<mailchimpStoreId>
+        // at default scope, this path resolves to an array for any store with no scalar
+        // override of its own. Such a store has not recorded a completion date, so treat
+        // it as "not yet synced" instead of returning the array to the callers.
+        if (is_array($syncDate) || $syncDate === null || $syncDate == '') {
             $syncDate = '1900-01-01';
         }
         return $syncDate;


### PR DESCRIPTION
Backport of the multi-account sync fixes from #2289 (develop-2.4) to `develop-2.3`.

This branch already carried the connect-bug fix (Invalid API Key on additional website scope / Getaccountdetails). These two commits add the remaining fixes found while resolving #2288:

**1. `getMCMinSyncDateFlag()` always returns a scalar — `Helper/Data.php`**
The per-Mailchimp-store flag is saved under `mailchimp/general/issync/<mailchimpStoreId>` at default scope, turning `issync` into a config branch node. Any active store without its own scalar `issync` leaf inherits that branch, so the helper returned an **array** instead of a date string — producing `Array to string conversion` in the scalar consumers (`generatePOSTPayload`, date comparisons, cron gates) and leaving non-default stores unable to build their payloads (stuck "Syncing"). The fix treats an array/null/empty result as "not yet synced" (`1900-01-01`), so the store builds its payloads, completes its initial sync, and writes its own scalar leaf (self-heals).

**2. `_ping` failure skips the store instead of aborting the cron — `Cron/Ecommerce.php`**
A failed `_ping` on one store did a hard `return`, aborting the loop over every remaining store. Changed to `continue` so one unreachable Mailchimp account no longer blocks the others.

The affected code is byte-identical across these release branches, so the ports apply verbatim. Verified end-to-end on develop-2.4 against a 2-website / 2-account install (product, customer and order all synced to the second account with no errors).

Refs #2288. Canonical PR: #2289.