### PR TITLE
version 81 for magento 2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [103.4.81](https://github.com/mailchimp/mc-magento2/tree/103.4.81)
+
+[Full Changelog](https://github.com/mailchimp/mc-magento2/compare/103.4.80...103.4.81)
+
+**Fixed bugs:**
+
+- Remove usage of campaign\_id as an attribute in orders API requests [\#2293](https://github.com/mailchimp/mc-magento2/issues/2293)
+
+**Merged pull requests:**
+
+- Fix cart sync gate: block carts until the store is fully synced [\#2336](https://github.com/mailchimp/mc-magento2/pull/2336)
+- Harden abandoned-cart restore and escape admin account details [\#2333](https://github.com/mailchimp/mc-magento2/pull/2333)
+- Migrate support email to mailchimp@help.ebizmarts.com [\#2332](https://github.com/mailchimp/mc-magento2/pull/2332)
+
 ## [103.4.80](https://github.com/mailchimp/mc-magento2/tree/103.4.80)
 
 [Full Changelog](https://github.com/mailchimp/mc-magento2/compare/103.4.79...103.4.80)

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   },
   "description": "Connect MailChimp with Magento",
   "type": "magento2-module",
-  "version": "103.4.80",
+  "version": "103.4.81",
   "authors": [
     {
       "name": "Ebizmarts Corp",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -11,7 +11,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Ebizmarts_MailChimp" setup_version="103.4.80">
+    <module name="Ebizmarts_MailChimp" setup_version="103.4.81">
         <sequence>
             <module name="Magento_Newsletter"/>
             <module name="Magento_Sales"/>


### PR DESCRIPTION
Release **103.4.81** for Magento 2.4.

Version bump on `composer.json`, `etc/module.xml` and `CHANGELOG.md`.

### Included since 103.4.80

**Fixed bugs:**
- Remove usage of campaign_id as an attribute in orders API requests (#2293) — #2335

**Merged pull requests:**
- Fix cart sync gate: block carts until the store is fully synced — #2336
- Harden abandoned-cart restore and escape admin account details — #2333
- Migrate support email to mailchimp@help.ebizmarts.com — #2332

[Full Changelog](https://github.com/mailchimp/mc-magento2/compare/103.4.80...103.4.81)