### PR TITLE
Version 79 for magento 2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [103.4.79](https://github.com/mailchimp/mc-magento2/tree/103.4.79)
+
+[Full Changelog](https://github.com/mailchimp/mc-magento2/compare/103.4.78...103.4.79)
+
+**Implemented enhancements:**
+
+- Pixel integration [\#2280](https://github.com/mailchimp/mc-magento2/issues/2280)
+- PHP 8.5 deprecated usage of curl\_close [\#2287](https://github.com/mailchimp/mc-magento2/issues/2287)
+- Processing products takes too much time in \_markSpecialPrices [\#2294](https://github.com/mailchimp/mc-magento2/issues/2294)
+
+**Fixed bugs:**
+
+- Concurrent cron writes produce duplicate core\_config\_data rows causing site-wide fatal TypeError [\#2312](https://github.com/mailchimp/mc-magento2/issues/2312)
+- Fix deadlock in SaveBefore observer by acquiring IS\_SUBSCRIBER lock before IS\_CUSTOMER [\#2292](https://github.com/mailchimp/mc-magento2/issues/2292)
+- Using a second Mailchimp account on a certain Magento scope makes the dropdown list disappear [\#2288](https://github.com/mailchimp/mc-magento2/issues/2288)
+- Wrong Exception import in Helper/Data.php breaks catch blocks [\#2290](https://github.com/mailchimp/mc-magento2/issues/2290)
+- Skip unreachable store instead of aborting whole ecommerce cron
+- Fix getMCMinSyncDateFlag returning an array on multi-store installs
+- Array to string conversion warning \(follow-up\) [\#2250](https://github.com/mailchimp/mc-magento2/issues/2250)
+
 ## [103.4.78](https://github.com/mailchimp/mc-magento2/tree/103.4.78)
 
 [Full Changelog](https://github.com/mailchimp/mc-magento2/compare/103.4.77...103.4.78)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,6 @@
 - Fix deadlock in SaveBefore observer by acquiring IS\_SUBSCRIBER lock before IS\_CUSTOMER [\#2292](https://github.com/mailchimp/mc-magento2/issues/2292)
 - Using a second Mailchimp account on a certain Magento scope makes the dropdown list disappear [\#2288](https://github.com/mailchimp/mc-magento2/issues/2288)
 - Wrong Exception import in Helper/Data.php breaks catch blocks [\#2290](https://github.com/mailchimp/mc-magento2/issues/2290)
-- Skip unreachable store instead of aborting whole ecommerce cron
-- Fix getMCMinSyncDateFlag returning an array on multi-store installs
 - Array to string conversion warning \(follow-up\) [\#2250](https://github.com/mailchimp/mc-magento2/issues/2250)
 
 ## [103.4.78](https://github.com/mailchimp/mc-magento2/tree/103.4.78)

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   },
   "description": "Connect MailChimp with Magento",
   "type": "magento2-module",
-  "version": "103.4.78",
+  "version": "103.4.79",
   "authors": [
     {
       "name": "Ebizmarts Corp",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -11,7 +11,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Ebizmarts_MailChimp" setup_version="103.4.78">
+    <module name="Ebizmarts_MailChimp" setup_version="103.4.79">
         <sequence>
             <module name="Magento_Newsletter"/>
             <module name="Magento_Sales"/>


### PR DESCRIPTION
## Summary

Bump version to 103.4.79. Full changelog in CHANGELOG.md.

**Implemented enhancements:**

- Pixel integration [\#2280](https://github.com/mailchimp/mc-magento2/issues/2280)
- PHP 8.5 deprecated usage of curl_close [\#2287](https://github.com/mailchimp/mc-magento2/issues/2287)
- Processing products takes too much time in _markSpecialPrices [\#2294](https://github.com/mailchimp/mc-magento2/issues/2294)

**Fixed bugs:**

- Concurrent cron writes produce duplicate core_config_data rows causing site-wide fatal TypeError [\#2312](https://github.com/mailchimp/mc-magento2/issues/2312)
- Fix deadlock in SaveBefore observer by acquiring IS_SUBSCRIBER lock before IS_CUSTOMER [\#2292](https://github.com/mailchimp/mc-magento2/issues/2292)
- Using a second Mailchimp account on a certain Magento scope makes the dropdown list disappear [\#2288](https://github.com/mailchimp/mc-magento2/issues/2288)
- Wrong Exception import in Helper/Data.php breaks catch blocks [\#2290](https://github.com/mailchimp/mc-magento2/issues/2290)
- Skip unreachable store instead of aborting whole ecommerce cron
- Fix getMCMinSyncDateFlag returning an array on multi-store installs
- Array to string conversion warning (follow-up) [\#2250](https://github.com/mailchimp/mc-magento2/issues/2250)