### PR TITLE
Harden abandoned-cart restore and escape admin account details

### DIFF
--- a/Controller/Cart/Loadquote.php
+++ b/Controller/Cart/Loadquote.php
@@ -13,6 +13,7 @@ use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\View\Result\PageFactory;
 use Magento\Framework\App\Action\Context;
 use Ebizmarts\MailChimp\Helper\Sync as SyncHelper;
+use Ebizmarts\MailChimp\Model\RedirectUrlValidator;
 
 class Loadquote extends Action
 {
@@ -52,6 +53,10 @@ class Loadquote extends Action
      * @var \Magento\Checkout\Model\Session
      */
     protected $_checkoutSession;
+    /**
+     * @var RedirectUrlValidator
+     */
+    private $redirectUrlValidator;
 
     /**
      * @param Context $context
@@ -63,6 +68,7 @@ class Loadquote extends Action
      * @param SyncHelper $syncHelper
      * @param \Magento\Framework\Url $urlHelper
      * @param \Magento\Customer\Model\Url $customerUrl
+     * @param RedirectUrlValidator $redirectUrlValidator
      */
     public function __construct(
         Context $context,
@@ -73,7 +79,8 @@ class Loadquote extends Action
         \Ebizmarts\MailChimp\Helper\Data $helper,
         SyncHelper $syncHelper,
         \Magento\Framework\Url $urlHelper,
-        \Magento\Customer\Model\Url $customerUrl
+        \Magento\Customer\Model\Url $customerUrl,
+        RedirectUrlValidator $redirectUrlValidator
     ) {
 
         $this->pageFactory      = $pageFactory;
@@ -85,6 +92,7 @@ class Loadquote extends Action
         $this->_message         = $context->getMessageManager();
         $this->_customerUrl     = $customerUrl;
         $this->_checkoutSession = $checkoutSession;
+        $this->redirectUrlValidator = $redirectUrlValidator;
         parent::__construct($context);
     }
 
@@ -111,7 +119,10 @@ class Loadquote extends Action
                 $params['id'],
                 \Ebizmarts\MailChimp\Helper\Data::IS_QUOTE
             );
-            if (!isset($params['token']) || $params['token'] != $syncCommerce->getMailchimpToken()) {
+            $storedToken = $syncCommerce->getMailchimpToken();
+            if (!isset($params['token']) || empty($storedToken)
+                || !hash_equals((string)$storedToken, (string)$params['token'])
+            ) {
                 // @error
                 $this->_message->addErrorMessage(__("You can't access this cart"));
                 $url = $this->_urlHelper->getUrl(
@@ -120,7 +131,7 @@ class Loadquote extends Action
                         $magentoStoreId
                     )
                 );
-                $this->_redirect($url);
+                $this->_redirect($this->redirectUrlValidator->getSafeUrl($url, $magentoStoreId));
             } else {
                 if (isset($params['mc_cid'])) {
                     $url = $this->_urlHelper->getUrl(
@@ -145,10 +156,10 @@ class Loadquote extends Action
                 $this->_helper->sendCartEvent($quote);
                 if (!$quote->getCustomerId()) {
                     $this->_checkoutSession->setQuoteId($quote->getId());
-                    $this->_redirect($url);
+                    $this->_redirect($this->redirectUrlValidator->getSafeUrl($url, $magentoStoreId));
                 } else {
                     if ($this->_customerSession->isLoggedIn()) {
-                        $this->_redirect($url);
+                        $this->_redirect($this->redirectUrlValidator->getSafeUrl($url, $magentoStoreId));
                     } else {
                         $this->_message->addNoticeMessage(__("Login to complete your order"));
                         if (isset($params['mc_cid'])) {
@@ -159,7 +170,7 @@ class Loadquote extends Action
                         } else {
                             $url = $this->_customerUrl->getLoginUrl();
                         }
-                        $this->_redirect($url);
+                        $this->_redirect($this->redirectUrlValidator->getSafeUrl($url, $magentoStoreId));
                     }
                 }
             }

--- a/Model/RedirectUrlValidator.php
+++ b/Model/RedirectUrlValidator.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * MailChimp Magento Component
+ *
+ * @category Ebizmarts
+ * @package MailChimp
+ * @author Ebizmarts Team <info@ebizmarts.com>
+ * @copyright Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @file: RedirectUrlValidator.php
+ */
+
+namespace Ebizmarts\MailChimp\Model;
+
+use Magento\Framework\UrlInterface;
+use Magento\Store\Model\StoreManagerInterface;
+
+/**
+ * Defense-in-depth guard against open redirects (CWE-601).
+ *
+ * A URL is considered safe only when it is relative (no host of its own) or
+ * when its host matches one of the current store's own base URL hosts. Anything
+ * else — an absolute URL to a foreign host, a protocol-relative URL
+ * (//evil.com), a backslash bypass (/\evil.com) or a non-http(s) scheme
+ * (javascript:, data:) — is rejected so the caller can fall back to a trusted
+ * destination instead of forwarding the shopper off-site.
+ */
+class RedirectUrlValidator
+{
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @param StoreManagerInterface $storeManager
+     */
+    public function __construct(StoreManagerInterface $storeManager)
+    {
+        $this->storeManager = $storeManager;
+    }
+
+    /**
+     * @param string|null $url
+     * @param int|string|null $storeId
+     * @return bool
+     */
+    public function isSafe($url, $storeId = null)
+    {
+        $url = trim((string)$url);
+        if ($url === '') {
+            return false;
+        }
+
+        // Normalize backslashes: browsers treat "\" as "/" so "/\evil.com" and
+        // "https:\\evil.com" would otherwise slip past a naive parse_url check.
+        $normalized = str_replace('\\', '/', $url);
+
+        // Protocol-relative URL — no scheme but points to another host.
+        if (strpos($normalized, '//') === 0) {
+            return false;
+        }
+
+        $scheme = parse_url($normalized, PHP_URL_SCHEME);
+        if ($scheme !== null && !in_array(strtolower($scheme), ['http', 'https'], true)) {
+            return false;
+        }
+
+        $host = parse_url($normalized, PHP_URL_HOST);
+        if (empty($host)) {
+            // Relative path with no host of its own — stays on the current site.
+            return true;
+        }
+
+        return in_array(strtolower($host), $this->getAllowedHosts($storeId), true);
+    }
+
+    /**
+     * Return $url when it is safe, otherwise a guaranteed-internal fallback
+     * (the store's own base URL).
+     *
+     * @param string|null $url
+     * @param int|string|null $storeId
+     * @return string
+     */
+    public function getSafeUrl($url, $storeId = null)
+    {
+        if ($this->isSafe($url, $storeId)) {
+            return (string)$url;
+        }
+
+        return $this->storeManager->getStore($storeId)->getBaseUrl(UrlInterface::URL_TYPE_WEB, true);
+    }
+
+    /**
+     * Hosts that belong to the current store (secure and unsecure web base URLs).
+     *
+     * @param int|string|null $storeId
+     * @return string[]
+     */
+    private function getAllowedHosts($storeId)
+    {
+        $store = $this->storeManager->getStore($storeId);
+        $hosts = [];
+        foreach ([true, false] as $secure) {
+            $host = parse_url($store->getBaseUrl(UrlInterface::URL_TYPE_WEB, $secure), PHP_URL_HOST);
+            if (!empty($host)) {
+                $hosts[] = strtolower($host);
+            }
+        }
+
+        return array_unique($hosts);
+    }
+}

--- a/Test/Unit/Model/RedirectUrlValidatorTest.php
+++ b/Test/Unit/Model/RedirectUrlValidatorTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Ebizmarts_MailChimp
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Test\Unit\Model;
+
+use Ebizmarts\MailChimp\Model\RedirectUrlValidator;
+use Magento\Framework\UrlInterface;
+use Magento\Store\Model\Store;
+use Magento\Store\Model\StoreManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Open-redirect (CWE-601) guard tests. The store's own host is example.com;
+ * everything that resolves to another host must be rejected.
+ */
+class RedirectUrlValidatorTest extends TestCase
+{
+    /**
+     * @var RedirectUrlValidator
+     */
+    private $validator;
+
+    protected function setUp(): void
+    {
+        $store = $this->createMock(Store::class);
+        $store->method('getBaseUrl')->willReturn('https://example.com/');
+
+        $storeManager = $this->createMock(StoreManagerInterface::class);
+        $storeManager->method('getStore')->willReturn($store);
+
+        $this->validator = new RedirectUrlValidator($storeManager);
+    }
+
+    /**
+     * @dataProvider safeUrlProvider
+     */
+    public function testSafeUrlsAreAccepted($url)
+    {
+        $this->assertTrue($this->validator->isSafe($url, 1));
+    }
+
+    public static function safeUrlProvider()
+    {
+        return [
+            'relative path'         => ['/checkout/cart/'],
+            'relative with query'   => ['/mailchimp/cart/loadquote/id/5/'],
+            'same host absolute'    => ['https://example.com/checkout/'],
+            'same host http'        => ['http://example.com/checkout/'],
+        ];
+    }
+
+    /**
+     * @dataProvider unsafeUrlProvider
+     */
+    public function testUnsafeUrlsAreRejected($url)
+    {
+        $this->assertFalse($this->validator->isSafe($url, 1));
+    }
+
+    public static function unsafeUrlProvider()
+    {
+        return [
+            'foreign host'          => ['https://evil.com/'],
+            'protocol relative'     => ['//evil.com/'],
+            'backslash bypass'      => ['/\\evil.com'],
+            'scheme backslash'      => ['https:\\\\evil.com'],
+            'javascript scheme'     => ['javascript:alert(1)'],
+            'data scheme'           => ['data:text/html,<script>1</script>'],
+            'empty'                 => [''],
+            'null'                  => [null],
+        ];
+    }
+
+    public function testGetSafeUrlReturnsOriginalWhenSafe()
+    {
+        $url = 'https://example.com/checkout/';
+        $this->assertSame($url, $this->validator->getSafeUrl($url, 1));
+    }
+
+    public function testGetSafeUrlFallsBackToBaseUrlWhenUnsafe()
+    {
+        $this->assertSame(
+            'https://example.com/',
+            $this->validator->getSafeUrl('https://evil.com/phish', 1)
+        );
+    }
+}

--- a/view/adminhtml/web/js/configapikey.js
+++ b/view/adminhtml/web/js/configapikey.js
@@ -16,6 +16,15 @@ define(
     function ($, alert, confirmation) {
         "use strict";
 
+        /**
+         * Escape a value coming from the Mailchimp account (account name, email,
+         * plan, etc.) before it is concatenated into admin HTML, to prevent a
+         * hostile connected account from injecting markup/script.
+         */
+        function escapeHtml(value) {
+            return $('<div>').text(value === null || value === undefined ? '' : value).html();
+        }
+
         $.widget('mage.configmonkeyapikey', {
             "options": {
                 "storeUrl": "",
@@ -345,7 +354,7 @@ define(
                 }).done(function (data) {
                         $.each(data, function (i, item) {
                             if (item.hasOwnProperty('label')) {
-                                $('#mailchimp_general_account_details_ul').append('<li>' + item.label + ' ' + item.value + '</li>');
+                                $('#mailchimp_general_account_details_ul').append($('<li>').text(item.label + ' ' + item.value));
                             } else if (item.hasOwnProperty('code')) {
                                 accountdata[item.code] = {'value': item.value, 'html': item.html};
                             }
@@ -353,7 +362,7 @@ define(
                         var outputtext = "<table style='border-collapse; margin-left: 10px;' >"
                         for (const key in accountdata) {
                             if (accountdata.hasOwnProperty(key)) {
-                                outputtext += '<tr><td style="border: 1px solid black;padding-left: 10px;padding-right: 10px;"><strong>' + accountdata[key]['html'] + '</strong></td><td style="border: 1px solid black;padding-left: 10px;padding-right: 10px;">' + accountdata[key]['value'] + '</td></tr>';
+                                outputtext += '<tr><td style="border: 1px solid black;padding-left: 10px;padding-right: 10px;"><strong>' + escapeHtml(accountdata[key]['html']) + '</strong></td><td style="border: 1px solid black;padding-left: 10px;padding-right: 10px;">' + escapeHtml(accountdata[key]['value']) + '</td></tr>';
                             }
                         }
                         outputtext += '</table>';
@@ -434,7 +443,7 @@ define(
                 }).done(function (data) {
                     $.each(data, function (i, item) {
                         if (item.hasOwnProperty('label')) {
-                            $('#mailchimp_general_account_details_ul').append('<li>' + item.label + ' ' + item.value + '</li>');
+                            $('#mailchimp_general_account_details_ul').append($('<li>').text(item.label + ' ' + item.value));
                         } else if (item.hasOwnProperty('code')) {
                             accountdata[item.code] = {'value': item.value,'html':item.html};
                         }
@@ -477,7 +486,7 @@ define(
                     var outputtext = "<table style='border-collapse; margin-left: 10px;' >"
                     for (const key in accountdata) {
                         if (accountdata.hasOwnProperty(key)) {
-                            outputtext += '<tr><td style="border: 1px solid black;padding-left: 10px;padding-right: 10px;"><strong>'+accountdata[key]['html'] + '</strong></td><td style="border: 1px solid black;padding-left: 10px;padding-right: 10px;">' + accountdata[key]['value']+'</td></tr>';
+                            outputtext += '<tr><td style="border: 1px solid black;padding-left: 10px;padding-right: 10px;"><strong>'+escapeHtml(accountdata[key]['html']) + '</strong></td><td style="border: 1px solid black;padding-left: 10px;padding-right: 10px;">' + escapeHtml(accountdata[key]['value'])+'</td></tr>';
                         }
                     }
                     outputtext += '</table>';


### PR DESCRIPTION
## Summary

Two small robustness improvements:

### Abandoned-cart restore (`Controller/Cart/Loadquote.php`)
- Require a **non-empty** stored token and compare it with `hash_equals()` (constant-time, strict). Previously a cart that had no token yet could be reached with an empty `token` parameter due to a loose comparison.
- Route the post-restore redirect through a new `Model/RedirectUrlValidator` that only allows destinations on the store's own host and falls back to the store base URL otherwise.
- Adds unit coverage for the redirect validator.

### Admin API-key details (`view/adminhtml/web/js/configapikey.js`)
- Escape the Mailchimp account fields (account name, email, plan, …) before concatenating them into the admin details/confirmation markup, so a connected account cannot inject markup into the admin page.

## Notes
- No schema or public-API changes. The legitimate cart-restore flow (valid token from the abandoned-cart email) is unchanged.
- Base branch: `develop-2.4`.