### PR TITLE
Closes #2290 for Magento 2.3

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -14,7 +14,6 @@ namespace Ebizmarts\MailChimp\Helper;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\Exception\ValidatorException;
 use Magento\Store\Model\Store;
-use Symfony\Component\Config\Definition\Exception\Exception;
 use Ebizmarts\MailChimp\Model\MailchimpNotificationFactory as MailchimpNotificationFactory;
 
 class Data extends \Magento\Framework\App\Helper\AbstractHelper


### PR DESCRIPTION
Port of #2291 to the develop-2.3 branch.

Removes the accidental `use Symfony\Component\Config\Definition\Exception\Exception;` import in `Helper/Data.php` so the unqualified `Exception` resolves to the global `\Exception` as intended. This repairs the catch-all fallbacks (e.g. `getSubscriberInterest()` / `deleteStore()`), which previously could not catch standard exceptions such as the `\InvalidArgumentException` thrown by `Json::unserialize` on non-JSON data.

Same one-line fix as #2291 (develop-2.4), applied to develop-2.3. Relates to #2290.