### PR TITLE
fixes #2312 atomic issync write; eliminate scalar/branch path collision

### DIFF
--- a/Cron/Ecommerce.php
+++ b/Cron/Ecommerce.php
@@ -291,10 +291,14 @@ class Ecommerce
         $countTotal = $this->_helper->getTotalNewItemsSent();
         $syncing = $this->_helper->getMCMinSyncDateFlag($storeId);
         if ($countTotal == 0 && $syncing) {
+            // Pass $mailchimpStoreId so the write goes to issync/<id> only —
+            // writing the bare scalar issync alongside issync/<id> children at
+            // the same scope causes a fatal in Magento's Scope\Converter.
             $this->_helper->saveMCMinSyncing(
-                null,
+                $mailchimpStoreId,
                 date('Y-m-d'),
-                $storeId
+                0,
+                'default'
             );
         }
 
@@ -308,6 +312,14 @@ class Ecommerce
     protected function updateSyncFlagData($storeId, $mailchimpStoreId)
     {
         $this->apiUpdateSyncFlag($storeId, $mailchimpStoreId);
+        // Defensively remove any bare scalar issync row at default scope before
+        // writing the per-store issync/<id> child. If both coexist at the same
+        // scope Magento's Scope\Converter throws a site-wide fatal TypeError.
+        $this->_helper->deleteConfig(
+            \Ebizmarts\MailChimp\Helper\Data::XML_PATH_IS_SYNC,
+            0,
+            'default'
+        );
         $this->_helper->saveMCMinSyncing(
             $mailchimpStoreId,
             date('Y-m-d'),

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -534,13 +534,57 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         }
         $this->_cacheTypeList->cleanType('config');
     }
-    public function saveMCMinSyncing($mailchimpStoreId, $value, $storeId = null, $scope = null)
+
+    /**
+     * Atomically upsert a single config row using INSERT … ON DUPLICATE KEY UPDATE.
+     *
+     * core_config_data has a UNIQUE KEY on (scope, scope_id, path), so a plain
+     * INSERT … ON DUPLICATE KEY UPDATE is one round-trip and race-free — unlike
+     * Magento's ResourceModel\Config::saveConfig() which does a SELECT then
+     * INSERT/UPDATE (TOCTOU window under concurrent cron workers).
+     *
+     * Does NOT flush the config cache — callers that need an immediate cache
+     * refresh should call $this->_cacheTypeList->cleanType('config') themselves.
+     */
+    private function saveConfigValueAtomic(string $path, string $value, string $scope, int $scopeId): void
     {
-        if ($mailchimpStoreId) {
-            $this->saveConfigValue(self::XML_PATH_IS_SYNC . "/$mailchimpStoreId", $value, $storeId, $scope);
-        } else {
-            $this->saveConfigValue(self::XML_PATH_IS_SYNC, $value, $storeId, $scope);
+        $table = $this->_resource->getTableName('core_config_data');
+        $this->connection->insertOnDuplicate(
+            $table,
+            ['scope' => $scope, 'scope_id' => $scopeId, 'path' => $path, 'value' => $value],
+            ['value']
+        );
+    }
+
+    /**
+     * Write the issync flag for a Mailchimp store.
+     *
+     * Only the per-mailchimpStore path (issync/<mcStoreId>) is ever written.
+     * Writing the bare scalar issync alongside issync/<id> children at the
+     * same scope causes Magento\Framework\App\Config\Scope\Converter to throw
+     * "Cannot access offset of type string on string" — a site-wide fatal.
+     *
+     * The write is atomic (INSERT … ON DUPLICATE KEY UPDATE) to prevent the
+     * check-then-write race that produces duplicate core_config_data rows under
+     * concurrent cron workers.
+     *
+     * @param string $mailchimpStoreId
+     * @param string $value
+     * @param int    $scopeId
+     * @param string $scope
+     */
+    public function saveMCMinSyncing($mailchimpStoreId, $value, $scopeId = 0, $scope = 'default')
+    {
+        if (!$mailchimpStoreId) {
+            // Bare-scalar write intentionally removed — see docblock above.
+            return;
         }
+        $this->saveConfigValueAtomic(
+            self::XML_PATH_IS_SYNC . '/' . $mailchimpStoreId,
+            (string) $value,
+            (string) $scope,
+            (int) $scopeId
+        );
     }
     public function getCartUrl($storeId, $cartId, $token)
     {

--- a/Setup/Patch/Data/CleanIssyncOrphanRows.php
+++ b/Setup/Patch/Data/CleanIssyncOrphanRows.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Ebizmarts_MailChimp Magento Component
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Setup\Patch\Data;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Setup\Patch\DataPatchInterface;
+
+/**
+ * Removes orphaned bare-scalar mailchimp/general/issync rows from
+ * core_config_data that coexist with per-store issync/<mailchimpStoreId>
+ * child rows at the same scope.
+ *
+ * When both shapes exist at the same scope Magento's Scope\Converter sets
+ * issync = "<date>" (string) and then tries issync['<id>'] = … resulting in
+ * "Cannot access offset of type string on string" — a site-wide fatal on
+ * every request.
+ *
+ * Safe to run on clean installs (DELETE WHERE … is a no-op when no orphans
+ * exist). Idempotent.
+ */
+class CleanIssyncOrphanRows implements DataPatchInterface
+{
+    private const ISSYNC_PATH = 'mailchimp/general/issync';
+
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+
+    /**
+     * @param ResourceConnection $resourceConnection
+     */
+    public function __construct(ResourceConnection $resourceConnection)
+    {
+        $this->resourceConnection = $resourceConnection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function apply()
+    {
+        $connection = $this->resourceConnection->getConnection();
+        $table      = $this->resourceConnection->getTableName('core_config_data');
+
+        // Find every (scope, scope_id) pair that has BOTH the bare scalar path
+        // AND at least one per-store child path.  Only delete the bare scalar
+        // from those pairs — leave clean installs untouched.
+        $childExists = $connection->select()
+            ->from(['child' => $table], [])
+            ->where('child.scope   = parent.scope')
+            ->where('child.scope_id = parent.scope_id')
+            ->where('child.path LIKE ?', self::ISSYNC_PATH . '/%');
+
+        $connection->delete(
+            $table,
+            [
+                'path = ?'                    => self::ISSYNC_PATH,
+                'EXISTS (' . $childExists . ')' => null,
+            ]
+        );
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getDependencies(): array
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAliases(): array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
Closes #2312

## Summary

- **A — Atomic write:** `saveConfigValueAtomic()` uses `INSERT … ON DUPLICATE KEY UPDATE` on `core_config_data` — single round-trip, eliminates the TOCTOU race between concurrent cron workers that produced duplicate rows.
- **B — One config shape only:** `saveMCMinSyncing()` only writes `issync/<mailchimpStoreId>` children, never the bare scalar `issync`. `updateSyncFlagData()` defensively deletes the bare scalar at default scope before writing. `_processStore()` passes `$mailchimpStoreId` instead of `null`.
- **C — Data cleanup:** `Setup/Patch/Data/CleanIssyncOrphanRows` deletes orphaned bare-scalar `issync` rows coexisting with child rows at the same scope — lets affected merchants safely reinstall without manually patching their DB.
- **D — No per-write cache flush:** `saveConfigValueAtomic()` does not call `cleanType('config')`, eliminating the cache-thrash loop under concurrent cron load.

## Test plan

- [ ] Run ecommerce cron on a store with pending items — `issync/<mcStoreId>` row written at default scope, no bare scalar `issync` row created
- [ ] Simulate concurrent cron execution — only one `core_config_data` row exists for each `(scope, scope_id, path)` after both workers finish
- [ ] On an installation with an orphaned bare scalar `issync` row: run `setup:upgrade` — orphan row is removed, site loads without TypeError
- [ ] No regression on stores that have never triggered the bug — patch is a no-op