### PR TITLE
Fix profile webhook recreating newsletter subscribers as Not Activated

### DIFF
--- a/Cron/Webhook.php
+++ b/Cron/Webhook.php
@@ -286,18 +286,13 @@ class Webhook
                     $serializedGroups = $this->_helper->serialize($groups);
                     $subscriber = $this->_subscriberFactory->create();
                     $subscriber->loadByCustomer($customer->getId(),$websiteId);
-                    $interestGroup = $this->interestGroupFactory->create();
+                    // Only sync interest groups for customers who are already newsletter
+                    // subscribers. Never subscribe from a profile webhook: the customer may
+                    // be an ecommerce-only contact, and core subscribe() would add a
+                    // "Not Activated" row and send a confirmation email when double opt-in is
+                    // on, which Mailchimp then echoes back, recreating the row on every run.
                     if ($subscriber->getEmail()==$customer->getEmail()) {
-                        $interestGroup->getBySubscriberIdStoreId($subscriber->getSubscriberId(), $subscriber->getStoreId());
-                        $interestGroup->setGroupdata($serializedGroups);
-                        $interestGroup->setSubscriberId($subscriber->getSubscriberId());
-                        $interestGroup->setStoreId($subscriber->getStoreId());
-                        $interestGroup->setUpdatedAt($this->_helper->getGmtDate());
-                        $interestGroup->getResource()->save($interestGroup);
-                        $listId = $this->_helper->getGeneralList($subscriber->getStoreId());
-                    } else {
-                        $this->_subscriberFactory->create()->subscribe($customer->getEmail());
-                        $subscriber->loadBySubscriberEmail($customer->getEmail(), $websiteId);
+                        $interestGroup = $this->interestGroupFactory->create();
                         $interestGroup->getBySubscriberIdStoreId($subscriber->getSubscriberId(), $subscriber->getStoreId());
                         $interestGroup->setGroupdata($serializedGroups);
                         $interestGroup->setSubscriberId($subscriber->getSubscriberId());

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1047,7 +1047,10 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         $sources = [
             'user' => true,
             'admin' => true,
-            'api' => true
+            // Do not subscribe to API-originated events: the extension writes members
+            // through the API (customer/subscriber sync), and echoing those changes back
+            // as webhooks creates a feedback loop that recreates newsletter subscribers.
+            'api' => false
         ];
         try {
             $api = $this->getApiByApiKey($apikey);


### PR DESCRIPTION
## Problem

Guest/newsletter subscribers reappear as **Not Activated** shortly after being deleted, and the affected addresses receive an opt-in confirmation email — even when they never subscribed. Deleting the row (admin grid or SQL) does not help; it comes back on the next cron run. Reported in #2334.

## Root cause

When the webhook cron processes a Mailchimp **`profile`** webhook for an address that belongs to a Magento **customer** (customers are pushed to the audience by the ecommerce sync as non-subscribed contacts), `Cron/Webhook::_processMerges()` calls the **core** `Subscriber::subscribe()` for any customer that is not already a subscriber. With **double opt-in** ("Newsletter → Need to Confirm" = Yes) that creates a `STATUS_NOT_ACTIVATED` row and sends a confirmation email.

This is self-sustaining: the extension writes members through the API (customer/subscriber sync), and the audience webhook is registered with `sources.api = true`, so Mailchimp echoes those API-originated updates back as `profile` webhooks. Each echo re-runs `_processMerges()` and recreates the row, so deleting it locally never sticks.

## Fix

- **`Cron/Webhook.php`** — `_processMerges()` now only syncs interest groups for customers who are **already** subscribers. It no longer calls `subscribe()` from a webhook, so a profile event can never create a `Not Activated` row or trigger a confirmation email.
- **`Helper/Data.php`** — `createWebHook()` registers the webhook with **`sources.api = false`** (Mailchimp's recommended setting), so the extension's own API writes are no longer echoed back as webhooks, removing the feedback loop at the source.

## Validation

Reproduced end-to-end on a 2.4 install with double opt-in enabled:

- **Before:** injecting a `profile` webhook for a customer who is not a subscriber creates a `newsletter_subscriber` row with `subscriber_status = 2` (Not Activated).
- **After:** the same webhook is processed (`processed = 1`) and **no** subscriber row is created.

## Note for existing installs

`sources.api = false` applies to newly registered webhooks. Existing audiences keep `api = true` until the webhook is re-registered, but the `Cron/Webhook.php` change alone stops the rows and emails regardless of the webhook source.

Fixes #2334