### PR TITLE
fixes #2312 atomic issync write; eliminate scalar/branch path collision

### DIFF
--- a/Cron/Ecommerce.php
+++ b/Cron/Ecommerce.php
@@ -290,10 +290,14 @@ class Ecommerce
         $countTotal = $this->_helper->getTotalNewItemsSent();
         $syncing = $this->_helper->getMCMinSyncDateFlag($storeId);
         if ($countTotal == 0 && $syncing) {
+            // Pass $mailchimpStoreId so the write goes to issync/<id> only —
+            // writing the bare scalar issync alongside issync/<id> children at
+            // the same scope causes a fatal in Magento's Scope\Converter.
             $this->_helper->saveMCMinSyncing(
-                null,
+                $mailchimpStoreId,
                 date('Y-m-d'),
-                $storeId
+                0,
+                'default'
             );
         }
 
@@ -307,6 +311,14 @@ class Ecommerce
     protected function updateSyncFlagData($storeId, $mailchimpStoreId)
     {
         $this->apiUpdateSyncFlag($storeId, $mailchimpStoreId);
+        // Defensively remove any bare scalar issync row at default scope before
+        // writing the per-store issync/<id> child. If both coexist at the same
+        // scope Magento's Scope\Converter throws a site-wide fatal TypeError.
+        $this->_helper->deleteConfig(
+            \Ebizmarts\MailChimp\Helper\Data::XML_PATH_IS_SYNC,
+            0,
+            'default'
+        );
         $this->_helper->saveMCMinSyncing(
             $mailchimpStoreId,
             date('Y-m-d'),

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -512,13 +512,57 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         }
         $this->_cacheTypeList->cleanType('config');
     }
-    public function saveMCMinSyncing($mailchimpStoreId, $value, $storeId = null, $scope = null)
+
+    /**
+     * Atomically upsert a single config row using INSERT … ON DUPLICATE KEY UPDATE.
+     *
+     * core_config_data has a UNIQUE KEY on (scope, scope_id, path), so a plain
+     * INSERT … ON DUPLICATE KEY UPDATE is one round-trip and race-free — unlike
+     * Magento's ResourceModel\Config::saveConfig() which does a SELECT then
+     * INSERT/UPDATE (TOCTOU window under concurrent cron workers).
+     *
+     * Does NOT flush the config cache — callers that need an immediate cache
+     * refresh should call $this->_cacheTypeList->cleanType('config') themselves.
+     */
+    private function saveConfigValueAtomic(string $path, string $value, string $scope, int $scopeId): void
     {
-        if ($mailchimpStoreId) {
-            $this->saveConfigValue(self::XML_PATH_IS_SYNC . "/$mailchimpStoreId", $value, $storeId, $scope);
-        } else {
-            $this->saveConfigValue(self::XML_PATH_IS_SYNC, $value, $storeId, $scope);
+        $table = $this->_resource->getTableName('core_config_data');
+        $this->connection->insertOnDuplicate(
+            $table,
+            ['scope' => $scope, 'scope_id' => $scopeId, 'path' => $path, 'value' => $value],
+            ['value']
+        );
+    }
+
+    /**
+     * Write the issync flag for a Mailchimp store.
+     *
+     * Only the per-mailchimpStore path (issync/<mcStoreId>) is ever written.
+     * Writing the bare scalar issync alongside issync/<id> children at the
+     * same scope causes Magento\Framework\App\Config\Scope\Converter to throw
+     * "Cannot access offset of type string on string" — a site-wide fatal.
+     *
+     * The write is atomic (INSERT … ON DUPLICATE KEY UPDATE) to prevent the
+     * check-then-write race that produces duplicate core_config_data rows under
+     * concurrent cron workers.
+     *
+     * @param string $mailchimpStoreId
+     * @param string $value
+     * @param int    $scopeId
+     * @param string $scope
+     */
+    public function saveMCMinSyncing($mailchimpStoreId, $value, $scopeId = 0, $scope = 'default')
+    {
+        if (!$mailchimpStoreId) {
+            // Bare-scalar write intentionally removed — see docblock above.
+            return;
         }
+        $this->saveConfigValueAtomic(
+            self::XML_PATH_IS_SYNC . '/' . $mailchimpStoreId,
+            (string) $value,
+            (string) $scope,
+            (int) $scopeId
+        );
     }
     public function getCartUrl($storeId, $cartId, $token)
     {

--- a/Setup/Patch/Data/CleanIssyncOrphanRows.php
+++ b/Setup/Patch/Data/CleanIssyncOrphanRows.php
@@ -55,18 +55,19 @@ class CleanIssyncOrphanRows implements DataPatchInterface
         // Find every (scope, scope_id) pair that has BOTH the bare scalar path
         // AND at least one per-store child path.  Only delete the bare scalar
         // from those pairs — leave clean installs untouched.
-        $childExists = $connection->select()
-            ->from(['child' => $table], [])
-            ->where('child.scope   = parent.scope')
-            ->where('child.scope_id = parent.scope_id')
+        $childSelect = $connection->select()
+            ->from(['child' => $table], [new \Zend_Db_Expr('1')])
+            ->where('child.scope    = main.scope')
+            ->where('child.scope_id = main.scope_id')
             ->where('child.path LIKE ?', self::ISSYNC_PATH . '/%');
 
-        $connection->delete(
-            $table,
-            [
-                'path = ?'                    => self::ISSYNC_PATH,
-                'EXISTS (' . $childExists . ')' => null,
-            ]
+        $deleteSelect = $connection->select()
+            ->from(['main' => $table], ['config_id'])
+            ->where('main.path = ?', self::ISSYNC_PATH)
+            ->where('EXISTS (' . $childSelect . ')');
+
+        $connection->query(
+            'DELETE FROM ' . $table . ' WHERE config_id IN (' . $deleteSelect . ')'
         );
 
         return $this;

--- a/Setup/Patch/Data/CleanIssyncOrphanRows.php
+++ b/Setup/Patch/Data/CleanIssyncOrphanRows.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Ebizmarts_MailChimp Magento Component
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Setup\Patch\Data;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Setup\Patch\DataPatchInterface;
+
+/**
+ * Removes orphaned bare-scalar mailchimp/general/issync rows from
+ * core_config_data that coexist with per-store issync/<mailchimpStoreId>
+ * child rows at the same scope.
+ *
+ * When both shapes exist at the same scope Magento's Scope\Converter sets
+ * issync = "<date>" (string) and then tries issync['<id>'] = … resulting in
+ * "Cannot access offset of type string on string" — a site-wide fatal on
+ * every request.
+ *
+ * Safe to run on clean installs (DELETE WHERE … is a no-op when no orphans
+ * exist). Idempotent.
+ */
+class CleanIssyncOrphanRows implements DataPatchInterface
+{
+    private const ISSYNC_PATH = 'mailchimp/general/issync';
+
+    /**
+     * @var ResourceConnection
+     */
+    private $resourceConnection;
+
+    /**
+     * @param ResourceConnection $resourceConnection
+     */
+    public function __construct(ResourceConnection $resourceConnection)
+    {
+        $this->resourceConnection = $resourceConnection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function apply()
+    {
+        $connection = $this->resourceConnection->getConnection();
+        $table      = $this->resourceConnection->getTableName('core_config_data');
+
+        // Find every (scope, scope_id) pair that has BOTH the bare scalar path
+        // AND at least one per-store child path.  Only delete the bare scalar
+        // from those pairs — leave clean installs untouched.
+        $childExists = $connection->select()
+            ->from(['child' => $table], [])
+            ->where('child.scope   = parent.scope')
+            ->where('child.scope_id = parent.scope_id')
+            ->where('child.path LIKE ?', self::ISSYNC_PATH . '/%');
+
+        $connection->delete(
+            $table,
+            [
+                'path = ?'                    => self::ISSYNC_PATH,
+                'EXISTS (' . $childExists . ')' => null,
+            ]
+        );
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getDependencies(): array
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAliases(): array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
## Summary

- **`saveConfigValueAtomic()`**: uses `INSERT … ON DUPLICATE KEY UPDATE` on `core_config_data` — single round-trip, eliminates TOCTOU race between concurrent cron workers.
- **`saveMCMinSyncing()`**: only writes `issync/<mailchimpStoreId>` child paths, never the bare scalar `issync`. `updateSyncFlagData()` defensively deletes the bare scalar at default scope before writing the child path. `_processStore()` passes `mailchimpStoreId` instead of `null`.
- **`Setup/Patch/Data/CleanIssyncOrphanRows`**: deletes orphaned bare-scalar `issync` rows that coexist with child rows at the same scope, letting affected merchants safely reinstall. Fixes a SQL syntax error by using a `SELECT 1` subquery with an explicit alias and deleting via `config_id` subselect to avoid invalid `EXISTS()` syntax generated by Zend_Db.
- **`saveConfigValueAtomic()`** does not flush the config cache, eliminating per-write `cleanType()` thrash under concurrent cron load.

## Test plan

- [ ] Run ecommerce cron with multiple concurrent workers and verify no scalar/branch collision in `core_config_data`
- [ ] Verify `issync/<mailchimpStoreId>` child rows are written correctly per store
- [ ] Run `CleanIssyncOrphanRows` patch on an affected installation and confirm orphaned rows are removed without SQL errors
- [ ] Confirm config cache is not flushed on every `saveConfigValueAtomic()` call under load