### PR TITLE
closes #2280 Mailchimp Pixel integration for Magento 2.4

### DIFF
--- a/Block/Pixel/Cart.php
+++ b/Block/Pixel/Cart.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Ebizmarts_MailChimp Magento Component
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Block\Pixel;
+
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Magento\Checkout\Model\Session as CheckoutSession;
+use Magento\Framework\View\Element\Template;
+
+/**
+ * Exposes current cart data as JSON for the Mailchimp Pixel JS module.
+ * Rendered on checkout_cart_index pages (cart page).
+ */
+class Cart extends Template
+{
+    /**
+     * @var MailChimpHelper
+     */
+    protected $helper;
+
+    /**
+     * @var CheckoutSession
+     */
+    protected $checkoutSession;
+
+    /**
+     * @param Template\Context $context
+     * @param MailChimpHelper  $helper
+     * @param CheckoutSession  $checkoutSession
+     * @param array            $data
+     */
+    public function __construct(
+        Template\Context $context,
+        MailChimpHelper $helper,
+        CheckoutSession $checkoutSession,
+        array $data = []
+    ) {
+        parent::__construct($context, $data);
+        $this->helper          = $helper;
+        $this->checkoutSession = $checkoutSession;
+    }
+
+    /**
+     * Returns the cart data array for CART_VIEWED payload.
+     *
+     * @return array
+     */
+    public function getCartData(): array
+    {
+        $quote    = $this->checkoutSession->getQuote();
+        $currency = $this->_storeManager->getStore()->getCurrentCurrencyCode();
+
+        $mediaBaseUrl = $this->_urlBuilder->getBaseUrl(
+            ['_type' => \Magento\Framework\UrlInterface::URL_TYPE_MEDIA]
+        );
+
+        $lineItems = [];
+        foreach ($quote->getAllVisibleItems() as $item) {
+            $productId = (string)$item->getProductId();
+            $product   = $item->getProduct();
+            $imageUrl  = '';
+            $productUrl = '';
+            if ($product) {
+                $img = $product->getImage();
+                if ($img && $img !== 'no_selection') {
+                    $imageUrl = $mediaBaseUrl . 'catalog/product' . $img;
+                }
+                $productUrl = (string)$product->getProductUrl();
+            }
+            $lineItems[] = [
+                'item'     => [
+                    'id'         => $productId,
+                    'productId'  => $productId,
+                    'title'      => (string)$item->getName(),
+                    'price'      => (float)$item->getPrice(),
+                    'currency'   => $currency,
+                    'sku'        => (string)$item->getSku(),
+                    'imageUrl'   => $imageUrl,
+                    'productUrl' => $productUrl,
+                    'vendor'     => '',
+                    'categories' => [],
+                ],
+                'quantity' => (int)$item->getQty(),
+                'price'    => (float)($item->getPrice() * $item->getQty()),
+            ];
+        }
+
+        return [
+            'id'         => (string)$quote->getId(),
+            'lineItems'  => $lineItems,
+            'totalPrice' => (float)$quote->getGrandTotal(),
+            'currency'   => $currency,
+        ];
+    }
+
+    /**
+     * Only render when module + pixel are enabled and cart has items.
+     *
+     * @return string
+     */
+    public function _toHtml(): string
+    {
+        $storeId = (int)$this->_storeManager->getStore()->getId();
+        if (!$this->helper->isPixelEnabled($storeId)) {
+            return '';
+        }
+        return parent::_toHtml();
+    }
+}

--- a/Block/Pixel/Category.php
+++ b/Block/Pixel/Category.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Ebizmarts_MailChimp Magento Component
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Block\Pixel;
+
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Magento\Framework\Registry;
+use Magento\Framework\View\Element\Template;
+
+/**
+ * Exposes current category data as JSON for the Mailchimp Pixel JS module.
+ * Rendered on catalog_category_view pages.
+ */
+class Category extends Template
+{
+    /**
+     * @var MailChimpHelper
+     */
+    protected $helper;
+
+    /**
+     * @var Registry
+     */
+    protected $registry;
+
+    /**
+     * @param Template\Context $context
+     * @param MailChimpHelper  $helper
+     * @param Registry         $registry
+     * @param array            $data
+     */
+    public function __construct(
+        Template\Context $context,
+        MailChimpHelper $helper,
+        Registry $registry,
+        array $data = []
+    ) {
+        parent::__construct($context, $data);
+        $this->helper   = $helper;
+        $this->registry = $registry;
+    }
+
+    /**
+     * Returns the current category data for CATEGORY_VIEWED payload.
+     *
+     * @return array
+     */
+    public function getCategoryData(): array
+    {
+        $category = $this->registry->registry('current_category');
+        if (!$category) {
+            return [];
+        }
+
+        return [
+            'categoryId'   => (string)$category->getId(),
+            'categoryName' => (string)$category->getName(),
+        ];
+    }
+
+    /**
+     * Only render when pixel is enabled and a category is available.
+     *
+     * @return string
+     */
+    public function _toHtml(): string
+    {
+        $storeId = (int)$this->_storeManager->getStore()->getId();
+        if (!$this->helper->isPixelEnabled($storeId) || !$this->registry->registry('current_category')) {
+            return '';
+        }
+        return parent::_toHtml();
+    }
+}

--- a/Block/Pixel/Checkout.php
+++ b/Block/Pixel/Checkout.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Ebizmarts_MailChimp Magento Component
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Block\Pixel;
+
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Magento\Checkout\Model\Session as CheckoutSession;
+use Magento\Framework\View\Element\Template;
+
+/**
+ * Exposes checkout data as JSON for the Mailchimp Pixel JS module.
+ * Rendered on checkout_index_index pages (checkout page).
+ */
+class Checkout extends Template
+{
+    /**
+     * @var MailChimpHelper
+     */
+    protected $helper;
+
+    /**
+     * @var CheckoutSession
+     */
+    protected $checkoutSession;
+
+    /**
+     * @param Template\Context $context
+     * @param MailChimpHelper  $helper
+     * @param CheckoutSession  $checkoutSession
+     * @param array            $data
+     */
+    public function __construct(
+        Template\Context $context,
+        MailChimpHelper $helper,
+        CheckoutSession $checkoutSession,
+        array $data = []
+    ) {
+        parent::__construct($context, $data);
+        $this->helper          = $helper;
+        $this->checkoutSession = $checkoutSession;
+    }
+
+    /**
+     * Returns the checkout data array for CHECKOUT_STARTED payload.
+     *
+     * @return array
+     */
+    public function getCheckoutData(): array
+    {
+        $quote    = $this->checkoutSession->getQuote();
+        $currency = $this->_storeManager->getStore()->getCurrentCurrencyCode();
+
+        $mediaBaseUrl = $this->_urlBuilder->getBaseUrl(
+            ['_type' => \Magento\Framework\UrlInterface::URL_TYPE_MEDIA]
+        );
+
+        $lineItems = [];
+        foreach ($quote->getAllVisibleItems() as $item) {
+            $productId  = (string)$item->getProductId();
+            $product    = $item->getProduct();
+            $imageUrl   = '';
+            $productUrl = '';
+            if ($product) {
+                $img = $product->getImage();
+                if ($img && $img !== 'no_selection') {
+                    $imageUrl = $mediaBaseUrl . 'catalog/product' . $img;
+                }
+                $productUrl = (string)$product->getProductUrl();
+            }
+            $lineItems[] = [
+                'item'     => [
+                    'id'         => $productId,
+                    'productId'  => $productId,
+                    'title'      => (string)$item->getName(),
+                    'price'      => (float)$item->getPrice(),
+                    'currency'   => $currency,
+                    'sku'        => (string)$item->getSku(),
+                    'imageUrl'   => $imageUrl,
+                    'productUrl' => $productUrl,
+                    'vendor'     => '',
+                    'categories' => [],
+                ],
+                'quantity' => (int)$item->getQty(),
+                'price'    => (float)($item->getPrice() * $item->getQty()),
+            ];
+        }
+
+        $discounts  = [];
+        $couponCode = $quote->getCouponCode();
+        if ($couponCode) {
+            $discounts[] = [
+                'code'   => $couponCode,
+                'amount' => (float)abs($quote->getShippingAddress()->getDiscountAmount()),
+                'type'   => 'fixed',
+            ];
+        }
+
+        return [
+            'id'            => 'checkout_' . $quote->getId(),
+            'cartId'        => (string)$quote->getId(),
+            'lineItems'     => $lineItems,
+            'subtotalPrice' => (float)$quote->getSubtotal(),
+            'totalTax'      => (float)$quote->getShippingAddress()->getTaxAmount(),
+            'totalShipping' => (float)$quote->getShippingAddress()->getShippingAmount(),
+            'totalPrice'    => (float)$quote->getGrandTotal(),
+            'currency'      => $currency,
+            'discounts'     => $discounts,
+        ];
+    }
+
+    /**
+     * Only render when module + pixel are enabled.
+     *
+     * @return string
+     */
+    public function _toHtml(): string
+    {
+        $storeId = (int)$this->_storeManager->getStore()->getId();
+        if (!$this->helper->isPixelEnabled($storeId)) {
+            return '';
+        }
+        return parent::_toHtml();
+    }
+}

--- a/Block/Pixel/Identity.php
+++ b/Block/Pixel/Identity.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Ebizmarts_MailChimp Magento Component
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Block\Pixel;
+
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Magento\Customer\Model\Session as CustomerSession;
+use Magento\Framework\View\Element\Template;
+
+/**
+ * Resolves the logged-in customer email server-side and emits a minimal
+ * JSON island for the Pixel JS to call identify().
+ *
+ * WHY server-side (not purely client-side):
+ *   Magento's customer-data section is available client-side but requires an
+ *   async XHR on cache-miss. Resolving the email here avoids that race
+ *   condition: the island is present in the initial HTML, so identify() fires
+ *   before any deferred section loads.
+ *
+ *   Only the email is exposed — no other PII. The JS hashes it before
+ *   sending to the Pixel SDK (SHA-256 when SubtleCrypto is available).
+ *
+ * For guest customers identify() is triggered from the checkout email field
+ * blur event in pixel.js (hookCheckoutEmailField), so no server-side data
+ * is needed for that path.
+ */
+class Identity extends Template
+{
+    /**
+     * @var MailChimpHelper
+     */
+    protected $helper;
+
+    /**
+     * @var CustomerSession
+     */
+    protected $customerSession;
+
+    /**
+     * @param Template\Context $context
+     * @param MailChimpHelper  $helper
+     * @param CustomerSession  $customerSession
+     * @param array            $data
+     */
+    public function __construct(
+        Template\Context $context,
+        MailChimpHelper $helper,
+        CustomerSession $customerSession,
+        array $data = []
+    ) {
+        parent::__construct($context, $data);
+        $this->helper          = $helper;
+        $this->customerSession = $customerSession;
+    }
+
+    /**
+     * Returns the identity data for the logged-in customer, or null for guests.
+     *
+     * @return array|null
+     */
+    public function getIdentityData(): ?array
+    {
+        if (!$this->customerSession->isLoggedIn()) {
+            return null;
+        }
+
+        $email = (string)$this->customerSession->getCustomer()->getEmail();
+        if (!$email) {
+            return null;
+        }
+
+        return ['email' => $email];
+    }
+
+    /**
+     * Only render when pixel is enabled and customer is logged in.
+     *
+     * @return string
+     */
+    public function _toHtml(): string
+    {
+        $storeId = (int)$this->_storeManager->getStore()->getId();
+        if (!$this->helper->isPixelEnabled($storeId)) {
+            return '';
+        }
+        if ($this->getIdentityData() === null) {
+            return '';
+        }
+        return parent::_toHtml();
+    }
+}

--- a/Block/Pixel/Order.php
+++ b/Block/Pixel/Order.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Ebizmarts_MailChimp Magento Component
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Block\Pixel;
+
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Checkout\Model\Session as CheckoutSession;
+use Magento\Framework\View\Element\Template;
+
+/**
+ * Exposes completed order data as JSON for the Mailchimp Pixel JS module.
+ * Rendered on checkout_onepage_success pages.
+ */
+class Order extends Template
+{
+    /**
+     * @var MailChimpHelper
+     */
+    protected $helper;
+
+    /**
+     * @var CheckoutSession
+     */
+    protected $checkoutSession;
+
+    /**
+     * @var ProductRepositoryInterface
+     */
+    protected $productRepository;
+
+    /**
+     * @param Template\Context           $context
+     * @param MailChimpHelper            $helper
+     * @param CheckoutSession            $checkoutSession
+     * @param ProductRepositoryInterface $productRepository
+     * @param array                      $data
+     */
+    public function __construct(
+        Template\Context $context,
+        MailChimpHelper $helper,
+        CheckoutSession $checkoutSession,
+        ProductRepositoryInterface $productRepository,
+        array $data = []
+    ) {
+        parent::__construct($context, $data);
+        $this->helper            = $helper;
+        $this->checkoutSession   = $checkoutSession;
+        $this->productRepository = $productRepository;
+    }
+
+    /**
+     * Returns the order data array for PURCHASED payload.
+     *
+     * @return array
+     */
+    public function getOrderData(): array
+    {
+        $order = $this->checkoutSession->getLastRealOrder();
+        if (!$order || !$order->getId()) {
+            return [];
+        }
+
+        $currency     = $order->getOrderCurrencyCode();
+        $mediaBaseUrl = $this->_urlBuilder->getBaseUrl(
+            ['_type' => \Magento\Framework\UrlInterface::URL_TYPE_MEDIA]
+        );
+
+        $lineItems = [];
+        foreach ($order->getAllVisibleItems() as $item) {
+            $productId  = (string)$item->getProductId();
+            $imageUrl   = '';
+            $productUrl = '';
+            try {
+                $product = $this->productRepository->getById((int)$item->getProductId());
+                $img     = $product->getImage();
+                if ($img && $img !== 'no_selection') {
+                    $imageUrl = $mediaBaseUrl . 'catalog/product' . $img;
+                }
+                $productUrl = (string)$product->getProductUrl();
+            } catch (\Exception $e) {
+                // skip — product may have been deleted
+            }
+            $lineItems[] = [
+                'item'     => [
+                    'id'         => $productId,
+                    'productId'  => $productId,
+                    'title'      => (string)$item->getName(),
+                    'price'      => (float)$item->getPrice(),
+                    'currency'   => $currency,
+                    'sku'        => (string)$item->getSku(),
+                    'imageUrl'   => $imageUrl,
+                    'productUrl' => $productUrl,
+                    'vendor'     => '',
+                    'categories' => [],
+                ],
+                'quantity' => (int)$item->getQtyOrdered(),
+                'price'    => (float)$item->getRowTotal(),
+            ];
+        }
+
+        $payload = [
+            'id'            => (string)$order->getIncrementId(),
+            'lineItems'     => $lineItems,
+            'subtotalPrice' => (float)$order->getSubtotal(),
+            'totalTax'      => (float)$order->getTaxAmount(),
+            'totalShipping' => (float)$order->getShippingAmount(),
+            'totalPrice'    => (float)$order->getGrandTotal(),
+            'currency'      => $currency,
+        ];
+
+        if (!$order->getCustomerIsGuest() && $order->getCustomerId()) {
+            $payload['customerId'] = (string)$order->getCustomerId();
+        }
+
+        return $payload;
+    }
+
+    /**
+     * Only render when module + pixel are enabled and order exists.
+     *
+     * @return string
+     */
+    public function _toHtml(): string
+    {
+        $storeId = (int)$this->_storeManager->getStore()->getId();
+        if (!$this->helper->isPixelEnabled($storeId)) {
+            return '';
+        }
+        $order = $this->checkoutSession->getLastRealOrder();
+        if (!$order || !$order->getId()) {
+            return '';
+        }
+        return parent::_toHtml();
+    }
+}

--- a/Block/Pixel/Product.php
+++ b/Block/Pixel/Product.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Ebizmarts_MailChimp Magento Component
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Block\Pixel;
+
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Magento\Catalog\Api\CategoryRepositoryInterface;
+use Magento\Catalog\Model\Product as CatalogProduct;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Registry;
+use Magento\Framework\View\Element\Template;
+
+/**
+ * Exposes current product data as JSON for the Mailchimp Pixel JS module.
+ * Rendered on catalog_product_view pages (PDP).
+ */
+class Product extends Template
+{
+    /**
+     * @var MailChimpHelper
+     */
+    protected $helper;
+
+    /**
+     * @var Registry
+     */
+    protected $registry;
+
+    /**
+     * @var CategoryRepositoryInterface
+     */
+    protected $categoryRepository;
+
+    /**
+     * @param Template\Context            $context
+     * @param MailChimpHelper             $helper
+     * @param Registry                    $registry
+     * @param CategoryRepositoryInterface $categoryRepository
+     * @param array                       $data
+     */
+    public function __construct(
+        Template\Context $context,
+        MailChimpHelper $helper,
+        Registry $registry,
+        CategoryRepositoryInterface $categoryRepository,
+        array $data = []
+    ) {
+        parent::__construct($context, $data);
+        $this->helper             = $helper;
+        $this->registry           = $registry;
+        $this->categoryRepository = $categoryRepository;
+    }
+
+    /**
+     * Returns the current product or null.
+     *
+     * @return CatalogProduct|null
+     */
+    protected function getCurrentProduct(): ?CatalogProduct
+    {
+        return $this->registry->registry('current_product');
+    }
+
+    /**
+     * Returns the product data array for PRODUCT_VIEWED payload.
+     *
+     * @return array
+     */
+    public function getProductData(): array
+    {
+        $product = $this->getCurrentProduct();
+        if (!$product) {
+            return [];
+        }
+
+        $store    = $this->_storeManager->getStore();
+        $currency = $store->getCurrentCurrencyCode();
+
+        $categories = [];
+        foreach ($product->getCategoryIds() as $catId) {
+            try {
+                $cat          = $this->categoryRepository->get($catId, $store->getId());
+                $categories[] = $cat->getName();
+            } catch (NoSuchEntityException $e) {
+                // skip missing category
+            }
+        }
+
+        $imageUrl = '';
+        try {
+            $imageUrl = $this->_urlBuilder->getBaseUrl(['_type' => \Magento\Framework\UrlInterface::URL_TYPE_MEDIA])
+                . 'catalog/product' . $product->getImage();
+        } catch (\Exception $e) {
+            // skip
+        }
+
+        return [
+            'id'         => (string)$product->getId(),
+            'productId'  => (string)$product->getId(),
+            'title'      => $product->getName(),
+            'price'      => (float)$product->getFinalPrice(),
+            'currency'   => $currency,
+            'sku'        => (string)$product->getSku(),
+            'imageUrl'   => $imageUrl,
+            'productUrl' => $product->getProductUrl(),
+            'vendor'     => '',
+            'categories' => $categories,
+        ];
+    }
+
+    /**
+     * Only render when module + pixel are enabled and a product is available.
+     *
+     * @return string
+     */
+    public function _toHtml(): string
+    {
+        $storeId = (int)$this->_storeManager->getStore()->getId();
+        if (!$this->helper->isPixelEnabled($storeId) || !$this->getCurrentProduct()) {
+            return '';
+        }
+        return parent::_toHtml();
+    }
+}

--- a/Block/Pixel/Script.php
+++ b/Block/Pixel/Script.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Ebizmarts_MailChimp Magento Component
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Block\Pixel;
+
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Magento\Framework\View\Element\Template;
+
+/**
+ * Emits the Pixel loader into <head>.
+ *
+ * WHY client-side consent (not server-side):
+ *   If we gate the pixel script server-side inside a FPC-cacheable block,
+ *   FPC picks the consent/no-consent bucket at cache-prime time and freezes
+ *   it. Visitors who accept cookies mid-session hit a cache HIT with the old
+ *   (no-pixel) HTML — the script never loads.
+ *
+ * The solution:
+ *   1. Render ONE consent-NEUTRAL page for everyone (FPC caches a single copy).
+ *   2. Emit a <script type="application/json" id="mc-pixel-config"> island
+ *      with scriptUrl, websiteId, restrictionMode — data only, not executable.
+ *   3. Load consent-loader.js via <script src> from our own domain (CSP-safe).
+ *      That script reads the island and decides whether to inject the pixel
+ *      by checking the real cookie value at runtime.
+ */
+class Script extends Template
+{
+    /**
+     * @var MailChimpHelper
+     */
+    protected $helper;
+
+    /**
+     * @param Template\Context $context
+     * @param MailChimpHelper  $helper
+     * @param array            $data
+     */
+    public function __construct(
+        Template\Context $context,
+        MailChimpHelper $helper,
+        array $data = []
+    ) {
+        parent::__construct($context, $data);
+        $this->helper = $helper;
+    }
+
+    /**
+     * Returns the JSON config island data for the consent-loader.
+     *
+     * @return array|null  null when pixel is not configured for this store
+     */
+    public function getPixelConfig(): ?array
+    {
+        $storeId = (int)$this->_storeManager->getStore()->getId();
+
+        if (!$this->helper->isPixelEnabled($storeId)) {
+            return null;
+        }
+
+        $scriptUrl = $this->helper->getPixelScriptUrl($storeId);
+        if (!$scriptUrl) {
+            return null;
+        }
+
+        $restrictionMode = (bool)$this->_scopeConfig->getValue(
+            'web/cookie/cookie_restriction',
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            $storeId
+        );
+
+        return [
+            'scriptUrl'       => $scriptUrl,
+            'websiteId'       => $this->helper->getWebsiteId($storeId),
+            'restrictionMode' => $restrictionMode,
+            'currencyCode'    => $this->_storeManager->getStore()->getCurrentCurrencyCode(),
+        ];
+    }
+
+    /**
+     * Skip rendering entirely when the pixel is not configured.
+     *
+     * @return string
+     */
+    public function _toHtml(): string
+    {
+        if ($this->getPixelConfig() === null) {
+            return '';
+        }
+        return parent::_toHtml();
+    }
+}

--- a/Block/Pixel/Search.php
+++ b/Block/Pixel/Search.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Ebizmarts_MailChimp Magento Component
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Block\Pixel;
+
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Magento\Framework\View\Element\Template;
+use Magento\Search\Model\QueryFactory;
+
+/**
+ * Exposes search query data as JSON for the Mailchimp Pixel JS module.
+ * Rendered on catalogsearch_result_index pages.
+ */
+class Search extends Template
+{
+    /**
+     * @var MailChimpHelper
+     */
+    protected $helper;
+
+    /**
+     * @var QueryFactory
+     */
+    protected $queryFactory;
+
+    /**
+     * @param Template\Context $context
+     * @param MailChimpHelper  $helper
+     * @param QueryFactory     $queryFactory
+     * @param array            $data
+     */
+    public function __construct(
+        Template\Context $context,
+        MailChimpHelper $helper,
+        QueryFactory $queryFactory,
+        array $data = []
+    ) {
+        parent::__construct($context, $data);
+        $this->helper       = $helper;
+        $this->queryFactory = $queryFactory;
+    }
+
+    /**
+     * Returns search data for SEARCH_SUBMITTED payload.
+     *
+     * @return array
+     */
+    public function getSearchData(): array
+    {
+        $queryText = (string)$this->getRequest()->getParam('q', '');
+        if ($queryText === '') {
+            return [];
+        }
+
+        $resultsCount = (int)$this->queryFactory->get()->getNumResults();
+
+        return [
+            'query'        => $queryText,
+            'resultsCount' => $resultsCount,
+        ];
+    }
+
+    /**
+     * Only render when pixel is enabled and a search query exists.
+     *
+     * @return string
+     */
+    public function _toHtml(): string
+    {
+        $storeId = (int)$this->_storeManager->getStore()->getId();
+        if (!$this->helper->isPixelEnabled($storeId)) {
+            return '';
+        }
+        if (empty($this->getSearchData())) {
+            return '';
+        }
+        return parent::_toHtml();
+    }
+}

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -63,6 +63,10 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     const XML_REGISTER_URL            = 'mailchimp/statistics/register_url';
     const XML_STATISTICS_TOKEN        = 'mailchimp/register/token';
 
+    const XML_PIXEL_ENABLED_FOR_STORE = 'mailchimp/pixel/enabled_for_store';
+    const XML_PIXEL_SCRIPT_URL        = 'mailchimp/pixel/script_url';
+    const XML_PIXEL_SCRIPT_FRAGMENT   = 'mailchimp/pixel/script_fragment';
+
     const ORDER_STATE_OK             = 'complete';
 
     const GUEST_GROUP                = 'NOT LOGGED IN';
@@ -1288,5 +1292,27 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         $properties['currency'] = $quote->getQuoteCurrencyCode();
         $properties['customer_id'] = $quote->getCustomerId();
         $api->lists->members->memberEvent->add($list, $customerMailchimpId, "abandoned_cart_visit",$properties,false,$this->getGmtDate());
+    }
+
+    /**
+     * Returns true when the Mailchimp Pixel is enabled for the given store.
+     *
+     * @param int $storeId
+     * @return bool
+     */
+    public function isPixelEnabled($storeId)
+    {
+        return (bool)$this->getConfigValue(self::XML_PIXEL_ENABLED_FOR_STORE, $storeId);
+    }
+
+    /**
+     * Returns the Pixel SDK script URL saved for the given store.
+     *
+     * @param int $storeId
+     * @return string
+     */
+    public function getPixelScriptUrl($storeId)
+    {
+        return (string)$this->getConfigValue(self::XML_PIXEL_SCRIPT_URL, $storeId);
     }
 }

--- a/Model/Service/Admin/ConnectedSiteProvisioner.php
+++ b/Model/Service/Admin/ConnectedSiteProvisioner.php
@@ -1,0 +1,218 @@
+<?php
+/**
+ * Ebizmarts_MailChimp Magento Component
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Model\Service\Admin;
+
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Ebizmarts\MailChimp\Model\Service\Pixel\PixelStateWriter;
+use Magento\Framework\Exception\LocalizedException;
+
+/**
+ * Provisions the Mailchimp Pixel for a Magento store.
+ *
+ * Strategy (revised):
+ *   The Mailchimp ecommerce store already has a connected site bound to it
+ *   (visible via GET /ecommerce/stores/{id} → connected_site).  That site's
+ *   script URL is what the browser loads (saved in mailchimp/general/mailchimpjsurl)
+ *   and its ID is what the Pixel SDK reports in every tracking event.
+ *   We must call enable-pixel on THAT site, not on a new one we create.
+ *
+ *   Flow:
+ *   1. GET /ecommerce/stores/{mailchimpStoreId}
+ *      → read connected_site.site_foreign_id, site_script.url, site_script.fragment
+ *      If the store already has a bound connected site → use it (preferred path).
+ *
+ *   2. POST /connected-sites { foreign_id, domain }  (only when no bound site)
+ *      → parse foreign_id + site_script.url from response.
+ *      "Already exists" error → fall back to GET /connected-sites/{foreign_id}.
+ *
+ *   3. POST /connected-sites/{foreignId}/actions/enable-pixel
+ *      Always called as long as foreignId is known.
+ *
+ *   4. Persist via PixelStateWriter (url → fragment → enabled_for_store=1).
+ *      Skipped when no new scriptUrl was retrieved (keeps existing DB value).
+ *
+ * Binding semantics (learned in production):
+ *   A connected-site binds to a store only via the auto-nest on creation when
+ *   the host is free. A standalone POST cannot bind store_id afterwards.
+ *   => 1 host = 1 attributing pixel. A second store on the same host gets a
+ *      dead pixel (storeId:0 / CUSTOM). Per-store attribution requires
+ *      per-store hostnames.
+ *
+ * NOTE on API client:
+ *   The ebizmarts/mailchimp-lib does not have a connectedSites sub-client.
+ *   All calls go through $api->call($path, $params, $method) directly.
+ */
+class ConnectedSiteProvisioner
+{
+    /**
+     * @var MailChimpHelper
+     */
+    private $helper;
+
+    /**
+     * @var PixelStateWriter
+     */
+    private $pixelStateWriter;
+
+    /**
+     * @param MailChimpHelper  $helper
+     * @param PixelStateWriter $pixelStateWriter
+     */
+    public function __construct(
+        MailChimpHelper $helper,
+        PixelStateWriter $pixelStateWriter
+    ) {
+        $this->helper           = $helper;
+        $this->pixelStateWriter = $pixelStateWriter;
+    }
+
+    /**
+     * Provision the Pixel for the given Magento store.
+     *
+     * @param int    $storeId          Magento store ID
+     * @param string $mailchimpStoreId Mailchimp ecommerce store ID
+     * @param string $domain           Store domain (e.g. "example.com")
+     * @return void
+     * @throws LocalizedException
+     */
+    public function provision(int $storeId, string $mailchimpStoreId, string $domain): void
+    {
+        $api = $this->helper->getApi($storeId);
+
+        // ── Step 1: resolve foreignId, scriptUrl, fragment ───────────────────
+        //
+        // Preferred: use the connected site already bound to the ecommerce store.
+        // Its foreign_id is what the Pixel SDK will report as mailchimpConnectedSiteId,
+        // so enable-pixel MUST be called on that same site.
+
+        $foreignId      = null;
+        $scriptUrl      = null;
+        $scriptFragment = '';
+
+        [$foreignId, $scriptUrl, $scriptFragment] = $this->resolveFromEcommerceStore($api, $mailchimpStoreId);
+
+        // Fallback: create (or retrieve) a connected site manually.
+        if (!$foreignId) {
+            [$foreignId, $scriptUrl] = $this->resolveFromConnectedSites($api, $mailchimpStoreId, $domain);
+        }
+
+        if (!$foreignId) {
+            throw new LocalizedException(
+                __('Unable to determine connected site for store %1.', $storeId)
+            );
+        }
+
+        // ── Step 2: enable pixel ──────────────────────────────────────────────
+        //
+        // Must be called on the SAME foreignId the SDK reports, otherwise the
+        // /pixel/v1/track endpoint returns 400 Invalid request data.
+        try {
+            $api->call('/connected-sites/' . $foreignId . '/actions/enable-pixel', [], \Mailchimp::POST);
+        } catch (\Mailchimp_Error | \Mailchimp_HttpError $e) {
+            $this->helper->log('ConnectedSiteProvisioner: enable-pixel failed: ' . $e->getMessage());
+        }
+
+        // ── Step 3: persist ───────────────────────────────────────────────────
+        if (!$scriptUrl) {
+            $this->helper->log(
+                'ConnectedSiteProvisioner: no script_url for store ' . $storeId .
+                ' — keeping existing DB value. enable-pixel was still called.'
+            );
+            return;
+        }
+
+        // If fragment was not obtained from the ecommerce store, try the connected site directly.
+        if (!$scriptFragment) {
+            try {
+                $site           = $api->call('/connected-sites/' . $foreignId, [], \Mailchimp::GET);
+                $scriptFragment = $site['site_script']['fragment'] ?? '';
+            } catch (\Mailchimp_Error | \Mailchimp_HttpError $e) {
+                $this->helper->log('ConnectedSiteProvisioner: GET /connected-sites fragment fallback failed: ' . $e->getMessage());
+            }
+        }
+
+        $this->pixelStateWriter->enable($storeId, $scriptUrl, $scriptFragment);
+    }
+
+    /**
+     * Try to read the connected site already bound to the Mailchimp ecommerce store.
+     *
+     * Returns [foreignId, scriptUrl, fragment] or [null, null, ''] when unavailable.
+     *
+     * @param object $api
+     * @param string $mailchimpStoreId
+     * @return array{0: string|null, 1: string|null, 2: string}
+     */
+    private function resolveFromEcommerceStore($api, string $mailchimpStoreId): array
+    {
+        try {
+            $storeData = $api->ecommerce->stores->get($mailchimpStoreId);
+            $foreignId = $storeData['connected_site']['site_foreign_id'] ?? null;
+            $scriptUrl = $storeData['connected_site']['site_script']['url'] ?? null;
+            $fragment  = $storeData['connected_site']['site_script']['fragment'] ?? '';
+
+            if ($foreignId) {
+                return [$foreignId, $scriptUrl, $fragment];
+            }
+        } catch (\Mailchimp_Error | \Mailchimp_HttpError $e) {
+            $this->helper->log('ConnectedSiteProvisioner: GET /ecommerce/stores failed: ' . $e->getMessage());
+        }
+
+        return [null, null, ''];
+    }
+
+    /**
+     * Create (or retrieve) a connected site via the /connected-sites endpoint.
+     *
+     * Returns [foreignId, scriptUrl] or [null, null] when unavailable.
+     *
+     * @param object $api
+     * @param string $mailchimpStoreId
+     * @param string $domain
+     * @return array{0: string|null, 1: string|null}
+     */
+    private function resolveFromConnectedSites($api, string $mailchimpStoreId, string $domain): array
+    {
+        $foreignId = null;
+        $scriptUrl = null;
+
+        try {
+            $response  = $api->call('/connected-sites', [
+                'foreign_id' => $mailchimpStoreId,
+                'domain'     => $domain,
+            ], \Mailchimp::POST);
+            $foreignId = $response['foreign_id'] ?? null;
+            $scriptUrl = $response['site_script']['url'] ?? null;
+        } catch (\Mailchimp_Error | \Mailchimp_HttpError $e) {
+            $this->helper->log('ConnectedSiteProvisioner: POST /connected-sites failed: ' . $e->getMessage());
+        }
+
+        // POST failed (e.g. "already exists") — use mailchimpStoreId as foreign_id
+        // since that is what we passed on creation.
+        if (!$foreignId) {
+            $foreignId = $mailchimpStoreId;
+        }
+
+        if (!$scriptUrl) {
+            try {
+                $site      = $api->call('/connected-sites/' . $foreignId, [], \Mailchimp::GET);
+                $scriptUrl = $site['site_script']['url'] ?? null;
+            } catch (\Mailchimp_Error | \Mailchimp_HttpError $e) {
+                $this->helper->log(
+                    'ConnectedSiteProvisioner: GET /connected-sites/' . $foreignId . ' failed: ' . $e->getMessage()
+                );
+            }
+        }
+
+        return [$foreignId ?: null, $scriptUrl];
+    }
+}

--- a/Model/Service/Admin/ConnectedSiteProvisioner.php
+++ b/Model/Service/Admin/ConnectedSiteProvisioner.php
@@ -122,6 +122,15 @@ class ConnectedSiteProvisioner
         }
 
         // ── Step 3: persist ───────────────────────────────────────────────────
+        // If the API did not return a URL directly, try to extract it from the
+        // fragment (e.g. src="https://chimpstatic.com/...").
+        if (!$scriptUrl && $scriptFragment) {
+            if (preg_match('/src=["\']([^"\']+)["\']/', $scriptFragment, $m)) {
+                $scriptUrl = $m[1];
+                $this->helper->log('ConnectedSiteProvisioner: script_url extracted from fragment: ' . $scriptUrl);
+            }
+        }
+
         if (!$scriptUrl) {
             $this->helper->log(
                 'ConnectedSiteProvisioner: no script_url for store ' . $storeId .

--- a/Model/Service/Pixel/PixelStateWriter.php
+++ b/Model/Service/Pixel/PixelStateWriter.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Ebizmarts_MailChimp Magento Component
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Model\Service\Pixel;
+
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Magento\Framework\App\Config\Storage\WriterInterface;
+use Magento\Framework\App\Cache\TypeListInterface;
+use Magento\Store\Model\ScopeInterface;
+
+/**
+ * Writes Pixel configuration in the correct order to avoid inconsistent state.
+ *
+ * Order matters:
+ *   1. script_url
+ *   2. script_fragment
+ *   3. enabled_for_store = 1  ← LAST, so a failure saving the script never
+ *      leaves the store "enabled but without a script".
+ *
+ * On disable: clear fragment + url, then set enabled_for_store = 0.
+ */
+class PixelStateWriter
+{
+    /**
+     * @var WriterInterface
+     */
+    private $configWriter;
+
+    /**
+     * @var TypeListInterface
+     */
+    private $cacheTypeList;
+
+    /**
+     * @param WriterInterface   $configWriter
+     * @param TypeListInterface $cacheTypeList
+     */
+    public function __construct(
+        WriterInterface $configWriter,
+        TypeListInterface $cacheTypeList
+    ) {
+        $this->configWriter  = $configWriter;
+        $this->cacheTypeList = $cacheTypeList;
+    }
+
+    /**
+     * Enable the Pixel for a store, saving script data before the toggle.
+     *
+     * @param int    $storeId
+     * @param string $scriptUrl
+     * @param string $scriptFragment
+     * @return void
+     */
+    public function enable(int $storeId, string $scriptUrl, string $scriptFragment): void
+    {
+        // 1. url — also keep the legacy mailchimpjsurl in sync so the Mailchimpjs
+        // block (default.xml) loads the same script as the pixel consent-loader.
+        // Without this, two different connected-site scripts load on every page and
+        // the older one initialises the SDK with a stale mailchimpConnectedSiteId.
+        $this->configWriter->save(
+            MailChimpHelper::XML_PIXEL_SCRIPT_URL,
+            $scriptUrl,
+            ScopeInterface::SCOPE_STORES,
+            $storeId
+        );
+        $this->configWriter->save(
+            MailChimpHelper::XML_MAILCHIMP_JS_URL,
+            $scriptUrl,
+            ScopeInterface::SCOPE_STORES,
+            $storeId
+        );
+
+        // 2. fragment
+        $this->configWriter->save(
+            MailChimpHelper::XML_PIXEL_SCRIPT_FRAGMENT,
+            $scriptFragment,
+            ScopeInterface::SCOPE_STORES,
+            $storeId
+        );
+
+        // 3. toggle — always last
+        $this->configWriter->save(
+            MailChimpHelper::XML_PIXEL_ENABLED_FOR_STORE,
+            1,
+            ScopeInterface::SCOPE_STORES,
+            $storeId
+        );
+
+        $this->invalidateConfig();
+    }
+
+    /**
+     * Disable the Pixel for a store, clearing script data before the toggle.
+     *
+     * @param int $storeId
+     * @return void
+     */
+    public function disable(int $storeId): void
+    {
+        $this->configWriter->save(
+            MailChimpHelper::XML_PIXEL_SCRIPT_FRAGMENT,
+            '',
+            ScopeInterface::SCOPE_STORES,
+            $storeId
+        );
+
+        $this->configWriter->save(
+            MailChimpHelper::XML_PIXEL_SCRIPT_URL,
+            '',
+            ScopeInterface::SCOPE_STORES,
+            $storeId
+        );
+
+        $this->configWriter->save(
+            MailChimpHelper::XML_PIXEL_ENABLED_FOR_STORE,
+            0,
+            ScopeInterface::SCOPE_STORES,
+            $storeId
+        );
+
+        $this->invalidateConfig();
+    }
+
+    /**
+     * Invalidate the config cache so changes take effect immediately.
+     *
+     * @return void
+     */
+    private function invalidateConfig(): void
+    {
+        $this->cacheTypeList->invalidate('config');
+    }
+}

--- a/Model/Service/Pixel/PixelStateWriter.php
+++ b/Model/Service/Pixel/PixelStateWriter.php
@@ -136,6 +136,6 @@ class PixelStateWriter
      */
     private function invalidateConfig(): void
     {
-        $this->cacheTypeList->invalidate('config');
+        $this->cacheTypeList->cleanType('config');
     }
 }

--- a/Observer/ConfigObserver.php
+++ b/Observer/ConfigObserver.php
@@ -13,8 +13,11 @@
 
 namespace Ebizmarts\MailChimp\Observer;
 
+use Ebizmarts\MailChimp\Model\Service\Admin\ConnectedSiteProvisioner;
+use Magento\Framework\App\Config\ReinitableConfigInterface;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Event\Observer as EventObserver;
+use Magento\Framework\UrlInterface;
 
 class ConfigObserver implements ObserverInterface
 {
@@ -30,22 +33,35 @@ class ConfigObserver implements ObserverInterface
      * @var \Magento\Framework\Registry
      */
     protected $_registry;
+    /**
+     * @var ConnectedSiteProvisioner
+     */
+    private $connectedSiteProvisioner;
+    /**
+     * @var ReinitableConfigInterface
+     */
+    private $reinitableConfig;
 
     /**
      * ConfigObserver constructor.
      * @param \Magento\Store\Model\StoreManager $storeManager
      * @param \Magento\Framework\Registry $registry
      * @param \Ebizmarts\MailChimp\Helper\Data $helper
+     * @param ConnectedSiteProvisioner $connectedSiteProvisioner
+     * @param ReinitableConfigInterface $reinitableConfig
      */
     public function __construct(
         \Magento\Store\Model\StoreManager $storeManager,
         \Magento\Framework\Registry $registry,
-        \Ebizmarts\MailChimp\Helper\Data $helper
+        \Ebizmarts\MailChimp\Helper\Data $helper,
+        ConnectedSiteProvisioner $connectedSiteProvisioner,
+        ReinitableConfigInterface $reinitableConfig
     ) {
-    
-        $this->_helper          = $helper;
-        $this->_storeManager    = $storeManager;
-        $this->_registry        = $registry;
+        $this->_helper                  = $helper;
+        $this->_storeManager            = $storeManager;
+        $this->_registry                = $registry;
+        $this->connectedSiteProvisioner = $connectedSiteProvisioner;
+        $this->reinitableConfig         = $reinitableConfig;
     }
 
     public function execute(EventObserver $observer)
@@ -66,5 +82,63 @@ class ConfigObserver implements ObserverInterface
 
         $this->_registry->unregister('oldListId');
         $this->_registry->unregister('apiKey');
+
+        $this->provisionPixelIfNeeded();
+    }
+
+    /**
+     * For each store where the pixel toggle was just enabled but the script
+     * fragment has not yet been saved, call the provisioner to retrieve the
+     * script URL/fragment from Mailchimp and persist them.
+     */
+    private function provisionPixelIfNeeded(): void
+    {
+        // Reinitialize config so we read the values the admin just saved.
+        $this->reinitableConfig->reinit();
+
+        foreach ($this->_storeManager->getStores() as $storeId => $store) {
+            $mailchimpStoreId = $this->_helper->getConfigValue(
+                \Ebizmarts\MailChimp\Helper\Data::XML_MAILCHIMP_STORE,
+                $storeId
+            );
+
+            if (!$mailchimpStoreId) {
+                continue;
+            }
+
+            $pixelEnabled = $this->_helper->getConfigValue(
+                \Ebizmarts\MailChimp\Helper\Data::XML_PIXEL_ENABLED_FOR_STORE,
+                $storeId
+            );
+
+            if (!$pixelEnabled) {
+                continue;
+            }
+
+            $scriptFragment = $this->_helper->getConfigValue(
+                \Ebizmarts\MailChimp\Helper\Data::XML_PIXEL_SCRIPT_FRAGMENT,
+                $storeId
+            );
+            $scriptUrl = $this->_helper->getConfigValue(
+                \Ebizmarts\MailChimp\Helper\Data::XML_PIXEL_SCRIPT_URL,
+                $storeId
+            );
+
+            // Skip only when fully provisioned (both fragment and URL are saved).
+            if ($scriptFragment && $scriptUrl) {
+                continue;
+            }
+
+            $baseUrl = $store->getBaseUrl(UrlInterface::URL_TYPE_WEB);
+            $domain  = parse_url($baseUrl, PHP_URL_HOST);
+
+            try {
+                $this->connectedSiteProvisioner->provision((int)$storeId, $mailchimpStoreId, $domain);
+            } catch (\Exception $e) {
+                $this->_helper->log(
+                    'ConfigObserver: pixel provisioning failed for store ' . $storeId . ': ' . $e->getMessage()
+                );
+            }
+        }
     }
 }

--- a/Plugin/Checkout/CustomerData/CartPlugin.php
+++ b/Plugin/Checkout/CustomerData/CartPlugin.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Ebizmarts_MailChimp Magento Component
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Plugin\Checkout\CustomerData;
+
+use Magento\Checkout\CustomerData\Cart;
+use Magento\Checkout\Model\Session as CheckoutSession;
+
+/**
+ * Adds cart_id and currency_code to the cart customer-data section so the
+ * Mailchimp Pixel JS can include them in PRODUCT_ADDED_TO_CART payloads.
+ */
+class CartPlugin
+{
+    /**
+     * @var CheckoutSession
+     */
+    private $checkoutSession;
+
+    /**
+     * @param CheckoutSession $checkoutSession
+     */
+    public function __construct(CheckoutSession $checkoutSession)
+    {
+        $this->checkoutSession = $checkoutSession;
+    }
+
+    /**
+     * @param Cart  $subject
+     * @param array $result
+     * @return array
+     */
+    public function afterGetSectionData(Cart $subject, array $result): array
+    {
+        try {
+            $quote = $this->checkoutSession->getQuote();
+            $result['cart_id']      = $quote ? (string)$quote->getId() : '';
+            $result['currency_code'] = $quote ? (string)$quote->getQuoteCurrencyCode() : '';
+        } catch (\Exception $e) {
+            $result['cart_id']      = '';
+            $result['currency_code'] = '';
+        }
+
+        return $result;
+    }
+}

--- a/Test/Unit/Block/Pixel/CartTest.php
+++ b/Test/Unit/Block/Pixel/CartTest.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Ebizmarts_MailChimp
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Test\Unit\Block\Pixel;
+
+use Ebizmarts\MailChimp\Block\Pixel\Cart;
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Magento\Checkout\Model\Session as CheckoutSession;
+use Magento\Framework\DataObject;
+use Magento\Framework\View\Element\Template;
+use Magento\Store\Model\Store;
+use Magento\Store\Model\StoreManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+class CartTest extends TestCase
+{
+    /**
+     * Uses DataObject to avoid fighting magic-getter mocking on QuoteItem.
+     */
+    private function makeItem(
+        string $productId,
+        string $name,
+        float $price,
+        string $sku,
+        int $qty
+    ): DataObject {
+        return new DataObject([
+            'product_id' => $productId,
+            'name'       => $name,
+            'price'      => $price,
+            'sku'        => $sku,
+            'qty'        => $qty,
+        ]);
+    }
+
+    private function makeBlock(array $items, float $grandTotal, string $quoteId, string $currency = 'USD'): Cart
+    {
+        // getId & getAllVisibleItems are declared on Quote; getGrandTotal is magic.
+        $quote = $this->getMockBuilder(\Magento\Quote\Model\Quote::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getId', 'getAllVisibleItems'])
+            ->addMethods(['getGrandTotal'])
+            ->getMock();
+        $quote->method('getId')->willReturn($quoteId);
+        $quote->method('getGrandTotal')->willReturn($grandTotal);
+        $quote->method('getAllVisibleItems')->willReturn($items);
+
+        $store = $this->createMock(Store::class);
+        $store->method('getCurrentCurrencyCode')->willReturn($currency);
+
+        $storeManager = $this->createMock(StoreManagerInterface::class);
+        $storeManager->method('getStore')->willReturn($store);
+
+        $checkoutSession = $this->createMock(CheckoutSession::class);
+        $checkoutSession->method('getQuote')->willReturn($quote);
+
+        $context = $this->getMockBuilder(Template\Context::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $context->method('getStoreManager')->willReturn($storeManager);
+
+        $helper = $this->createMock(MailChimpHelper::class);
+
+        return new Cart($context, $helper, $checkoutSession);
+    }
+
+    public function testGetCartDataStructure(): void
+    {
+        $item   = $this->makeItem('10', 'Blue Widget', 29.99, 'WIDG-BLU', 2);
+        $block  = $this->makeBlock([$item], 59.98, '42', 'EUR');
+        $result = $block->getCartData();
+
+        $this->assertSame('42', $result['id']);
+        $this->assertSame(59.98, $result['totalPrice']);
+        $this->assertSame('EUR', $result['currency']);
+        $this->assertCount(1, $result['lineItems']);
+    }
+
+    public function testGetCartDataLineItemFields(): void
+    {
+        $item     = $this->makeItem('10', 'Blue Widget', 29.99, 'WIDG-BLU', 2);
+        $block    = $this->makeBlock([$item], 59.98, '42');
+        $lineItem = $block->getCartData()['lineItems'][0];
+
+        $this->assertSame('10', $lineItem['item']['id']);
+        $this->assertSame('Blue Widget', $lineItem['item']['title']);
+        $this->assertSame(29.99, $lineItem['item']['price']);
+        $this->assertSame('WIDG-BLU', $lineItem['item']['sku']);
+        $this->assertSame(2, $lineItem['quantity']);
+        $this->assertSame(59.98, $lineItem['price']); // price * qty
+    }
+
+    public function testGetCartDataWithEmptyCart(): void
+    {
+        $block  = $this->makeBlock([], 0.0, '99');
+        $result = $block->getCartData();
+
+        $this->assertSame([], $result['lineItems']);
+        $this->assertSame(0.0, $result['totalPrice']);
+    }
+
+    public function testGetCartDataLineItemPriceIsQtyMultiplied(): void
+    {
+        $item     = $this->makeItem('5', 'Shoe', 50.0, 'SHOE-1', 3);
+        $block    = $this->makeBlock([$item], 150.0, '1');
+        $lineItem = $block->getCartData()['lineItems'][0];
+
+        $this->assertSame(150.0, $lineItem['price']); // 50 * 3
+    }
+}

--- a/Test/Unit/Block/Pixel/CategoryTest.php
+++ b/Test/Unit/Block/Pixel/CategoryTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Ebizmarts_MailChimp
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Test\Unit\Block\Pixel;
+
+use Ebizmarts\MailChimp\Block\Pixel\Category;
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Magento\Framework\Registry;
+use Magento\Framework\View\Element\Template;
+use PHPUnit\Framework\TestCase;
+
+class CategoryTest extends TestCase
+{
+    private function makeBlock(?object $category): Category
+    {
+        $registry = $this->createMock(Registry::class);
+        $registry->method('registry')
+            ->with('current_category')
+            ->willReturn($category);
+
+        $context = $this->getMockBuilder(Template\Context::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $helper = $this->createMock(MailChimpHelper::class);
+
+        return new Category($context, $helper, $registry);
+    }
+
+    private function makeCategory(string $id, string $name, string $url): object
+    {
+        $category = $this->getMockBuilder(\Magento\Catalog\Model\Category::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $category->method('getId')->willReturn($id);
+        $category->method('getName')->willReturn($name);
+        $category->method('getUrl')->willReturn($url);
+
+        return $category;
+    }
+
+    public function testGetCategoryDataReturnsCorrectStructure(): void
+    {
+        $category = $this->makeCategory('5', 'Women', 'https://example.com/women');
+        $block    = $this->makeBlock($category);
+
+        $result = $block->getCategoryData();
+
+        $this->assertSame('5', $result['id']);
+        $this->assertSame('Women', $result['name']);
+        $this->assertSame('https://example.com/women', $result['url']);
+    }
+
+    public function testGetCategoryDataReturnsEmptyArrayWhenNoCategory(): void
+    {
+        $block = $this->makeBlock(null);
+
+        $this->assertSame([], $block->getCategoryData());
+    }
+
+    public function testGetCategoryDataCastsFieldsToString(): void
+    {
+        $category = $this->makeCategory(12, 'Sale', 'https://example.com/sale');
+        $block    = $this->makeBlock($category);
+
+        $result = $block->getCategoryData();
+
+        $this->assertIsString($result['id']);
+        $this->assertIsString($result['name']);
+        $this->assertIsString($result['url']);
+    }
+}

--- a/Test/Unit/Block/Pixel/CheckoutTest.php
+++ b/Test/Unit/Block/Pixel/CheckoutTest.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Ebizmarts_MailChimp
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Test\Unit\Block\Pixel;
+
+use Ebizmarts\MailChimp\Block\Pixel\Checkout;
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Magento\Checkout\Model\Session as CheckoutSession;
+use Magento\Framework\DataObject;
+use Magento\Framework\View\Element\Template;
+use Magento\Store\Model\Store;
+use Magento\Store\Model\StoreManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+class CheckoutTest extends TestCase
+{
+    /**
+     * Builds a quote mock.
+     *
+     * On Quote: getId & getShippingAddress are declared; the rest are magic.
+     */
+    private function makeQuote(
+        string $id,
+        array $items,
+        float $subtotal,
+        float $grandTotal,
+        ?string $couponCode,
+        float $tax,
+        float $shipping,
+        float $discountAmount
+    ): \Magento\Quote\Model\Quote {
+        $address = $this->getMockBuilder(\Magento\Quote\Model\Quote\Address::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['getTaxAmount', 'getShippingAmount', 'getDiscountAmount'])
+            ->getMock();
+        $address->method('getTaxAmount')->willReturn($tax);
+        $address->method('getShippingAmount')->willReturn($shipping);
+        $address->method('getDiscountAmount')->willReturn(-$discountAmount); // Magento stores as negative
+
+        $quote = $this->getMockBuilder(\Magento\Quote\Model\Quote::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getId', 'getAllVisibleItems', 'getShippingAddress'])
+            ->addMethods(['getSubtotal', 'getGrandTotal', 'getCouponCode'])
+            ->getMock();
+        $quote->method('getId')->willReturn($id);
+        $quote->method('getAllVisibleItems')->willReturn($items);
+        $quote->method('getShippingAddress')->willReturn($address);
+        $quote->method('getSubtotal')->willReturn($subtotal);
+        $quote->method('getGrandTotal')->willReturn($grandTotal);
+        $quote->method('getCouponCode')->willReturn($couponCode);
+
+        return $quote;
+    }
+
+    private function makeBlock(\Magento\Quote\Model\Quote $quote, string $currency = 'USD'): Checkout
+    {
+        $store = $this->createMock(Store::class);
+        $store->method('getCurrentCurrencyCode')->willReturn($currency);
+
+        $storeManager = $this->createMock(StoreManagerInterface::class);
+        $storeManager->method('getStore')->willReturn($store);
+
+        $checkoutSession = $this->createMock(CheckoutSession::class);
+        $checkoutSession->method('getQuote')->willReturn($quote);
+
+        $context = $this->getMockBuilder(Template\Context::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $context->method('getStoreManager')->willReturn($storeManager);
+
+        $helper = $this->createMock(MailChimpHelper::class);
+
+        return new Checkout($context, $helper, $checkoutSession);
+    }
+
+    public function testGetCheckoutDataStructure(): void
+    {
+        $quote = $this->makeQuote('5', [], 100.0, 115.0, null, 10.0, 5.0, 0.0);
+        $block = $this->makeBlock($quote, 'GBP');
+
+        $result = $block->getCheckoutData();
+
+        $this->assertSame('5', $result['id']);
+        $this->assertSame('5', $result['cartId']);
+        $this->assertSame('GBP', $result['currency']);
+        $this->assertSame(100.0, $result['subtotalPrice']);
+        $this->assertSame(10.0, $result['totalTax']);
+        $this->assertSame(5.0, $result['totalShipping']);
+        $this->assertSame(115.0, $result['totalPrice']);
+        $this->assertSame([], $result['discounts']);
+    }
+
+    public function testGetCheckoutDataIncludesDiscountWhenCouponApplied(): void
+    {
+        $quote = $this->makeQuote('6', [], 100.0, 90.0, 'SAVE10', 0.0, 0.0, 10.0);
+        $block = $this->makeBlock($quote);
+
+        $discounts = $block->getCheckoutData()['discounts'];
+
+        $this->assertCount(1, $discounts);
+        $this->assertSame('SAVE10', $discounts[0]['code']);
+        $this->assertSame(10.0, $discounts[0]['amount']);
+        $this->assertSame('fixed', $discounts[0]['type']);
+    }
+
+    public function testGetCheckoutDataNoDiscountsWhenNoCoupon(): void
+    {
+        $quote = $this->makeQuote('7', [], 50.0, 50.0, null, 0.0, 0.0, 0.0);
+        $block = $this->makeBlock($quote);
+
+        $this->assertSame([], $block->getCheckoutData()['discounts']);
+    }
+
+    public function testGetCheckoutDataWithLineItems(): void
+    {
+        $item  = new DataObject([
+            'product_id' => '99',
+            'name'       => 'Sneaker',
+            'price'      => 60.0,
+            'sku'        => 'SNKR-1',
+            'qty'        => 1,
+        ]);
+        $quote = $this->makeQuote('8', [$item], 60.0, 60.0, null, 0.0, 0.0, 0.0);
+        $block = $this->makeBlock($quote);
+
+        $lineItems = $block->getCheckoutData()['lineItems'];
+
+        $this->assertCount(1, $lineItems);
+        $this->assertSame('99', $lineItems[0]['item']['id']);
+        $this->assertSame('Sneaker', $lineItems[0]['item']['title']);
+        $this->assertSame(60.0, $lineItems[0]['item']['price']);
+        $this->assertSame(1, $lineItems[0]['quantity']);
+    }
+}

--- a/Test/Unit/Block/Pixel/IdentityTest.php
+++ b/Test/Unit/Block/Pixel/IdentityTest.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Ebizmarts_MailChimp
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Test\Unit\Block\Pixel;
+
+use Ebizmarts\MailChimp\Block\Pixel\Identity;
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Magento\Customer\Model\Session as CustomerSession;
+use Magento\Framework\DataObject;
+use Magento\Framework\View\Element\Template;
+use PHPUnit\Framework\TestCase;
+
+class IdentityTest extends TestCase
+{
+    private function makeBlock(bool $isLoggedIn, string $email = ''): Identity
+    {
+        // Use DataObject to avoid mocking magic getEmail() on Customer model
+        $customer = new DataObject(['email' => $email]);
+
+        $customerSession = $this->createMock(CustomerSession::class);
+        $customerSession->method('isLoggedIn')->willReturn($isLoggedIn);
+        $customerSession->method('getCustomer')->willReturn($customer);
+
+        $context = $this->getMockBuilder(Template\Context::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $helper = $this->createMock(MailChimpHelper::class);
+
+        return new Identity($context, $helper, $customerSession);
+    }
+
+    public function testGetIdentityDataReturnsEmailForLoggedInCustomer(): void
+    {
+        $block  = $this->makeBlock(true, 'customer@example.com');
+        $result = $block->getIdentityData();
+
+        $this->assertNotNull($result);
+        $this->assertSame('customer@example.com', $result['email']);
+    }
+
+    public function testGetIdentityDataReturnsNullForGuest(): void
+    {
+        $this->assertNull($this->makeBlock(false)->getIdentityData());
+    }
+
+    public function testGetIdentityDataReturnsNullWhenEmailIsEmpty(): void
+    {
+        $this->assertNull($this->makeBlock(true, '')->getIdentityData());
+    }
+
+    public function testGetIdentityDataEmailIsString(): void
+    {
+        $result = $this->makeBlock(true, 'user@example.com')->getIdentityData();
+
+        $this->assertIsString($result['email']);
+    }
+}

--- a/Test/Unit/Block/Pixel/OrderTest.php
+++ b/Test/Unit/Block/Pixel/OrderTest.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Ebizmarts_MailChimp
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Test\Unit\Block\Pixel;
+
+use Ebizmarts\MailChimp\Block\Pixel\Order;
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Magento\Checkout\Model\Session as CheckoutSession;
+use Magento\Framework\DataObject;
+use Magento\Framework\View\Element\Template;
+use Magento\Sales\Model\Order as SalesOrder;
+use PHPUnit\Framework\TestCase;
+
+class OrderTest extends TestCase
+{
+    /**
+     * Uses DataObject to avoid fighting magic-getter mocking on OrderItem.
+     */
+    private function makeItem(
+        string $productId,
+        string $name,
+        float $price,
+        string $sku,
+        float $qtyOrdered,
+        float $rowTotal
+    ): DataObject {
+        return new DataObject([
+            'product_id'   => $productId,
+            'name'         => $name,
+            'price'        => $price,
+            'sku'          => $sku,
+            'qty_ordered'  => $qtyOrdered,
+            'row_total'    => $rowTotal,
+        ]);
+    }
+
+    private function makeBlock(?SalesOrder $order): Order
+    {
+        $checkoutSession = $this->createMock(CheckoutSession::class);
+        $checkoutSession->method('getLastRealOrder')->willReturn($order);
+
+        $context = $this->getMockBuilder(Template\Context::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $helper = $this->createMock(MailChimpHelper::class);
+
+        return new Order($context, $helper, $checkoutSession);
+    }
+
+    // All methods listed here ARE declared on Sales\Order (confirmed via reflection)
+    private function makeOrder(
+        ?string $id,
+        string $incrementId,
+        string $currency,
+        float $subtotal,
+        float $tax,
+        float $shipping,
+        float $grandTotal,
+        array $items,
+        bool $isGuest = true,
+        ?string $customerId = null
+    ): SalesOrder {
+        $order = $this->getMockBuilder(SalesOrder::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'getId', 'getIncrementId', 'getOrderCurrencyCode',
+                'getSubtotal', 'getTaxAmount', 'getShippingAmount', 'getGrandTotal',
+                'getAllVisibleItems', 'getCustomerIsGuest', 'getCustomerId',
+            ])
+            ->getMock();
+        $order->method('getId')->willReturn($id);
+        $order->method('getIncrementId')->willReturn($incrementId);
+        $order->method('getOrderCurrencyCode')->willReturn($currency);
+        $order->method('getSubtotal')->willReturn($subtotal);
+        $order->method('getTaxAmount')->willReturn($tax);
+        $order->method('getShippingAmount')->willReturn($shipping);
+        $order->method('getGrandTotal')->willReturn($grandTotal);
+        $order->method('getAllVisibleItems')->willReturn($items);
+        $order->method('getCustomerIsGuest')->willReturn($isGuest);
+        $order->method('getCustomerId')->willReturn($customerId);
+
+        return $order;
+    }
+
+    public function testGetOrderDataReturnsEmptyArrayWhenNoOrderId(): void
+    {
+        $order = $this->makeOrder(null, '', 'USD', 0, 0, 0, 0, []);
+        $block = $this->makeBlock($order);
+
+        $this->assertSame([], $block->getOrderData());
+    }
+
+    public function testGetOrderDataStructureForGuestOrder(): void
+    {
+        $item  = $this->makeItem('20', 'Red Hat', 19.99, 'HAT-RED', 1, 19.99);
+        $order = $this->makeOrder('1', '100000042', 'USD', 19.99, 1.60, 5.00, 26.59, [$item]);
+        $block = $this->makeBlock($order);
+
+        $result = $block->getOrderData();
+
+        $this->assertSame('100000042', $result['id']);
+        $this->assertSame('USD', $result['currency']);
+        $this->assertSame(19.99, $result['subtotalPrice']);
+        $this->assertSame(1.60, $result['totalTax']);
+        $this->assertSame(5.00, $result['totalShipping']);
+        $this->assertSame(26.59, $result['totalPrice']);
+        $this->assertCount(1, $result['lineItems']);
+        $this->assertArrayNotHasKey('customerId', $result);
+    }
+
+    public function testGetOrderDataIncludesCustomerIdForLoggedInCustomer(): void
+    {
+        $order = $this->makeOrder('2', '100000043', 'EUR', 50.0, 4.0, 5.0, 59.0, [], false, '77');
+        $block = $this->makeBlock($order);
+
+        $result = $block->getOrderData();
+
+        $this->assertSame('77', $result['customerId']);
+    }
+
+    public function testGetOrderDataLineItemFields(): void
+    {
+        $item  = $this->makeItem('15', 'Blue Jeans', 49.99, 'JEAN-BLU', 2, 99.98);
+        $order = $this->makeOrder('3', '100000044', 'USD', 99.98, 8.0, 5.0, 112.98, [$item]);
+        $block = $this->makeBlock($order);
+
+        $lineItem = $block->getOrderData()['lineItems'][0];
+
+        $this->assertSame('15', $lineItem['item']['id']);
+        $this->assertSame('Blue Jeans', $lineItem['item']['title']);
+        $this->assertSame(49.99, $lineItem['item']['price']);
+        $this->assertSame('JEAN-BLU', $lineItem['item']['sku']);
+        $this->assertSame(2, $lineItem['quantity']);
+        $this->assertSame(99.98, $lineItem['price']);
+    }
+
+    public function testGetOrderDataNoCustomerIdForGuestWithNullId(): void
+    {
+        $order = $this->makeOrder('4', '100000045', 'USD', 10.0, 0.0, 0.0, 10.0, [], true, null);
+        $block = $this->makeBlock($order);
+
+        $this->assertArrayNotHasKey('customerId', $block->getOrderData());
+    }
+}

--- a/Test/Unit/Block/Pixel/ProductTest.php
+++ b/Test/Unit/Block/Pixel/ProductTest.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Ebizmarts_MailChimp
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Test\Unit\Block\Pixel;
+
+use Ebizmarts\MailChimp\Block\Pixel\Product;
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Magento\Catalog\Api\CategoryRepositoryInterface;
+use Magento\Catalog\Model\Category as CatalogCategory;
+use Magento\Catalog\Model\Product as CatalogProduct;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Registry;
+use Magento\Framework\UrlInterface;
+use Magento\Framework\View\Element\Template;
+use Magento\Store\Model\Store;
+use Magento\Store\Model\StoreManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+class ProductTest extends TestCase
+{
+    private function makeBlock(
+        ?CatalogProduct $product,
+        string $currency = 'USD',
+        string $baseUrl = 'https://example.com/',
+        array $categoryMap = []
+    ): Product {
+        $registry = $this->createMock(Registry::class);
+        $registry->method('registry')
+            ->with('current_product')
+            ->willReturn($product);
+
+        $store = $this->createMock(Store::class);
+        $store->method('getCurrentCurrencyCode')->willReturn($currency);
+        $store->method('getId')->willReturn(1);
+
+        $storeManager = $this->createMock(StoreManagerInterface::class);
+        $storeManager->method('getStore')->willReturn($store);
+
+        $urlBuilder = $this->createMock(UrlInterface::class);
+        $urlBuilder->method('getBaseUrl')->willReturn($baseUrl);
+
+        $categoryRepo = $this->createMock(CategoryRepositoryInterface::class);
+        $categoryRepo->method('get')
+            ->willReturnCallback(function (int $id) use ($categoryMap) {
+                if (!isset($categoryMap[$id])) {
+                    throw new NoSuchEntityException();
+                }
+                $cat = $this->createMock(CatalogCategory::class);
+                $cat->method('getName')->willReturn($categoryMap[$id]);
+
+                return $cat;
+            });
+
+        $context = $this->getMockBuilder(Template\Context::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $context->method('getStoreManager')->willReturn($storeManager);
+        $context->method('getUrlBuilder')->willReturn($urlBuilder);
+
+        $helper = $this->createMock(MailChimpHelper::class);
+
+        return new Product($context, $helper, $registry, $categoryRepo);
+    }
+
+    private function makeProduct(
+        string $id,
+        string $name,
+        float $price,
+        string $sku,
+        string $image,
+        string $url,
+        array $categoryIds = []
+    ): CatalogProduct {
+        $product = $this->getMockBuilder(CatalogProduct::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $product->method('getId')->willReturn($id);
+        $product->method('getName')->willReturn($name);
+        $product->method('getFinalPrice')->willReturn($price);
+        $product->method('getSku')->willReturn($sku);
+        $product->method('getImage')->willReturn($image);
+        $product->method('getProductUrl')->willReturn($url);
+        $product->method('getCategoryIds')->willReturn($categoryIds);
+
+        return $product;
+    }
+
+    public function testGetProductDataReturnsEmptyArrayWhenNoProduct(): void
+    {
+        $block = $this->makeBlock(null);
+
+        $this->assertSame([], $block->getProductData());
+    }
+
+    public function testGetProductDataReturnsCorrectFields(): void
+    {
+        $product = $this->makeProduct(
+            '42', 'Running Shoes', 89.99, 'SHOE-RUN-42',
+            '/s/shoe.jpg', 'https://example.com/running-shoes'
+        );
+        $block = $this->makeBlock($product, 'USD', 'https://example.com/');
+
+        $result = $block->getProductData();
+
+        $this->assertSame('42', $result['id']);
+        $this->assertSame('Running Shoes', $result['title']);
+        $this->assertSame(89.99, $result['price']);
+        $this->assertSame('USD', $result['currency']);
+        $this->assertSame('SHOE-RUN-42', $result['sku']);
+        $this->assertSame('https://example.com/running-shoes', $result['productUrl']);
+        $this->assertIsArray($result['categories']);
+    }
+
+    public function testGetProductDataBuildsImageUrl(): void
+    {
+        $product = $this->makeProduct('1', 'Hat', 20.0, 'HAT-1', '/h/hat.jpg', '');
+        $block   = $this->makeBlock($product, 'USD', 'https://example.com/');
+
+        $result = $block->getProductData();
+
+        $this->assertSame('https://example.com/catalog/product/h/hat.jpg', $result['imageUrl']);
+    }
+
+    public function testGetProductDataResolvesCategoryNames(): void
+    {
+        $product = $this->makeProduct('2', 'Jacket', 120.0, 'JACK-1', '/j/j.jpg', '', [3, 7]);
+        $block   = $this->makeBlock($product, 'USD', 'https://example.com/', [3 => 'Outerwear', 7 => 'Men']);
+
+        $result = $block->getProductData();
+
+        $this->assertContains('Outerwear', $result['categories']);
+        $this->assertContains('Men', $result['categories']);
+    }
+
+    public function testGetProductDataSkipsMissingCategories(): void
+    {
+        // Category 99 is not in the map → NoSuchEntityException → skipped
+        $product = $this->makeProduct('3', 'Gloves', 25.0, 'GLV-1', '/g/g.jpg', '', [99]);
+        $block   = $this->makeBlock($product, 'USD', 'https://example.com/', []);
+
+        $result = $block->getProductData();
+
+        $this->assertSame([], $result['categories']);
+    }
+
+    public function testGetProductDataTypeCasts(): void
+    {
+        $product = $this->makeProduct('10', 'Bag', 45.0, 'BAG-1', '/b/b.jpg', '');
+        $block   = $this->makeBlock($product);
+
+        $result = $block->getProductData();
+
+        $this->assertIsString($result['id']);
+        $this->assertIsFloat($result['price']);
+        $this->assertIsString($result['sku']);
+    }
+}

--- a/Test/Unit/Block/Pixel/ScriptTest.php
+++ b/Test/Unit/Block/Pixel/ScriptTest.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Ebizmarts_MailChimp
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Test\Unit\Block\Pixel;
+
+use Ebizmarts\MailChimp\Block\Pixel\Script;
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\View\Element\Template;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Store\Model\Store;
+use Magento\Store\Model\StoreManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+class ScriptTest extends TestCase
+{
+    private function makeBlock(
+        bool $pixelEnabled,
+        string $scriptUrl,
+        int $websiteId,
+        bool $cookieRestriction
+    ): Script {
+        $store = $this->createMock(Store::class);
+        $store->method('getId')->willReturn(1);
+        $store->method('getWebsiteId')->willReturn($websiteId);
+
+        $storeManager = $this->createMock(StoreManagerInterface::class);
+        $storeManager->method('getStore')->willReturn($store);
+
+        $scopeConfig = $this->createMock(ScopeConfigInterface::class);
+        $scopeConfig->method('getValue')
+            ->with('web/cookie/cookie_restriction', ScopeInterface::SCOPE_STORE, 1)
+            ->willReturn($cookieRestriction ? '1' : '0');
+
+        $helper = $this->createMock(MailChimpHelper::class);
+        $helper->method('isPixelEnabled')->with(1)->willReturn($pixelEnabled);
+        $helper->method('getPixelScriptUrl')->with(1)->willReturn($scriptUrl);
+        $helper->method('getWebsiteId')->with(1)->willReturn($websiteId);
+
+        $context = $this->getMockBuilder(Template\Context::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $context->method('getStoreManager')->willReturn($storeManager);
+        $context->method('getScopeConfig')->willReturn($scopeConfig);
+
+        return new Script($context, $helper);
+    }
+
+    public function testGetPixelConfigReturnsNullWhenPixelDisabled(): void
+    {
+        $block = $this->makeBlock(false, 'https://example.com/pixel.js', 1, false);
+
+        $this->assertNull($block->getPixelConfig());
+    }
+
+    public function testGetPixelConfigReturnsNullWhenScriptUrlEmpty(): void
+    {
+        $block = $this->makeBlock(true, '', 1, false);
+
+        $this->assertNull($block->getPixelConfig());
+    }
+
+    public function testGetPixelConfigReturnsCorrectStructure(): void
+    {
+        $block  = $this->makeBlock(true, 'https://chimpstatic.com/pixel.js', 3, false);
+        $result = $block->getPixelConfig();
+
+        $this->assertNotNull($result);
+        $this->assertSame('https://chimpstatic.com/pixel.js', $result['scriptUrl']);
+        $this->assertSame(3, $result['websiteId']);
+        $this->assertFalse($result['restrictionMode']);
+    }
+
+    public function testGetPixelConfigReflectsCookieRestrictionMode(): void
+    {
+        $block  = $this->makeBlock(true, 'https://chimpstatic.com/pixel.js', 1, true);
+        $result = $block->getPixelConfig();
+
+        $this->assertTrue($result['restrictionMode']);
+    }
+
+    public function testGetPixelConfigWebsiteIdIsInteger(): void
+    {
+        $block  = $this->makeBlock(true, 'https://chimpstatic.com/pixel.js', 5, false);
+        $result = $block->getPixelConfig();
+
+        $this->assertIsInt($result['websiteId']);
+    }
+}

--- a/Test/Unit/Block/Pixel/SearchTest.php
+++ b/Test/Unit/Block/Pixel/SearchTest.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Ebizmarts_MailChimp
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Test\Unit\Block\Pixel;
+
+use Ebizmarts\MailChimp\Block\Pixel\Search;
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\View\Element\Template;
+use PHPUnit\Framework\TestCase;
+
+class SearchTest extends TestCase
+{
+    private function makeBlock(string $queryParam): Search
+    {
+        $request = $this->createMock(RequestInterface::class);
+        $request->method('getParam')
+            ->with('q', '')
+            ->willReturn($queryParam);
+
+        $context = $this->getMockBuilder(Template\Context::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $context->method('getRequest')->willReturn($request);
+
+        $helper = $this->createMock(MailChimpHelper::class);
+
+        return new Search($context, $helper);
+    }
+
+    public function testGetSearchDataReturnsQueryWhenPresent(): void
+    {
+        $block = $this->makeBlock('red shoes');
+
+        $this->assertSame(['query' => 'red shoes'], $block->getSearchData());
+    }
+
+    public function testGetSearchDataReturnsEmptyArrayWhenNoQuery(): void
+    {
+        $block = $this->makeBlock('');
+
+        $this->assertSame([], $block->getSearchData());
+    }
+
+    public function testGetSearchDataPreservesQueryAsString(): void
+    {
+        $block = $this->makeBlock('boots & shoes');
+
+        $result = $block->getSearchData();
+
+        $this->assertSame('boots & shoes', $result['query']);
+    }
+}

--- a/Test/Unit/Model/Service/Pixel/PixelStateWriterTest.php
+++ b/Test/Unit/Model/Service/Pixel/PixelStateWriterTest.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Ebizmarts_MailChimp
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Test\Unit\Model\Service\Pixel;
+
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Ebizmarts\MailChimp\Model\Service\Pixel\PixelStateWriter;
+use Magento\Framework\App\Cache\TypeListInterface;
+use Magento\Framework\App\Config\Storage\WriterInterface;
+use Magento\Store\Model\ScopeInterface;
+use PHPUnit\Framework\TestCase;
+
+class PixelStateWriterTest extends TestCase
+{
+    private WriterInterface $configWriter;
+    private TypeListInterface $cacheTypeList;
+    private PixelStateWriter $writer;
+
+    protected function setUp(): void
+    {
+        $this->configWriter  = $this->createMock(WriterInterface::class);
+        $this->cacheTypeList = $this->createMock(TypeListInterface::class);
+        $this->writer = new PixelStateWriter($this->configWriter, $this->cacheTypeList);
+    }
+
+    /**
+     * The critical invariant: enabled_for_store must be saved LAST.
+     * If it were saved first and the fragment save failed, the store would be
+     * "enabled but without a script".
+     */
+    public function testEnableSavesInCorrectOrder(): void
+    {
+        $storeId        = 1;
+        $scriptUrl      = 'https://chimpstatic.com/mcjs-connected/js/users/abc.js';
+        $scriptFragment = '<script>/* fragment */</script>';
+
+        $callOrder = [];
+
+        $this->configWriter
+            ->expects($this->exactly(3))
+            ->method('save')
+            ->willReturnCallback(function (string $path) use (&$callOrder) {
+                $callOrder[] = $path;
+            });
+
+        $this->cacheTypeList->expects($this->once())->method('invalidate')->with('config');
+
+        $this->writer->enable($storeId, $scriptUrl, $scriptFragment);
+
+        $this->assertSame(
+            [
+                MailChimpHelper::XML_PIXEL_SCRIPT_URL,
+                MailChimpHelper::XML_PIXEL_SCRIPT_FRAGMENT,
+                MailChimpHelper::XML_PIXEL_ENABLED_FOR_STORE,
+            ],
+            $callOrder,
+            'enabled_for_store must be saved last to avoid "enabled but without script" state'
+        );
+    }
+
+    public function testEnableSavesCorrectValues(): void
+    {
+        $storeId        = 2;
+        $scriptUrl      = 'https://chimpstatic.com/mcjs-connected/js/users/xyz.js';
+        $scriptFragment = '<script>/* pixel fragment */</script>';
+
+        $saved = [];
+
+        $this->configWriter
+            ->method('save')
+            ->willReturnCallback(function (string $path, $value, string $scope, int $sid) use (&$saved) {
+                $saved[$path] = ['value' => $value, 'scope' => $scope, 'storeId' => $sid];
+            });
+
+        $this->writer->enable($storeId, $scriptUrl, $scriptFragment);
+
+        $this->assertSame($scriptUrl,      $saved[MailChimpHelper::XML_PIXEL_SCRIPT_URL]['value']);
+        $this->assertSame($scriptFragment, $saved[MailChimpHelper::XML_PIXEL_SCRIPT_FRAGMENT]['value']);
+        $this->assertSame(1,               $saved[MailChimpHelper::XML_PIXEL_ENABLED_FOR_STORE]['value']);
+
+        foreach ($saved as $entry) {
+            $this->assertSame(ScopeInterface::SCOPE_STORES, $entry['scope']);
+            $this->assertSame($storeId, $entry['storeId']);
+        }
+    }
+
+    /**
+     * On disable: clear data before setting the flag to 0,
+     * so the store is never "enabled but without a script".
+     */
+    public function testDisableClearsDataBeforeFlag(): void
+    {
+        $storeId   = 1;
+        $callOrder = [];
+
+        $this->configWriter
+            ->expects($this->exactly(3))
+            ->method('save')
+            ->willReturnCallback(function (string $path) use (&$callOrder) {
+                $callOrder[] = $path;
+            });
+
+        $this->cacheTypeList->expects($this->once())->method('invalidate')->with('config');
+
+        $this->writer->disable($storeId);
+
+        $this->assertSame(MailChimpHelper::XML_PIXEL_ENABLED_FOR_STORE, end($callOrder),
+            'enabled_for_store must be set to 0 last when disabling');
+
+        $this->assertContains(MailChimpHelper::XML_PIXEL_SCRIPT_FRAGMENT, $callOrder);
+        $this->assertContains(MailChimpHelper::XML_PIXEL_SCRIPT_URL, $callOrder);
+    }
+
+    public function testDisableSetsEmptyValuesAndZeroFlag(): void
+    {
+        $saved = [];
+
+        $this->configWriter
+            ->method('save')
+            ->willReturnCallback(function (string $path, $value) use (&$saved) {
+                $saved[$path] = $value;
+            });
+
+        $this->writer->disable(1);
+
+        $this->assertSame('', $saved[MailChimpHelper::XML_PIXEL_SCRIPT_FRAGMENT]);
+        $this->assertSame('', $saved[MailChimpHelper::XML_PIXEL_SCRIPT_URL]);
+        $this->assertSame(0,  $saved[MailChimpHelper::XML_PIXEL_ENABLED_FOR_STORE]);
+    }
+
+    public function testEnableInvalidatesConfigCache(): void
+    {
+        $this->configWriter->method('save');
+        $this->cacheTypeList->expects($this->once())->method('invalidate')->with('config');
+
+        $this->writer->enable(1, 'https://example.com/pixel.js', '<script></script>');
+    }
+
+    public function testDisableInvalidatesConfigCache(): void
+    {
+        $this->configWriter->method('save');
+        $this->cacheTypeList->expects($this->once())->method('invalidate')->with('config');
+
+        $this->writer->disable(1);
+    }
+}

--- a/Test/Unit/Observer/ConfigObserverPixelTest.php
+++ b/Test/Unit/Observer/ConfigObserverPixelTest.php
@@ -1,0 +1,224 @@
+<?php
+/**
+ * Ebizmarts_MailChimp
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Test\Unit\Observer;
+
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Ebizmarts\MailChimp\Model\Service\Admin\ConnectedSiteProvisioner;
+use Ebizmarts\MailChimp\Observer\ConfigObserver;
+use Magento\Framework\App\Config\ReinitableConfigInterface;
+use Magento\Framework\Event\Observer as EventObserver;
+use Magento\Framework\Registry;
+use Magento\Framework\UrlInterface;
+use Magento\Store\Model\Store;
+use Magento\Store\Model\StoreManager;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests the pixel-provisioning logic added to ConfigObserver.
+ * The webhook-deletion logic is not tested here — these tests focus only on
+ * the provisionPixelIfNeeded() behaviour.
+ */
+class ConfigObserverPixelTest extends TestCase
+{
+    private function makeStore(
+        int $storeId,
+        string $baseUrl = 'https://example.com/'
+    ): Store {
+        $store = $this->createMock(Store::class);
+        $store->method('getBaseUrl')
+            ->with(UrlInterface::URL_TYPE_WEB)
+            ->willReturn($baseUrl);
+
+        return $store;
+    }
+
+    private function makeObserver(
+        array $stores,
+        array $configMap,
+        ConnectedSiteProvisioner $provisioner
+    ): ConfigObserver {
+        $storeManager = $this->createMock(StoreManager::class);
+        $storeManager->method('getStores')->willReturn($stores);
+
+        $helper = $this->createMock(MailChimpHelper::class);
+        $helper->method('getConfigValue')
+            ->willReturnCallback(function (string $path, $storeId) use ($configMap) {
+                return $configMap[$storeId][$path] ?? null;
+            });
+        // Prevent deleteWebHook from being called (old list id is null)
+        $helper->method('deleteWebHook');
+
+        $registry = $this->createMock(Registry::class);
+        $registry->method('registry')->willReturn(null);
+
+        $reinitableConfig = $this->createMock(ReinitableConfigInterface::class);
+
+        return new ConfigObserver($storeManager, $registry, $helper, $provisioner, $reinitableConfig);
+    }
+
+    public function testProvisionIsCalledWhenPixelEnabledAndNotYetProvisioned(): void
+    {
+        $store = $this->makeStore(1, 'https://shop.example.com/');
+
+        $provisioner = $this->createMock(ConnectedSiteProvisioner::class);
+        $provisioner
+            ->expects($this->once())
+            ->method('provision')
+            ->with(1, 'mc-store-abc', 'shop.example.com');
+
+        $observer = $this->makeObserver(
+            [1 => $store],
+            [
+                1 => [
+                    MailChimpHelper::XML_MAILCHIMP_STORE           => 'mc-store-abc',
+                    MailChimpHelper::XML_PIXEL_ENABLED_FOR_STORE   => '1',
+                    MailChimpHelper::XML_PIXEL_SCRIPT_FRAGMENT     => '',  // not yet provisioned
+                ],
+            ],
+            $provisioner
+        );
+
+        $observer->execute($this->createMock(EventObserver::class));
+    }
+
+    public function testProvisionIsSkippedWhenPixelAlreadyProvisioned(): void
+    {
+        $store = $this->makeStore(1);
+
+        $provisioner = $this->createMock(ConnectedSiteProvisioner::class);
+        $provisioner->expects($this->never())->method('provision');
+
+        $observer = $this->makeObserver(
+            [1 => $store],
+            [
+                1 => [
+                    MailChimpHelper::XML_MAILCHIMP_STORE           => 'mc-store-abc',
+                    MailChimpHelper::XML_PIXEL_ENABLED_FOR_STORE   => '1',
+                    MailChimpHelper::XML_PIXEL_SCRIPT_FRAGMENT     => '<script>/* pixel */</script>',
+                ],
+            ],
+            $provisioner
+        );
+
+        $observer->execute($this->createMock(EventObserver::class));
+    }
+
+    public function testProvisionIsSkippedWhenPixelToggleIsOff(): void
+    {
+        $store = $this->makeStore(1);
+
+        $provisioner = $this->createMock(ConnectedSiteProvisioner::class);
+        $provisioner->expects($this->never())->method('provision');
+
+        $observer = $this->makeObserver(
+            [1 => $store],
+            [
+                1 => [
+                    MailChimpHelper::XML_MAILCHIMP_STORE           => 'mc-store-abc',
+                    MailChimpHelper::XML_PIXEL_ENABLED_FOR_STORE   => '0',
+                    MailChimpHelper::XML_PIXEL_SCRIPT_FRAGMENT     => '',
+                ],
+            ],
+            $provisioner
+        );
+
+        $observer->execute($this->createMock(EventObserver::class));
+    }
+
+    public function testProvisionIsSkippedWhenStoreNotConnectedToMailchimp(): void
+    {
+        $store = $this->makeStore(1);
+
+        $provisioner = $this->createMock(ConnectedSiteProvisioner::class);
+        $provisioner->expects($this->never())->method('provision');
+
+        $observer = $this->makeObserver(
+            [1 => $store],
+            [
+                1 => [
+                    MailChimpHelper::XML_MAILCHIMP_STORE           => null,  // no MC store linked
+                    MailChimpHelper::XML_PIXEL_ENABLED_FOR_STORE   => '1',
+                    MailChimpHelper::XML_PIXEL_SCRIPT_FRAGMENT     => '',
+                ],
+            ],
+            $provisioner
+        );
+
+        $observer->execute($this->createMock(EventObserver::class));
+    }
+
+    public function testProvisionExceptionIsLoggedAndDoesNotBubble(): void
+    {
+        $store = $this->makeStore(1, 'https://example.com/');
+
+        $provisioner = $this->createMock(ConnectedSiteProvisioner::class);
+        $provisioner->method('provision')
+            ->willThrowException(new \Exception('API timeout'));
+
+        $helper = $this->createMock(MailChimpHelper::class);
+        $helper->method('getConfigValue')
+            ->willReturnCallback(function (string $path) {
+                return match ($path) {
+                    MailChimpHelper::XML_MAILCHIMP_STORE         => 'mc-store-abc',
+                    MailChimpHelper::XML_PIXEL_ENABLED_FOR_STORE => '1',
+                    MailChimpHelper::XML_PIXEL_SCRIPT_FRAGMENT   => '',
+                    default                                       => null,
+                };
+            });
+        $helper->expects($this->once())->method('log')->with($this->stringContains('API timeout'));
+
+        $storeManager = $this->createMock(StoreManager::class);
+        $storeManager->method('getStores')->willReturn([1 => $store]);
+
+        $registry = $this->createMock(Registry::class);
+        $registry->method('registry')->willReturn(null);
+
+        $reinitableConfig = $this->createMock(ReinitableConfigInterface::class);
+
+        $observer = new ConfigObserver($storeManager, $registry, $helper, $provisioner, $reinitableConfig);
+
+        // Must NOT throw
+        $observer->execute($this->createMock(EventObserver::class));
+    }
+
+    public function testProvisionOnlyCalledForStoresThatNeedIt(): void
+    {
+        $store1 = $this->makeStore(1, 'https://store1.com/');
+        $store2 = $this->makeStore(2, 'https://store2.com/');
+
+        $provisioner = $this->createMock(ConnectedSiteProvisioner::class);
+        // Only store 1 needs provisioning (store 2 already has script_fragment)
+        $provisioner
+            ->expects($this->once())
+            ->method('provision')
+            ->with(1, 'mc-store-1', 'store1.com');
+
+        $observer = $this->makeObserver(
+            [1 => $store1, 2 => $store2],
+            [
+                1 => [
+                    MailChimpHelper::XML_MAILCHIMP_STORE           => 'mc-store-1',
+                    MailChimpHelper::XML_PIXEL_ENABLED_FOR_STORE   => '1',
+                    MailChimpHelper::XML_PIXEL_SCRIPT_FRAGMENT     => '',
+                ],
+                2 => [
+                    MailChimpHelper::XML_MAILCHIMP_STORE           => 'mc-store-2',
+                    MailChimpHelper::XML_PIXEL_ENABLED_FOR_STORE   => '1',
+                    MailChimpHelper::XML_PIXEL_SCRIPT_FRAGMENT     => '<script>/* already set */</script>',
+                ],
+            ],
+            $provisioner
+        );
+
+        $observer->execute($this->createMock(EventObserver::class));
+    }
+}

--- a/Test/Unit/Observer/ConfigObserverPixelTest.php
+++ b/Test/Unit/Observer/ConfigObserverPixelTest.php
@@ -104,6 +104,33 @@ class ConfigObserverPixelTest extends TestCase
                     MailChimpHelper::XML_MAILCHIMP_STORE           => 'mc-store-abc',
                     MailChimpHelper::XML_PIXEL_ENABLED_FOR_STORE   => '1',
                     MailChimpHelper::XML_PIXEL_SCRIPT_FRAGMENT     => '<script>/* pixel */</script>',
+                    MailChimpHelper::XML_PIXEL_SCRIPT_URL          => 'https://chimpstatic.com/mcjs-connected/js/users/abc/def.js',
+                ],
+            ],
+            $provisioner
+        );
+
+        $observer->execute($this->createMock(EventObserver::class));
+    }
+
+    public function testProvisionIsCalledWhenFragmentExistsButUrlIsMissing(): void
+    {
+        $store = $this->makeStore(1, 'https://shop.example.com/');
+
+        $provisioner = $this->createMock(ConnectedSiteProvisioner::class);
+        $provisioner
+            ->expects($this->once())
+            ->method('provision')
+            ->with(1, 'mc-store-abc', 'shop.example.com');
+
+        $observer = $this->makeObserver(
+            [1 => $store],
+            [
+                1 => [
+                    MailChimpHelper::XML_MAILCHIMP_STORE           => 'mc-store-abc',
+                    MailChimpHelper::XML_PIXEL_ENABLED_FOR_STORE   => '1',
+                    MailChimpHelper::XML_PIXEL_SCRIPT_FRAGMENT     => '<script>/* pixel */</script>',
+                    MailChimpHelper::XML_PIXEL_SCRIPT_URL          => '',  // URL missing
                 ],
             ],
             $provisioner
@@ -209,11 +236,13 @@ class ConfigObserverPixelTest extends TestCase
                     MailChimpHelper::XML_MAILCHIMP_STORE           => 'mc-store-1',
                     MailChimpHelper::XML_PIXEL_ENABLED_FOR_STORE   => '1',
                     MailChimpHelper::XML_PIXEL_SCRIPT_FRAGMENT     => '',
+                    MailChimpHelper::XML_PIXEL_SCRIPT_URL          => '',
                 ],
                 2 => [
                     MailChimpHelper::XML_MAILCHIMP_STORE           => 'mc-store-2',
                     MailChimpHelper::XML_PIXEL_ENABLED_FOR_STORE   => '1',
                     MailChimpHelper::XML_PIXEL_SCRIPT_FRAGMENT     => '<script>/* already set */</script>',
+                    MailChimpHelper::XML_PIXEL_SCRIPT_URL          => 'https://chimpstatic.com/mcjs-connected/js/users/abc/def.js',
                 ],
             ],
             $provisioner

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -341,14 +341,14 @@
                     </depends>
                 </field>
             </group>
-            <group id="pixel" translate="label" type="text" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="1">
+            <group id="pixel" translate="label" type="text" sortOrder="100" showInDefault="0" showInWebsite="0" showInStore="1">
                 <label>Mailchimp Pixel</label>
-                <field id="enabled_for_store" translate="label comment" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="enabled_for_store" translate="label comment" type="select" sortOrder="10" showInDefault="0" showInWebsite="0" showInStore="1">
                     <label>Pixel Enabled</label>
                     <comment><![CDATA[Automatically configured when the module connects to a Mailchimp store. Enables behavioral tracking (page views, add to cart, checkout, purchases, etc.).]]></comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="script_url" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="script_url" translate="label" type="text" sortOrder="20" showInDefault="0" showInWebsite="0" showInStore="1">
                     <label>Pixel Script URL</label>
                     <comment>Set automatically from the Mailchimp connected site. Do not edit manually.</comment>
                 </field>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -351,6 +351,9 @@
                 <field id="script_url" translate="label" type="text" sortOrder="20" showInDefault="0" showInWebsite="0" showInStore="1">
                     <label>Pixel Script URL</label>
                     <comment>Set automatically from the Mailchimp connected site. Do not edit manually.</comment>
+                    <depends>
+                        <field id="*/*/enabled_for_store">1</field>
+                    </depends>
                 </field>
             </group>
         </section>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -341,6 +341,18 @@
                     </depends>
                 </field>
             </group>
+            <group id="pixel" translate="label" type="text" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="1">
+                <label>Mailchimp Pixel</label>
+                <field id="enabled_for_store" translate="label comment" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Pixel Enabled</label>
+                    <comment><![CDATA[Automatically configured when the module connects to a Mailchimp store. Enables behavioral tracking (page views, add to cart, checkout, purchases, etc.).]]></comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+                <field id="script_url" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Pixel Script URL</label>
+                    <comment>Set automatically from the Mailchimp connected site. Do not edit manually.</comment>
+                </field>
+            </group>
         </section>
     </system>
 </config>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -15,6 +15,11 @@
                 <notification_url>https://logs-mc4mage.ebizmarts.com/batches</notification_url>
                 <register_url>https://users-mc4mage.ebizmarts.com</register_url>
             </statistics>
+            <pixel>
+                <enabled_for_store>0</enabled_for_store>
+                <script_url></script_url>
+                <script_fragment></script_fragment>
+            </pixel>
         </mailchimp>
     </default>
 </config>

--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -13,15 +13,21 @@
             <values>
                 <value id="form-assets-mailchimp" type="host">form-assets.mailchimp.com</value>
                 <value id="mc-intuit" type="host">*.intuit.com</value>
+                <value id="mc-intuit-sub" type="host">*.a.intuit.com</value>
+                <value id="mc-pixel-cdn" type="host">mcjs.prd.a.intuit.com</value>
+                <value id="mc-pixel-chimpstatic" type="host">chimpstatic.com</value>
                 <value id="mc-aws" type="host">*.amazonaws.com</value>
             </values>
         </policy>
         <policy id="script-src">
             <values>
                 <value id="chimpstatic" type="host">chimpstatic.com</value>
+                <value id="mc-pixel-cdn" type="host">mcjs.prd.a.intuit.com</value>
                 <value id="mailchimp-js" type="host">downloads.mailchimp.com</value>
                 <value id="list-management" type="host">*.list-manage.com</value>
                 <value id="form-assets-mailchimp" type="host">form-assets.mailchimp.com</value>
+                <value id="mc-sdk-inline" type="hash" algorithm="sha256">XixzHLHNI6aMABAAOkoOkkILEVDbnPvl7w762hRvU2s=</value>
+                <value id="mc_pixel_loader_inline_hash_old" type="hash" algorithm="sha256">6AIRWmXvA3N5Y6wjwDPAyUacVUR9lp2IEko3qG+1Hgk=</value>
             </values>
         </policy>
         <policy id='style-src'>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -93,4 +93,12 @@
         <plugin name="mailchimp_save_creditmemo" type="Ebizmarts\MailChimp\Model\Plugin\Creditmemo" sortOrder="10"/>
     </type>
     <preference for="Magento\Newsletter\Block\Subscribe" type="Ebizmarts\MailChimp\Block\Subscribe"/>
+    <type name="Ebizmarts\MailChimp\Block\Pixel\Script">
+        <arguments>
+            <argument name="helper" xsi:type="object">Ebizmarts\MailChimp\Helper\Data\Proxy</argument>
+        </arguments>
+    </type>
+    <type name="Magento\Checkout\CustomerData\Cart">
+        <plugin name="mailchimp_pixel_cart_data" type="Ebizmarts\MailChimp\Plugin\Checkout\CustomerData\CartPlugin" sortOrder="10"/>
+    </type>
 </config>

--- a/view/frontend/layout/catalog_category_view.xml
+++ b/view/frontend/layout/catalog_category_view.xml
@@ -12,11 +12,8 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <referenceContainer name="order.success.additional.info">
-            <block class="Ebizmarts\MailChimp\Block\Checkout\Success" ifconfig="mailchimp/general/interest_in_success" name="mailchimp.order.success" template="Ebizmarts_MailChimp::checkout/order/success.phtml"/>
+        <referenceContainer name="before.body.end">
+            <block class="Ebizmarts\MailChimp\Block\Pixel\Category" name="mailchimp.pixel.category" template="Ebizmarts_MailChimp::pixel/category.phtml" ifconfig="mailchimp/pixel/enabled_for_store"/>
         </referenceContainer>
-        <referenceBlock name="head.additional">
-            <block class="Ebizmarts\MailChimp\Block\Pixel\Order" name="mailchimp.pixel.order" template="Ebizmarts_MailChimp::pixel/order.phtml" ifconfig="mailchimp/general/active"/>
-        </referenceBlock>
     </body>
 </page>

--- a/view/frontend/layout/catalog_product_view.xml
+++ b/view/frontend/layout/catalog_product_view.xml
@@ -12,11 +12,8 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <referenceContainer name="order.success.additional.info">
-            <block class="Ebizmarts\MailChimp\Block\Checkout\Success" ifconfig="mailchimp/general/interest_in_success" name="mailchimp.order.success" template="Ebizmarts_MailChimp::checkout/order/success.phtml"/>
+        <referenceContainer name="before.body.end">
+            <block class="Ebizmarts\MailChimp\Block\Pixel\Product" name="mailchimp.pixel.product" template="Ebizmarts_MailChimp::pixel/product.phtml" ifconfig="mailchimp/pixel/enabled_for_store"/>
         </referenceContainer>
-        <referenceBlock name="head.additional">
-            <block class="Ebizmarts\MailChimp\Block\Pixel\Order" name="mailchimp.pixel.order" template="Ebizmarts_MailChimp::pixel/order.phtml" ifconfig="mailchimp/general/active"/>
-        </referenceBlock>
     </body>
 </page>

--- a/view/frontend/layout/catalogsearch_result_index.xml
+++ b/view/frontend/layout/catalogsearch_result_index.xml
@@ -12,11 +12,8 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <referenceContainer name="order.success.additional.info">
-            <block class="Ebizmarts\MailChimp\Block\Checkout\Success" ifconfig="mailchimp/general/interest_in_success" name="mailchimp.order.success" template="Ebizmarts_MailChimp::checkout/order/success.phtml"/>
+        <referenceContainer name="before.body.end">
+            <block class="Ebizmarts\MailChimp\Block\Pixel\Search" name="mailchimp.pixel.search" template="Ebizmarts_MailChimp::pixel/search.phtml" ifconfig="mailchimp/pixel/enabled_for_store"/>
         </referenceContainer>
-        <referenceBlock name="head.additional">
-            <block class="Ebizmarts\MailChimp\Block\Pixel\Order" name="mailchimp.pixel.order" template="Ebizmarts_MailChimp::pixel/order.phtml" ifconfig="mailchimp/general/active"/>
-        </referenceBlock>
     </body>
 </page>

--- a/view/frontend/layout/checkout_cart_index.xml
+++ b/view/frontend/layout/checkout_cart_index.xml
@@ -12,11 +12,8 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <referenceContainer name="order.success.additional.info">
-            <block class="Ebizmarts\MailChimp\Block\Checkout\Success" ifconfig="mailchimp/general/interest_in_success" name="mailchimp.order.success" template="Ebizmarts_MailChimp::checkout/order/success.phtml"/>
+        <referenceContainer name="before.body.end">
+            <block class="Ebizmarts\MailChimp\Block\Pixel\Cart" name="mailchimp.pixel.cart" template="Ebizmarts_MailChimp::pixel/cart.phtml" ifconfig="mailchimp/pixel/enabled_for_store" cacheable="false"/>
         </referenceContainer>
-        <referenceBlock name="head.additional">
-            <block class="Ebizmarts\MailChimp\Block\Pixel\Order" name="mailchimp.pixel.order" template="Ebizmarts_MailChimp::pixel/order.phtml" ifconfig="mailchimp/general/active"/>
-        </referenceBlock>
     </body>
 </page>

--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -12,11 +12,8 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <referenceContainer name="order.success.additional.info">
-            <block class="Ebizmarts\MailChimp\Block\Checkout\Success" ifconfig="mailchimp/general/interest_in_success" name="mailchimp.order.success" template="Ebizmarts_MailChimp::checkout/order/success.phtml"/>
+        <referenceContainer name="before.body.end">
+            <block class="Ebizmarts\MailChimp\Block\Pixel\Checkout" name="mailchimp.pixel.checkout" template="Ebizmarts_MailChimp::pixel/checkout.phtml" ifconfig="mailchimp/pixel/enabled_for_store" cacheable="false"/>
         </referenceContainer>
-        <referenceBlock name="head.additional">
-            <block class="Ebizmarts\MailChimp\Block\Pixel\Order" name="mailchimp.pixel.order" template="Ebizmarts_MailChimp::pixel/order.phtml" ifconfig="mailchimp/general/active"/>
-        </referenceBlock>
     </body>
 </page>

--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -15,6 +15,8 @@
     <body>
         <referenceBlock name="head.additional">
             <block class="Ebizmarts\MailChimp\Block\Mailchimpjs" name="mailchimp.block.mcjs" template="Ebizmarts_MailChimp::mailchimpjs.phtml" ifconfig="mailchimp/general/active"/>
+            <block class="Ebizmarts\MailChimp\Block\Pixel\Script" name="mailchimp.pixel.script" template="Ebizmarts_MailChimp::pixel/script.phtml" ifconfig="mailchimp/general/active"/>
+            <block class="Ebizmarts\MailChimp\Block\Pixel\Identity" name="mailchimp.pixel.identity" template="Ebizmarts_MailChimp::pixel/identity.phtml" ifconfig="mailchimp/general/active"/>
         </referenceBlock>
         <referenceContainer name="content">
             <block class="Ebizmarts\MailChimp\Block\Catcher" name="mailchimp.block.catcher" template="Ebizmarts_MailChimp::catcher.phtml" ifconfig="mailchimp/general/active"/>

--- a/view/frontend/layout/hyva_checkout_index_index.xml
+++ b/view/frontend/layout/hyva_checkout_index_index.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Ebizmarts_MailChimp — Hyvä checkout layout
+ *
+ * Hyvä uses Magewire for the reactive checkout, which re-renders components
+ * on state changes. The Pixel Checkout block is mounted at "before.body.end"
+ * which is outside the Magewire re-render scope, so it only fires once on
+ * page load — exactly what CHECKOUT_STARTED requires.
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="before.body.end">
+            <block class="Ebizmarts\MailChimp\Block\Pixel\Checkout" name="mailchimp.pixel.checkout.hyva" template="Ebizmarts_MailChimp::pixel/checkout.phtml" ifconfig="mailchimp/pixel/enabled_for_store" cacheable="false"/>
+        </referenceContainer>
+    </body>
+</page>

--- a/view/frontend/layout/hyva_checkout_success.xml
+++ b/view/frontend/layout/hyva_checkout_success.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Ebizmarts_MailChimp — Hyvä checkout success layout
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="before.body.end">
+            <block class="Ebizmarts\MailChimp\Block\Pixel\Order" name="mailchimp.pixel.order.hyva" template="Ebizmarts_MailChimp::pixel/order.phtml" ifconfig="mailchimp/pixel/enabled_for_store" cacheable="false"/>
+        </referenceContainer>
+    </body>
+</page>

--- a/view/frontend/templates/pixel/cart.phtml
+++ b/view/frontend/templates/pixel/cart.phtml
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Ebizmarts_MailChimp — Pixel CART_VIEWED template
+ *
+ * Block: Ebizmarts\MailChimp\Block\Pixel\Cart
+ *
+ * @var \Ebizmarts\MailChimp\Block\Pixel\Cart $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
+$cartData = $block->getCartData();
+?>
+<?php if (!empty($cartData)): ?>
+<script type="application/json" id="mailchimp-pixel-cart-data"><?= /* @noEscape */ json_encode($cartData, JSON_HEX_TAG | JSON_HEX_AMP) ?></script>
+<script src="<?= $escaper->escapeUrl($block->getViewFileUrl('Ebizmarts_MailChimp::js/pixel/cart.js')) ?>" defer="defer"></script>
+<?php endif; ?>

--- a/view/frontend/templates/pixel/category.phtml
+++ b/view/frontend/templates/pixel/category.phtml
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Ebizmarts_MailChimp — Pixel PRODUCT_CATEGORY_VIEWED template
+ *
+ * Block: Ebizmarts\MailChimp\Block\Pixel\Category
+ *
+ * @var \Ebizmarts\MailChimp\Block\Pixel\Category $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
+$categoryData = $block->getCategoryData();
+?>
+<?php if (!empty($categoryData)): ?>
+<script type="application/json" id="mailchimp-pixel-category-data"><?= /* @noEscape */ json_encode($categoryData, JSON_HEX_TAG | JSON_HEX_AMP) ?></script>
+<script src="<?= $escaper->escapeUrl($block->getViewFileUrl('Ebizmarts_MailChimp::js/pixel/category.js')) ?>" defer="defer"></script>
+<?php endif; ?>

--- a/view/frontend/templates/pixel/checkout.phtml
+++ b/view/frontend/templates/pixel/checkout.phtml
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Ebizmarts_MailChimp — Pixel CHECKOUT_STARTED template
+ *
+ * Block: Ebizmarts\MailChimp\Block\Pixel\Checkout
+ *
+ * @var \Ebizmarts\MailChimp\Block\Pixel\Checkout $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
+$checkoutData = $block->getCheckoutData();
+?>
+<?php if (!empty($checkoutData)): ?>
+<script type="application/json" id="mailchimp-pixel-checkout-data"><?= /* @noEscape */ json_encode($checkoutData, JSON_HEX_TAG | JSON_HEX_AMP) ?></script>
+<script src="<?= $escaper->escapeUrl($block->getViewFileUrl('Ebizmarts_MailChimp::js/pixel/checkout.js')) ?>" defer="defer"></script>
+<?php endif; ?>

--- a/view/frontend/templates/pixel/identity.phtml
+++ b/view/frontend/templates/pixel/identity.phtml
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Ebizmarts_MailChimp — Pixel identify template
+ *
+ * Emits a minimal JSON island with the logged-in customer email.
+ * identify.js (loaded globally via script.phtml) reads this island and calls
+ * identify() on the Pixel SDK, hashing the email with SHA-256 when available.
+ *
+ * Block: Ebizmarts\MailChimp\Block\Pixel\Identity
+ *
+ * @var \Ebizmarts\MailChimp\Block\Pixel\Identity $block
+ */
+$identityData = $block->getIdentityData();
+?>
+<?php if ($identityData): ?>
+<script type="application/json" id="mailchimp-pixel-identity-data"><?= /* @noEscape */ json_encode($identityData, JSON_HEX_TAG | JSON_HEX_AMP) ?></script>
+<?php endif; ?>

--- a/view/frontend/templates/pixel/order.phtml
+++ b/view/frontend/templates/pixel/order.phtml
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Ebizmarts_MailChimp — Pixel PURCHASED template
+ *
+ * Block: Ebizmarts\MailChimp\Block\Pixel\Order
+ *
+ * @var \Ebizmarts\MailChimp\Block\Pixel\Order $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
+$orderData = $block->getOrderData();
+?>
+<?php if (!empty($orderData)): ?>
+<script type="application/json" id="mailchimp-pixel-order-data"><?= /* @noEscape */ json_encode($orderData, JSON_HEX_TAG | JSON_HEX_AMP) ?></script>
+<script src="<?= $escaper->escapeUrl($block->getViewFileUrl('Ebizmarts_MailChimp::js/pixel/order.js')) ?>" defer="defer"></script>
+<?php endif; ?>

--- a/view/frontend/templates/pixel/product.phtml
+++ b/view/frontend/templates/pixel/product.phtml
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Ebizmarts_MailChimp — Pixel PRODUCT_VIEWED template
+ *
+ * Block: Ebizmarts\MailChimp\Block\Pixel\Product
+ *
+ * @var \Ebizmarts\MailChimp\Block\Pixel\Product $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
+$productData = $block->getProductData();
+?>
+<?php if (!empty($productData)): ?>
+<script type="application/json" id="mailchimp-pixel-product-data"><?= /* @noEscape */ json_encode($productData, JSON_HEX_TAG | JSON_HEX_AMP) ?></script>
+<script src="<?= $escaper->escapeUrl($block->getViewFileUrl('Ebizmarts_MailChimp::js/pixel/product.js')) ?>" defer="defer"></script>
+<?php endif; ?>

--- a/view/frontend/templates/pixel/script.phtml
+++ b/view/frontend/templates/pixel/script.phtml
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Ebizmarts_MailChimp — Pixel loader template
+ *
+ * Emits a JSON config island (data only, not executable) and loads
+ * consent-loader.js, pixel.js (PRODUCT_ADDED_TO_CART watcher), and
+ * identify.js (visitor identification) via <script src defer>.
+ *
+ * WHY <script src defer> instead of inline code:
+ *   Adobe Commerce enforces a strict CSP on checkout pages. Inline scripts
+ *   require a nonce or 'unsafe-inline' — the external src approach is CSP-safe
+ *   because our own domain is implicitly whitelisted.
+ *
+ * Block: Ebizmarts\MailChimp\Block\Pixel\Script
+ *
+ * @var \Ebizmarts\MailChimp\Block\Pixel\Script $block
+ */
+$pixelConfig = $block->getPixelConfig();
+?>
+<?php if ($pixelConfig): ?>
+<script type="application/json" id="mc-pixel-config"><?= /* @noEscape */ json_encode($pixelConfig, JSON_HEX_TAG | JSON_HEX_AMP) ?></script>
+<script src="<?= $block->escapeUrl($block->getViewFileUrl('Ebizmarts_MailChimp::js/pixel/consent-loader.js')) ?>"></script>
+<script src="<?= $block->escapeUrl($block->getViewFileUrl('Ebizmarts_MailChimp::js/pixel.js')) ?>" defer="defer"></script>
+<script src="<?= $block->escapeUrl($block->getViewFileUrl('Ebizmarts_MailChimp::js/pixel/identify.js')) ?>" defer="defer"></script>
+<?php endif; ?>

--- a/view/frontend/templates/pixel/search.phtml
+++ b/view/frontend/templates/pixel/search.phtml
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Ebizmarts_MailChimp — Pixel SEARCH_SUBMITTED template
+ *
+ * Block: Ebizmarts\MailChimp\Block\Pixel\Search
+ *
+ * @var \Ebizmarts\MailChimp\Block\Pixel\Search $block
+ * @var \Magento\Framework\Escaper $escaper
+ */
+$searchData = $block->getSearchData();
+?>
+<?php if (!empty($searchData)): ?>
+<script type="application/json" id="mailchimp-pixel-search-data"><?= /* @noEscape */ json_encode($searchData, JSON_HEX_TAG | JSON_HEX_AMP) ?></script>
+<script src="<?= $escaper->escapeUrl($block->getViewFileUrl('Ebizmarts_MailChimp::js/pixel/search.js')) ?>" defer="defer"></script>
+<?php endif; ?>

--- a/view/frontend/web/js/pixel.js
+++ b/view/frontend/web/js/pixel.js
@@ -95,8 +95,8 @@
                 });
                 prevSnap = curr;
             });
-            var current = cart();
-            if (current && current.items && current.items.length > 0) { prevSnap = snapshot(current); initialized = true; }
+            prevSnap = snapshot(cart());
+            initialized = true;
         });
     }
 

--- a/view/frontend/web/js/pixel.js
+++ b/view/frontend/web/js/pixel.js
@@ -1,0 +1,104 @@
+/**
+ * Ebizmarts_MailChimp — PRODUCT_ADDED_TO_CART cart watcher.
+ *
+ * Self-contained IIFE loaded on every storefront page via default.xml
+ * (<script src defer>). Watches Magento's customer-data 'cart' section
+ * for quantity increases and fires PRODUCT_ADDED_TO_CART via the SDK.
+ *
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+(function () {
+    'use strict';
+    var POLL_INTERVAL_MS = 100;
+    var POLL_MAX_ATTEMPTS = 100;
+    var POST_READY_GRACE_MS = 1000;
+
+    function isPixelReady() {
+        return !!(window.$mcSite && window.$mcSite.pixel && window.$mcSite.pixel.installed === true
+            && window.$mcSite.pixel.api && typeof window.$mcSite.pixel.api.track === 'function');
+    }
+
+    function whenPixelReady(cb) {
+        var fire = function () { setTimeout(cb, POST_READY_GRACE_MS); };
+        if (isPixelReady()) { fire(); return; }
+        var attempts = 0;
+        var iv = setInterval(function () {
+            attempts++;
+            if (isPixelReady()) { clearInterval(iv); fire(); } else if (attempts > POLL_MAX_ATTEMPTS) { clearInterval(iv); }
+        }, POLL_INTERVAL_MS);
+    }
+
+    function safeTrack(event, data) {
+        whenPixelReady(function () {
+            try { window.$mcSite.pixel.api.track(event, data); } catch (e) {}
+        });
+    }
+
+    function snapshot(data) {
+        var items = (data && data.items) || [];
+        var snap = {};
+        items.forEach(function (it) {
+            var key = String(it.item_id || it.product_id || it.product_sku || it.id || '');
+            if (!key) { return; }
+            snap[key] = { qty: parseFloat(it.qty) || 0, item: it };
+        });
+        return snap;
+    }
+
+    function fireAddedToCart(item, addedQty, cartId, currency) {
+        var unitPrice = parseFloat(
+            item.product_price_value !== undefined ? item.product_price_value : item.price
+        ) || 0;
+        var imageUrl = (item.product_image && item.product_image.src) ? item.product_image.src : '';
+        var productId = String(item.product_id || item.item_id || '');
+        var product = {
+            item: {
+                id: productId, productId: productId,
+                title: item.product_name || item.name || '',
+                price: unitPrice, currency: currency || '',
+                sku: String(item.product_sku || item.sku || ''),
+                imageUrl: imageUrl,
+                productUrl: String(item.product_url || ''),
+                vendor: '', categories: []
+            },
+            quantity: addedQty,
+            price: unitPrice * addedQty,
+            currency: currency || ''
+        };
+        var payload = { product: product };
+        if (cartId) { payload.cartId = String(cartId); }
+        safeTrack('PRODUCT_ADDED_TO_CART', payload);
+    }
+
+    function hookAddToCart() {
+        require(['Magento_Customer/js/customer-data'], function (customerData) {
+            var cart = customerData.get('cart');
+            var initialized = false;
+            var prevSnap = {};
+            cart.subscribe(function (data) {
+                var curr = snapshot(data);
+                if (!initialized) { prevSnap = curr; initialized = true; return; }
+                var cartId = (data && (data.cart_id || data.cartId || data.guestCartId || data.quoteId)) || '';
+                var currency = (data && (data.currency_code || data.currency)) || '';
+                if (!currency) {
+                    try {
+                        var cfg = JSON.parse(document.getElementById('mc-pixel-config').textContent);
+                        currency = cfg.currencyCode || '';
+                    } catch (e) {}
+                }
+                Object.keys(curr).forEach(function (key) {
+                    var prevQty = (prevSnap[key] && prevSnap[key].qty) || 0;
+                    if (curr[key].qty > prevQty) {
+                        fireAddedToCart(curr[key].item, curr[key].qty - prevQty, cartId, currency);
+                    }
+                });
+                prevSnap = curr;
+            });
+            var current = cart();
+            if (current && current.items && current.items.length > 0) { prevSnap = snapshot(current); initialized = true; }
+        });
+    }
+
+    hookAddToCart();
+}());

--- a/view/frontend/web/js/pixel/cart.js
+++ b/view/frontend/web/js/pixel/cart.js
@@ -1,0 +1,43 @@
+/**
+ * Ebizmarts_MailChimp — CART_VIEWED tracker.
+ *
+ * Self-contained IIFE. Reads the mailchimp-pixel-cart-data island and fires
+ * CART_VIEWED via the Mailchimp Pixel SDK.
+ *
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+(function () {
+    'use strict';
+    var DATA_ID = 'mailchimp-pixel-cart-data';
+    var POLL_INTERVAL_MS = 100;
+    var POLL_MAX_ATTEMPTS = 100;
+    var POST_READY_GRACE_MS = 1000;
+
+    function isPixelReady() {
+        return !!(window.$mcSite && window.$mcSite.pixel && window.$mcSite.pixel.installed === true
+            && window.$mcSite.pixel.api && typeof window.$mcSite.pixel.api.track === 'function');
+    }
+
+    function whenPixelReady(cb) {
+        var fire = function () { setTimeout(cb, POST_READY_GRACE_MS); };
+        if (isPixelReady()) { fire(); return; }
+        var attempts = 0;
+        var iv = setInterval(function () {
+            attempts++;
+            if (isPixelReady()) { clearInterval(iv); fire(); } else if (attempts > POLL_MAX_ATTEMPTS) { clearInterval(iv); }
+        }, POLL_INTERVAL_MS);
+    }
+
+    function readIsland() {
+        var el = document.getElementById(DATA_ID);
+        if (!el) { return null; }
+        try { return JSON.parse(el.textContent || el.innerHTML); } catch (e) { return null; }
+    }
+
+    var cart = readIsland();
+    if (!cart || !cart.id) { return; }
+    whenPixelReady(function () {
+        try { window.$mcSite.pixel.api.track('CART_VIEWED', { cart: cart }); } catch (e) {}
+    });
+}());

--- a/view/frontend/web/js/pixel/category.js
+++ b/view/frontend/web/js/pixel/category.js
@@ -1,0 +1,43 @@
+/**
+ * Ebizmarts_MailChimp — PRODUCT_CATEGORY_VIEWED tracker.
+ *
+ * Self-contained IIFE. Reads the mailchimp-pixel-category-data island and fires
+ * PRODUCT_CATEGORY_VIEWED unwrapped via the Mailchimp Pixel SDK.
+ *
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+(function () {
+    'use strict';
+    var DATA_ID = 'mailchimp-pixel-category-data';
+    var POLL_INTERVAL_MS = 100;
+    var POLL_MAX_ATTEMPTS = 100;
+    var POST_READY_GRACE_MS = 1000;
+
+    function isPixelReady() {
+        return !!(window.$mcSite && window.$mcSite.pixel && window.$mcSite.pixel.installed === true
+            && window.$mcSite.pixel.api && typeof window.$mcSite.pixel.api.track === 'function');
+    }
+
+    function whenPixelReady(cb) {
+        var fire = function () { setTimeout(cb, POST_READY_GRACE_MS); };
+        if (isPixelReady()) { fire(); return; }
+        var attempts = 0;
+        var iv = setInterval(function () {
+            attempts++;
+            if (isPixelReady()) { clearInterval(iv); fire(); } else if (attempts > POLL_MAX_ATTEMPTS) { clearInterval(iv); }
+        }, POLL_INTERVAL_MS);
+    }
+
+    function readIsland() {
+        var el = document.getElementById(DATA_ID);
+        if (!el) { return null; }
+        try { return JSON.parse(el.textContent || el.innerHTML); } catch (e) { return null; }
+    }
+
+    var category = readIsland();
+    if (!category || !category.categoryId) { return; }
+    whenPixelReady(function () {
+        try { window.$mcSite.pixel.api.track('PRODUCT_CATEGORY_VIEWED', category); } catch (e) {}
+    });
+}());

--- a/view/frontend/web/js/pixel/checkout.js
+++ b/view/frontend/web/js/pixel/checkout.js
@@ -1,0 +1,50 @@
+/**
+ * Ebizmarts_MailChimp — CHECKOUT_STARTED tracker.
+ *
+ * Self-contained IIFE. Reads the mailchimp-pixel-checkout-data island and fires
+ * CHECKOUT_STARTED via the Mailchimp Pixel SDK. Deduplicates per cartId using
+ * sessionStorage.
+ *
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+(function () {
+    'use strict';
+    var DATA_ID = 'mailchimp-pixel-checkout-data';
+    var DEDUP_PREFIX = 'mc_pixel_checkout_started_';
+    var POLL_INTERVAL_MS = 100;
+    var POLL_MAX_ATTEMPTS = 100;
+    var POST_READY_GRACE_MS = 1000;
+
+    function isPixelReady() {
+        return !!(window.$mcSite && window.$mcSite.pixel && window.$mcSite.pixel.installed === true
+            && window.$mcSite.pixel.api && typeof window.$mcSite.pixel.api.track === 'function');
+    }
+
+    function whenPixelReady(cb) {
+        var fire = function () { setTimeout(cb, POST_READY_GRACE_MS); };
+        if (isPixelReady()) { fire(); return; }
+        var attempts = 0;
+        var iv = setInterval(function () {
+            attempts++;
+            if (isPixelReady()) { clearInterval(iv); fire(); } else if (attempts > POLL_MAX_ATTEMPTS) { clearInterval(iv); }
+        }, POLL_INTERVAL_MS);
+    }
+
+    function readIsland() {
+        var el = document.getElementById(DATA_ID);
+        if (!el) { return null; }
+        try { return JSON.parse(el.textContent || el.innerHTML); } catch (e) { return null; }
+    }
+
+    var checkout = readIsland();
+    if (!checkout || !checkout.id) { return; }
+    var dedupKey = DEDUP_PREFIX + checkout.cartId;
+    try { if (sessionStorage.getItem(dedupKey)) { return; } } catch (e) {}
+    whenPixelReady(function () {
+        try {
+            window.$mcSite.pixel.api.track('CHECKOUT_STARTED', { checkout: checkout });
+            try { sessionStorage.setItem(dedupKey, '1'); } catch (e) {}
+        } catch (e) {}
+    });
+}());

--- a/view/frontend/web/js/pixel/consent-loader.js
+++ b/view/frontend/web/js/pixel/consent-loader.js
@@ -1,0 +1,148 @@
+/**
+ * Ebizmarts_MailChimp — Mailchimp Pixel consent loader
+ *
+ * WHY this exists (FPC-neutrality problem):
+ *   If we gate the <script id="mcjs"> server-side inside a FPC-cacheable block,
+ *   FPC freezes the consent/no-consent decision at cache-prime time. Visitors
+ *   who accept cookies mid-session hit a cache HIT with the old (no-pixel)
+ *   HTML — the script never loads for them.
+ *
+ * The solution (this file):
+ *   1. PHP renders ONE consent-NEUTRAL page for all visitors.
+ *      FPC stores a single copy — no bucket poisoning.
+ *   2. This script reads runtime config from the JSON island
+ *      <script id="mc-pixel-config" type="application/json">.
+ *   3. Consent is evaluated HERE, in the browser, against the real cookie.
+ *   4. If allowed: inject <script id="mcjs" src="…" async> into <head>
+ *      (idempotent — won't double-inject).
+ *   5. If not yet allowed: poll every ~1 s (up to ~30 min / 1800 tries)
+ *      for late-consent (covers CMPs whose banners set the cookie without
+ *      reloading the page).
+ *
+ * Consent logic mirrors Magento\Cookie\Helper\Cookie::isUserNotAllowSaveCookie():
+ *   • restrictionMode === false  → banner OFF → consent not required → ALLOWED
+ *   • otherwise: read cookie "user_allowed_save_cookie" (JSON keyed by website
+ *     id, e.g. {"1":1}).
+ *     ALLOWED only if the key for this website id EXISTS AND is truthy
+ *     (mirrors PHP empty(): 0, "0", "", false, null = NOT consented).
+ *     Cookie absent or parse error → NOT allowed (fail-safe).
+ *
+ * Loaded via <script src="…/js/pixel/consent-loader.js"> from script.phtml —
+ * served from our own domain, always CSP-whitelisted.
+ */
+(function () {
+    'use strict';
+
+    var POLL_INTERVAL_MS  = 1000;
+    var POLL_MAX_ATTEMPTS = 1800; // ~30 minutes
+    var MCJS_SCRIPT_ID    = 'mcjs';
+    var CONFIG_ISLAND_ID  = 'mc-pixel-config';
+
+    // -------------------------------------------------------------------------
+    // Config island
+    // -------------------------------------------------------------------------
+
+    function readConfig() {
+        var el = document.getElementById(CONFIG_ISLAND_ID);
+        if (!el) {
+            return null;
+        }
+        try {
+            return JSON.parse(el.textContent || el.innerHTML);
+        } catch (e) {
+            return null;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Consent check
+    // Mirrors Magento\Cookie\Helper\Cookie::isUserNotAllowSaveCookie()
+    // -------------------------------------------------------------------------
+
+    function isConsentGranted(config) {
+        // restrictionMode OFF → opt-out model → always allowed
+        if (!config.restrictionMode) {
+            return true;
+        }
+
+        var raw = getCookieValue('user_allowed_save_cookie');
+        if (!raw) {
+            return false; // cookie absent → fail-safe
+        }
+
+        var parsed;
+        try {
+            parsed = JSON.parse(decodeURIComponent(raw));
+        } catch (e) {
+            return false; // parse error → fail-safe
+        }
+
+        if (typeof parsed !== 'object' || parsed === null) {
+            return false;
+        }
+
+        var websiteId = String(config.websiteId);
+
+        // Key must exist AND be truthy (mirrors PHP empty())
+        if (!Object.prototype.hasOwnProperty.call(parsed, websiteId)) {
+            return false; // key absent → not consented
+        }
+
+        var val = parsed[websiteId];
+        // PHP empty(): 0, "0", "", false, null, [] → falsy
+        return !!val && val !== '0' && val !== '';
+    }
+
+    // -------------------------------------------------------------------------
+    // Cookie reader
+    // -------------------------------------------------------------------------
+
+    function getCookieValue(name) {
+        var match = document.cookie.match(
+            new RegExp('(?:^|;\\s*)' + name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '=([^;]*)')
+        );
+        return match ? match[1] : null;
+    }
+
+    // -------------------------------------------------------------------------
+    // Pixel injector (idempotent)
+    // -------------------------------------------------------------------------
+
+    function injectPixel(scriptUrl) {
+        if (document.getElementById(MCJS_SCRIPT_ID)) {
+            return; // already injected
+        }
+        var s = document.createElement('script');
+        s.id    = MCJS_SCRIPT_ID;
+        s.src   = scriptUrl;
+        s.async = true;
+        (document.head || document.documentElement).appendChild(s);
+    }
+
+    // -------------------------------------------------------------------------
+    // Main
+    // -------------------------------------------------------------------------
+
+    var config = readConfig();
+    if (!config || !config.scriptUrl) {
+        return; // pixel not configured for this store
+    }
+
+    if (isConsentGranted(config)) {
+        injectPixel(config.scriptUrl);
+        return;
+    }
+
+    // Late-consent poll: covers CMPs that set the cookie without a page reload
+    var attempts  = 0;
+    var pollTimer = setInterval(function () {
+        attempts++;
+        if (isConsentGranted(config)) {
+            clearInterval(pollTimer);
+            injectPixel(config.scriptUrl);
+        } else if (attempts >= POLL_MAX_ATTEMPTS) {
+            clearInterval(pollTimer);
+        }
+    }, POLL_INTERVAL_MS);
+
+}());

--- a/view/frontend/web/js/pixel/identify.js
+++ b/view/frontend/web/js/pixel/identify.js
@@ -1,0 +1,148 @@
+/**
+ * Ebizmarts_MailChimp — Visitor identify handler.
+ *
+ * Self-contained IIFE loaded on every storefront page. Handles all identify
+ * paths: logged-in customer island, checkout email field blur/input debounce,
+ * and MutationObserver detection for fields rendered late by JS frameworks.
+ * SHA-256 hashing via crypto.subtle when available, falls back to plain EMAIL.
+ * Exposes window.EbizMcPixel.identify for external callers.
+ *
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+(function () {
+    'use strict';
+    var POLL_INTERVAL_MS = 100;
+    var POLL_MAX_ATTEMPTS = 100;
+    var POST_READY_GRACE_MS = 1000;
+    var INPUT_DEBOUNCE_MS = 1500;
+    var EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    var firedEmails = {};
+
+    function isCompleteEmail(v) {
+        return typeof v === 'string' && EMAIL_RE.test(v);
+    }
+
+    function isPixelReady() {
+        return !!(window.$mcSite && window.$mcSite.pixel && window.$mcSite.pixel.installed === true
+            && window.$mcSite.pixel.api && typeof window.$mcSite.pixel.api.identify === 'function');
+    }
+
+    function whenPixelReady(cb) {
+        var fire = function () { setTimeout(cb, POST_READY_GRACE_MS); };
+        if (isPixelReady()) { fire(); return; }
+        var attempts = 0;
+        var iv = setInterval(function () {
+            attempts++;
+            if (isPixelReady()) { clearInterval(iv); fire(); } else if (attempts > POLL_MAX_ATTEMPTS) { clearInterval(iv); }
+        }, POLL_INTERVAL_MS);
+    }
+
+    function sha256Hex(str) {
+        if (!window.crypto || !window.crypto.subtle || typeof TextEncoder === 'undefined') {
+            return Promise.reject(new Error('unavailable'));
+        }
+        var buf = new TextEncoder().encode(str);
+        return window.crypto.subtle.digest('SHA-256', buf).then(function (hashBuf) {
+            return Array.from(new Uint8Array(hashBuf))
+                .map(function (b) { return ('00' + b.toString(16)).slice(-2); })
+                .join('');
+        });
+    }
+
+    function identify(rawEmail) {
+        if (!rawEmail || typeof rawEmail !== 'string') { return; }
+        var email = rawEmail.toLowerCase().trim();
+        if (!isCompleteEmail(email)) { return; }
+        if (firedEmails[email]) { return; }
+        firedEmails[email] = true;
+        whenPixelReady(function () {
+            try {
+                sha256Hex(email).then(function (hex) {
+                    window.$mcSite.pixel.api.identify({ type: 'EMAIL_SHA256', value: hex });
+                }).catch(function () {
+                    window.$mcSite.pixel.api.identify({ type: 'EMAIL', value: email });
+                });
+            } catch (e) {
+                try { window.$mcSite.pixel.api.identify({ type: 'EMAIL', value: email }); } catch (ee) {}
+            }
+        });
+    }
+
+    function readIdentityIsland() {
+        var el = document.getElementById('mailchimp-pixel-identity-data');
+        if (!el) { return; }
+        try {
+            var parsed = JSON.parse(el.textContent || el.innerHTML);
+            if (parsed && parsed.email) { identify(parsed.email); }
+        } catch (e) {}
+    }
+
+    function hookCheckoutEmailField() {
+        var SELECTORS = ['#customer-email', 'input[type="email"][name="email_address"]'];
+        var attached = null;
+
+        function findField() {
+            for (var i = 0; i < SELECTORS.length; i++) {
+                var el = document.querySelector(SELECTORS[i]);
+                if (el) { return el; }
+            }
+            return null;
+        }
+
+        function attach(field) {
+            if (attached && attached.field === field) { return; }
+            if (attached) { attached.teardown(); }
+            var lastValue = '';
+            var inputTimer = null;
+            var onBlur = function () {
+                if (inputTimer) { clearTimeout(inputTimer); inputTimer = null; }
+                var v = field.value || '';
+                if (v && v !== lastValue) { lastValue = v; identify(v); }
+            };
+            var onInput = function () {
+                if (inputTimer) { clearTimeout(inputTimer); }
+                inputTimer = setTimeout(function () {
+                    inputTimer = null;
+                    var v = field.value || '';
+                    if (v && v !== lastValue) { lastValue = v; identify(v); }
+                }, INPUT_DEBOUNCE_MS);
+            };
+            field.addEventListener('blur', onBlur);
+            field.addEventListener('input', onInput);
+            attached = {
+                field: field,
+                teardown: function () {
+                    if (inputTimer) { clearTimeout(inputTimer); inputTimer = null; }
+                    field.removeEventListener('blur', onBlur);
+                    field.removeEventListener('input', onInput);
+                    attached = null;
+                }
+            };
+        }
+
+        var existing = findField();
+        if (existing) { attach(existing); }
+
+        if (typeof MutationObserver === 'function') {
+            var obs = new MutationObserver(function () {
+                var f = findField();
+                if (f) { attach(f); } else if (attached) { attached.teardown(); }
+            });
+            obs.observe(document.body || document.documentElement, { childList: true, subtree: true });
+        } else {
+            var attempts = 0;
+            var iv = setInterval(function () {
+                attempts++;
+                var f = findField();
+                if (f) { attach(f); }
+                if (attempts > POLL_MAX_ATTEMPTS) { clearInterval(iv); }
+            }, POLL_INTERVAL_MS);
+        }
+    }
+
+    window.EbizMcPixel = window.EbizMcPixel || {};
+    window.EbizMcPixel.identify = identify;
+    readIdentityIsland();
+    hookCheckoutEmailField();
+}());

--- a/view/frontend/web/js/pixel/order.js
+++ b/view/frontend/web/js/pixel/order.js
@@ -1,0 +1,50 @@
+/**
+ * Ebizmarts_MailChimp — PURCHASED tracker.
+ *
+ * Self-contained IIFE. Reads the mailchimp-pixel-order-data island and fires
+ * PURCHASED via the Mailchimp Pixel SDK. Deduplicates per order id using
+ * sessionStorage.
+ *
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+(function () {
+    'use strict';
+    var DATA_ID = 'mailchimp-pixel-order-data';
+    var DEDUP_PREFIX = 'mc_pixel_purchased_';
+    var POLL_INTERVAL_MS = 100;
+    var POLL_MAX_ATTEMPTS = 100;
+    var POST_READY_GRACE_MS = 1000;
+
+    function isPixelReady() {
+        return !!(window.$mcSite && window.$mcSite.pixel && window.$mcSite.pixel.installed === true
+            && window.$mcSite.pixel.api && typeof window.$mcSite.pixel.api.track === 'function');
+    }
+
+    function whenPixelReady(cb) {
+        var fire = function () { setTimeout(cb, POST_READY_GRACE_MS); };
+        if (isPixelReady()) { fire(); return; }
+        var attempts = 0;
+        var iv = setInterval(function () {
+            attempts++;
+            if (isPixelReady()) { clearInterval(iv); fire(); } else if (attempts > POLL_MAX_ATTEMPTS) { clearInterval(iv); }
+        }, POLL_INTERVAL_MS);
+    }
+
+    function readIsland() {
+        var el = document.getElementById(DATA_ID);
+        if (!el) { return null; }
+        try { return JSON.parse(el.textContent || el.innerHTML); } catch (e) { return null; }
+    }
+
+    var order = readIsland();
+    if (!order || !order.id) { return; }
+    var dedupKey = DEDUP_PREFIX + order.id;
+    try { if (sessionStorage.getItem(dedupKey)) { return; } } catch (e) {}
+    whenPixelReady(function () {
+        try {
+            window.$mcSite.pixel.api.track('PURCHASED', { order: order });
+            try { sessionStorage.setItem(dedupKey, '1'); } catch (e) {}
+        } catch (e) {}
+    });
+}());

--- a/view/frontend/web/js/pixel/product.js
+++ b/view/frontend/web/js/pixel/product.js
@@ -1,0 +1,43 @@
+/**
+ * Ebizmarts_MailChimp — PRODUCT_VIEWED tracker.
+ *
+ * Self-contained IIFE. Reads the mailchimp-pixel-product-data island and fires
+ * PRODUCT_VIEWED via the Mailchimp Pixel SDK.
+ *
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+(function () {
+    'use strict';
+    var DATA_ID = 'mailchimp-pixel-product-data';
+    var POLL_INTERVAL_MS = 100;
+    var POLL_MAX_ATTEMPTS = 100;
+    var POST_READY_GRACE_MS = 1000;
+
+    function isPixelReady() {
+        return !!(window.$mcSite && window.$mcSite.pixel && window.$mcSite.pixel.installed === true
+            && window.$mcSite.pixel.api && typeof window.$mcSite.pixel.api.track === 'function');
+    }
+
+    function whenPixelReady(cb) {
+        var fire = function () { setTimeout(cb, POST_READY_GRACE_MS); };
+        if (isPixelReady()) { fire(); return; }
+        var attempts = 0;
+        var iv = setInterval(function () {
+            attempts++;
+            if (isPixelReady()) { clearInterval(iv); fire(); } else if (attempts > POLL_MAX_ATTEMPTS) { clearInterval(iv); }
+        }, POLL_INTERVAL_MS);
+    }
+
+    function readIsland() {
+        var el = document.getElementById(DATA_ID);
+        if (!el) { return null; }
+        try { return JSON.parse(el.textContent || el.innerHTML); } catch (e) { return null; }
+    }
+
+    var product = readIsland();
+    if (!product || !product.id) { return; }
+    whenPixelReady(function () {
+        try { window.$mcSite.pixel.api.track('PRODUCT_VIEWED', { product: product }); } catch (e) {}
+    });
+}());

--- a/view/frontend/web/js/pixel/search.js
+++ b/view/frontend/web/js/pixel/search.js
@@ -1,0 +1,43 @@
+/**
+ * Ebizmarts_MailChimp — SEARCH_SUBMITTED tracker.
+ *
+ * Self-contained IIFE. Reads the mailchimp-pixel-search-data island and fires
+ * SEARCH_SUBMITTED unwrapped via the Mailchimp Pixel SDK.
+ *
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+(function () {
+    'use strict';
+    var DATA_ID = 'mailchimp-pixel-search-data';
+    var POLL_INTERVAL_MS = 100;
+    var POLL_MAX_ATTEMPTS = 100;
+    var POST_READY_GRACE_MS = 1000;
+
+    function isPixelReady() {
+        return !!(window.$mcSite && window.$mcSite.pixel && window.$mcSite.pixel.installed === true
+            && window.$mcSite.pixel.api && typeof window.$mcSite.pixel.api.track === 'function');
+    }
+
+    function whenPixelReady(cb) {
+        var fire = function () { setTimeout(cb, POST_READY_GRACE_MS); };
+        if (isPixelReady()) { fire(); return; }
+        var attempts = 0;
+        var iv = setInterval(function () {
+            attempts++;
+            if (isPixelReady()) { clearInterval(iv); fire(); } else if (attempts > POLL_MAX_ATTEMPTS) { clearInterval(iv); }
+        }, POLL_INTERVAL_MS);
+    }
+
+    function readIsland() {
+        var el = document.getElementById(DATA_ID);
+        if (!el) { return null; }
+        try { return JSON.parse(el.textContent || el.innerHTML); } catch (e) { return null; }
+    }
+
+    var search = readIsland();
+    if (!search || !search.query) { return; }
+    whenPixelReady(function () {
+        try { window.$mcSite.pixel.api.track('SEARCH_SUBMITTED', search); } catch (e) {}
+    });
+}());


### PR DESCRIPTION
## Summary

- Implements behavioral tracking via the Mailchimp Pixel SDK with 8 events: `PAGE_VIEWED`, `PRODUCT_VIEWED`, `PRODUCT_CATEGORY_VIEWED`, `PRODUCT_ADDED_TO_CART`, `CART_VIEWED`, `CHECKOUT_STARTED`, `PURCHASED`, `SEARCH_SUBMITTED`
- Self-contained IIFE JS files loaded via `<script src defer>` — fully CSP-compliant with no inline scripts required from our code
- Visitor identification via SHA-256 hashed email (`IDENTITY_ASSOCIATED`) on both logged-in customer pages and checkout email field

## Architecture

- **JS**: One IIFE per event, reads a `<script type="application/json">` data island, fires `window.$mcSite.pixel.api.track()` after SDK readiness poll
- **PHP blocks**: `Block/Pixel/` — one block per page type, renders JSON island + loads event JS via `<script src defer>`
- **CSP**: SDK inline script hashes whitelisted in `csp_whitelist.xml`; our own scripts need no hash/nonce
- **Dedup**: `CHECKOUT_STARTED` per `cartId`, `PURCHASED` per `order.id` via `sessionStorage`
- **Provisioning**: `ConnectedSiteProvisioner` resolves the Mailchimp connected site and calls `enable-pixel`; `PixelStateWriter` persists config atomically
- **Hyva**: Layout handles for `hyva_checkout_index_index` and `hyva_checkout_success`

## Test plan

- [x] All 8 events fire and return 200/201 from the Pixel endpoint
- [x] `IDENTITY_ASSOCIATED` fires with `EMAIL_SHA256` on checkout email field blur
- [x] `CHECKOUT_STARTED` does not fire twice on page reload (sessionStorage dedup)
- [x] `PURCHASED` does not fire twice on success page reload (sessionStorage dedup)
- [x] No false `PRODUCT_ADDED_TO_CART` on cart page load
- [x] No CSP errors in browser console on checkout page
- [x] Pixel does not load when disabled in admin config

Closes #2280