### PR TITLE
Fix MySQL 1093 error in CleanIssyncOrphanRows data patch

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -527,7 +527,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     private function saveConfigValueAtomic(string $path, string $value, string $scope, int $scopeId): void
     {
         $table = $this->_resource->getTableName('core_config_data');
-        $this->connection->insertOnDuplicate(
+        $this->_resource->getConnection()->insertOnDuplicate(
             $table,
             ['scope' => $scope, 'scope_id' => $scopeId, 'path' => $path, 'value' => $value],
             ['value']

--- a/Setup/Patch/Data/CleanIssyncOrphanRows.php
+++ b/Setup/Patch/Data/CleanIssyncOrphanRows.php
@@ -66,8 +66,11 @@ class CleanIssyncOrphanRows implements DataPatchInterface
             ->where('main.path = ?', self::ISSYNC_PATH)
             ->where('EXISTS (' . $childSelect . ')');
 
+        // Wrap in a derived table to avoid MySQL/MariaDB error 1093
+        // ("You can't specify target table for update in FROM clause")
+        // which is triggered when rows exist that match the DELETE condition.
         $connection->query(
-            'DELETE FROM ' . $table . ' WHERE config_id IN (' . $deleteSelect . ')'
+            'DELETE FROM ' . $table . ' WHERE config_id IN (SELECT config_id FROM (' . $deleteSelect . ') AS _tmp)'
         );
 
         return $this;


### PR DESCRIPTION
## Fixes

### 1. MySQL 1093 error in \`CleanIssyncOrphanRows\` data patch

Running \`bin/magento setup:upgrade\` fails with MySQL/MariaDB error 1093 when orphaned \`mailchimp/general/issync\` rows exist in \`core_config_data\`:

\`\`\`
SQLSTATE[HY000]: General error: 1093 You can't specify target table
'core_config_data' for update in FROM clause
\`\`\`

MySQL and MariaDB do not allow a \`DELETE\` to reference the same table in the \`FROM\` clause of its subquery. The error only triggers when actual rows match the condition — installations without orphaned rows are unaffected, which is why it was not caught earlier.

**Fix:** Wrap the inner \`SELECT\` in a derived table, forcing the engine to materialize it before the \`DELETE\` runs. Compatible with MySQL 5.7+, MySQL 8.x, and MariaDB.

---

### 2. Undefined property \`\$connection\` in \`Helper/Data::saveConfigValueAtomic\`

The \`ebizmarts_ecommerce\` cron intermittently throws:

\`\`\`
Warning: Undefined property: Ebizmarts\MailChimp\Helper\Data::\$connection
in Helper/Data.php on line 530
\`\`\`

\`\$this->connection\` is used in \`saveConfigValueAtomic()\` but was never declared or injected into the class.

**Fix:** Replace \`\$this->connection\` with \`\$this->_resource->getConnection()\`, which is already available via the injected \`ResourceConnection\` instance.

---

## References

Closes #2327