### PR TITLE
Fix cart sync gate: block carts until the store is fully synced

### DIFF
--- a/Controller/Adminhtml/Ecommerce/DeleteStore.php
+++ b/Controller/Adminhtml/Ecommerce/DeleteStore.php
@@ -85,6 +85,9 @@ class DeleteStore extends \Magento\Backend\App\Action
         try {
             $this->helper->deleteStore($mailchimpStore);
             $this->_config->deleteConfig(\Ebizmarts\MailChimp\Helper\Data::XML_MAILCHIMP_STORE, $scope, $storeId);
+            // Clear the initial-sync-complete flag so carts stay blocked until the
+            // store is fully re-synced after being reconnected.
+            $this->helper->deleteMCMinSyncing($mailchimpStore);
         } catch (ValidatorException $e) {
             $valid = 0;
             $message = $e->getMessage();

--- a/Cron/Ecommerce.php
+++ b/Cron/Ecommerce.php
@@ -162,37 +162,6 @@ class Ecommerce
                 }
             }
         }
-        $syncs = [];
-        foreach ($this->_storeManager->getStores() as $storeId => $val) {
-            $mailchimpStoreId = $this->_helper->getConfigValue(
-                \Ebizmarts\MailChimp\Helper\Data::XML_MAILCHIMP_STORE,
-                $storeId
-            );
-            if ($mailchimpStoreId != -1 && $mailchimpStoreId != '') {
-                $dateSync = $this->_helper->getMCMinSyncDateFlag($storeId);
-                if (isset($syncs[$mailchimpStoreId])) {
-                    if ($syncs[$mailchimpStoreId] && $syncs[$mailchimpStoreId]['datesync'] < $dateSync) {
-                        $syncs[$mailchimpStoreId]['datesync'] = $dateSync;
-                        $syncs[$mailchimpStoreId]['storeid'] = $storeId;
-                    }
-                } elseif ($dateSync) {
-                    $syncs[$mailchimpStoreId]['datesync'] = $dateSync;
-                    $syncs[$mailchimpStoreId]['storeid'] = $storeId;
-                } else {
-                    $syncs[$mailchimpStoreId] = false;
-                }
-            }
-        }
-        foreach ($syncs as $mailchimpStoreId => $val) {
-            $flag = $this->_helper->getMCMinSyncDateFlagByMailchimpStore(
-                $mailchimpStoreId,
-                0,
-                'default'
-            );
-            if ($val && !$flag) {
-                $this->updateSyncFlagData($val['storeid'], $mailchimpStoreId);
-            }
-        }
     }
 
     protected function _processStore($storeId, $mailchimpStoreId, $listId)
@@ -220,7 +189,7 @@ class Ecommerce
             $countOrders = count($orders);
             $results = array_merge($results, $orders);
 
-            if ($this->_helper->getMCMinSyncDateFlag($storeId)) {
+            if ($this->_helper->getMCMinSyncDateFlagByMailchimpStore($mailchimpStoreId, 0, 'default')) {
                 $this->_helper->log('Generate Carts payload');
                 $carts = $this->_apiCart->createBatchJson($storeId);
                 $results = array_merge($results, $carts);
@@ -288,17 +257,14 @@ class Ecommerce
             $this->_helper->log("Nothing to sync for store $storeId");
         }
         $countTotal = $this->_helper->getTotalNewItemsSent();
-        $syncing = $this->_helper->getMCMinSyncDateFlag($storeId);
-        if ($countTotal == 0 && $syncing) {
-            // Pass $mailchimpStoreId so the write goes to issync/<id> only —
-            // writing the bare scalar issync alongside issync/<id> children at
-            // the same scope causes a fatal in Magento's Scope\Converter.
-            $this->_helper->saveMCMinSyncing(
-                $mailchimpStoreId,
-                date('Y-m-d'),
-                0,
-                'default'
-            );
+        // Mark the store as fully synced only once, on the first run that has
+        // nothing new left to send. updateSyncFlagData records the completion date
+        // under issync/<id> and tells Mailchimp the store is no longer syncing.
+        // This is the flag the cart sync above waits on.
+        if ($countTotal == 0
+            && !$this->_helper->getMCMinSyncDateFlagByMailchimpStore($mailchimpStoreId, 0, 'default')
+        ) {
+            $this->updateSyncFlagData($storeId, $mailchimpStoreId);
         }
 
         return $batchId;

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -563,6 +563,32 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
             (string) $scope,
             (int) $scopeId
         );
+        // saveConfigValueAtomic writes straight to the table; flush the config
+        // cache so the freshly written flag is visible to the next read (the cart
+        // sync gate depends on this).
+        $this->_cacheTypeList->cleanType('config');
+    }
+
+    /**
+     * Clear the "initial sync complete" flag for a Mailchimp store. After a store
+     * is deleted/reset the cart sync must stay blocked until the store has fully
+     * re-synced, so the per-store issync/<id> flag is removed here.
+     *
+     * @param string $mailchimpStoreId
+     * @param int $scopeId
+     * @param string $scope
+     */
+    public function deleteMCMinSyncing($mailchimpStoreId, $scopeId = 0, $scope = 'default')
+    {
+        if (!$mailchimpStoreId) {
+            return;
+        }
+        $this->deleteConfig(
+            self::XML_PATH_IS_SYNC . '/' . $mailchimpStoreId,
+            (int) $scopeId,
+            (string) $scope
+        );
+        $this->_cacheTypeList->cleanType('config');
     }
     public function getCartUrl($storeId, $cartId, $token)
     {


### PR DESCRIPTION
## Problem

Carts must sync only after a store's initial sync completes (products, customers, orders) — otherwise a cart references products that don't exist in Mailchimp yet. The gate in `Cron/Ecommerce::_processStore()` was supposed to enforce this, but it read the "sync complete" flag through `getMCMinSyncDateFlag()`, which reads the **parent** `mailchimp/general/issync` config path.

Since the flag is stored **per Mailchimp store** under `issync/<mailchimpStoreId>`, the parent read always resolves to an array and the method returns a truthy sentinel (`1900-01-01`). So the gate **never blocked**: on a fresh sync or a resync, carts were sent while products were still uploading, producing `Bad Request: A product with the provided ID does not exist in the account for this list`. A leftover backfill loop also set the flag prematurely, and the flag was never cleared on store deletion.

## Change

- **Gate** the cart sync on the **per-store** flag via `getMCMinSyncDateFlagByMailchimpStore()`.
- **Set** the completion flag once — on the first run with nothing new left to send (`countTotal == 0`) — via `updateSyncFlagData()`, and **remove** the premature backfill loop that set it too early.
- **Clear** the per-store flag when a store is deleted (`DeleteStore`), so carts are blocked again until the store re-syncs.
- **Flush the config cache** after writing/clearing the flag — `saveConfigValueAtomic` writes straight to `core_config_data` and bypasses Magento's config cache, so without this the gate never sees the freshly written flag.

This also makes the admin "Account Synced since" value consistent (it already read the per-store flag).

## Verified

End-to-end on a real delete → recreate → full re-sync (~2039 products): carts stayed **blocked** for the whole initial sync (no "product does not exist" errors), the flag was set automatically on completion, and the next run opened the cart sync (`Generate Carts payload`). Deleting the store cleared the flag and blocked carts again.

Base branch: `develop-2.4`.