### PR TITLE
chore(support): migrate support email to mailchimp@help.ebizmarts.com (Zendesk → Chatwoot)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 | ![wrong issue format](https://s3.amazonaws.com/ebizmartsgithubimages/wrongissueformat.png) | Issue has not been created according to requirements at the [Issue reporting guidelines](https://github.com/mailchimp/mc-magento2/wiki/Issue-reporting-guidelines). Will be closed until requirements are met. |
 | ![feature request](https://s3.amazonaws.com/ebizmartsgithubimages/featurerequest.png) | Feature request to be considered by the team. After approval will be labeled as enhancement. |
 | ![could not replicate](https://s3.amazonaws.com/ebizmartsgithubimages/couldnotreplicate.png) | The team was not able to replicate issue. It will be closed until missing information is given. |
-| ![contact support](https://s3.amazonaws.com/ebizmartsgithubimages/contactsupport.png) | Contact our support team at mailchimp@ebizmarts-desk.zendesk.com. Issue will be closed with no further action. |
+| ![contact support](https://s3.amazonaws.com/ebizmartsgithubimages/contactsupport.png) | Contact our support team at mailchimp@help.ebizmarts.com. Issue will be closed with no further action. |
 | ![low priority](https://s3.amazonaws.com/ebizmartsgithubimages/lowpriority.png) | Issue is considered as low priority by the team. |
 | ![priority](https://s3.amazonaws.com/ebizmartsgithubimages/priority.png) | Issue is considered as high priority by the team. |
 | ![conflict](https://s3.amazonaws.com/ebizmartsgithubimages/conflict.png) | Issue reports a conflict with other third party extension. |

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   "authors": [
     {
       "name": "Ebizmarts Corp",
-      "email": "mailchimp@ebizmarts-desk.zendesk.com",
+      "email": "mailchimp@help.ebizmarts.com",
       "homepage": "http://ebizmarts.com"
     }
   ],
@@ -19,7 +19,7 @@
     "AFL-3.0"
   ],
   "support": {
-    "email": "mailchimp@ebizmarts-desk.zendesk.com",
+    "email": "mailchimp@help.ebizmarts.com",
     "wiki": "https://connect.mailchimp.com/integrations/magento",
     "forum": "http://ebizmarts.com/forums/view/6"
   },

--- a/view/adminhtml/templates/system/config/fieldset/hint.phtml
+++ b/view/adminhtml/templates/system/config/fieldset/hint.phtml
@@ -38,7 +38,7 @@
             <?php if($block->checkLibVersion()) { ?>
                 <p style="color: red">You need to update the ebizmarts/mailchimp-lib</p>
             <?php } ?>
-            <p><?= $escaper->escapeHtml(__('Need help? See our ')) ?><a href="https://github.com/mailchimp/mc-magento2/wiki" target="_blank"><?= $escaper->escapeHtml(__('Wiki')) ?></a><?= $escaper->escapeUrl(__(' Got feedback? ')) ?><a href="mailto:mailchimp@ebizmarts-desk.zendesk.com?Subject=MailChimp For Magento Version <?= $escaper->escapeHtml($block->getModuleVersion())?>"><?= $escaper->escapeHtml(__('Email us')) ?></a></p>
+            <p><?= $escaper->escapeHtml(__('Need help? See our ')) ?><a href="https://github.com/mailchimp/mc-magento2/wiki" target="_blank"><?= $escaper->escapeHtml(__('Wiki')) ?></a><?= $escaper->escapeUrl(__(' Got feedback? ')) ?><a href="mailto:mailchimp@help.ebizmarts.com?Subject=MailChimp For Magento Version <?= $escaper->escapeHtml($block->getModuleVersion())?>"><?= $escaper->escapeHtml(__('Email us')) ?></a></p>
             <p><?= $escaper->escapeHtml(__('You can find more extension in our ')) ?><a href="http://store.ebizmarts.com" target="_blank"><?= $escaper->escapeUrl(__('Store')) ?></a></p>
             <?php if (!$block->getHasApiKey()): ?>
                 <p><a style="padding-top: 5px;padding-bottom:5px;padding-left: 30px;padding-right: 30px;background-color:#D75F07 ;color:white;font-weight: bold" href="https://bit.ly/2KpDH5C" target="_blank">Support Mailchimp4Magento, Subscribe for a free Mailchimp Account!</a> </p>


### PR DESCRIPTION
## What

Update the support contact email from the retired Zendesk mailbox to the new address:

- `mailchimp@ebizmarts-desk.zendesk.com` → `mailchimp@help.ebizmarts.com`

## Where

- `composer.json` — `support.email` and `authors[].email`
- `view/adminhtml/templates/system/config/fieldset/hint.phtml` — the "Email us" mailto (the `?Subject=` is preserved)
- `README.md` — the "contact support" label

## Notes

Support has moved from Zendesk to Chatwoot and the old mailbox is being retired. Documentation/config only — no functional or code changes.