### PR TITLE
Closes #2321 for Magento 2.3.6-p1

### DIFF
--- a/Model/Api/Order.php
+++ b/Model/Api/Order.php
@@ -14,7 +14,6 @@
 namespace Ebizmarts\MailChimp\Model\Api;
 
 use Magento\SalesRule\Model\RuleRepository;
-use Symfony\Component\Config\Definition\Exception\Exception;
 use Ebizmarts\MailChimp\Helper\Sync as SyncHelper;
 
 class Order


### PR DESCRIPTION
Port of the Model/Api/Order.php fix for #2321 to the develop-2.3.6-p1 branch.

Removes the accidental `use Symfony\Component\Config\Definition\Exception\Exception;` import so the unqualified `Exception` resolves to the global `\Exception`. This restores the per-order catch-all guards in the order-sync loops (`_getNewOrders()` / modified orders): a single unreadable order — e.g. one whose `sales_order_payment.additional_information` holds legacy non-JSON data that Magento core's Json serializer rejects during `OrderRepository::get()` — is now logged and skipped instead of aborting the whole `ebizmarts_ecommerce` cron.

Same class of fix as #2290/#2291, applied to `Model/Api/Order.php`. Relates to #2321.