### PR TITLE
Send the chosen variant in ProductVariantDto.id for configurable products

### DIFF
--- a/Block/Pixel/Cart.php
+++ b/Block/Pixel/Cart.php
@@ -12,6 +12,7 @@
 namespace Ebizmarts\MailChimp\Block\Pixel;
 
 use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Ebizmarts\MailChimp\Model\Product\LeafProductIdResolver;
 use Magento\Checkout\Model\Session as CheckoutSession;
 use Magento\Framework\View\Element\Template;
 
@@ -32,20 +33,28 @@ class Cart extends Template
     protected $checkoutSession;
 
     /**
-     * @param Template\Context $context
-     * @param MailChimpHelper  $helper
-     * @param CheckoutSession  $checkoutSession
-     * @param array            $data
+     * @var LeafProductIdResolver
+     */
+    protected $leafProductIdResolver;
+
+    /**
+     * @param Template\Context      $context
+     * @param MailChimpHelper       $helper
+     * @param CheckoutSession       $checkoutSession
+     * @param LeafProductIdResolver $leafProductIdResolver
+     * @param array                 $data
      */
     public function __construct(
         Template\Context $context,
         MailChimpHelper $helper,
         CheckoutSession $checkoutSession,
+        LeafProductIdResolver $leafProductIdResolver,
         array $data = []
     ) {
         parent::__construct($context, $data);
-        $this->helper          = $helper;
-        $this->checkoutSession = $checkoutSession;
+        $this->helper                = $helper;
+        $this->checkoutSession       = $checkoutSession;
+        $this->leafProductIdResolver = $leafProductIdResolver;
     }
 
     /**
@@ -65,6 +74,9 @@ class Cart extends Template
         $lineItems = [];
         foreach ($quote->getAllVisibleItems() as $item) {
             $productId = (string)$item->getProductId();
+            // Mailchimp variant identity: the chosen child for a configurable, the
+            // product itself otherwise. Must match what the REST sync publishes.
+            $variantId = (string)$this->leafProductIdResolver->forQuoteItem($item);
             $product   = $item->getProduct();
             $imageUrl  = '';
             $productUrl = '';
@@ -77,7 +89,7 @@ class Cart extends Template
             }
             $lineItems[] = [
                 'item'     => [
-                    'id'         => $productId,
+                    'id'         => $variantId,
                     'productId'  => $productId,
                     'title'      => (string)$item->getName(),
                     'price'      => (float)$item->getPrice(),

--- a/Block/Pixel/Checkout.php
+++ b/Block/Pixel/Checkout.php
@@ -12,6 +12,7 @@
 namespace Ebizmarts\MailChimp\Block\Pixel;
 
 use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Ebizmarts\MailChimp\Model\Product\LeafProductIdResolver;
 use Magento\Checkout\Model\Session as CheckoutSession;
 use Magento\Framework\View\Element\Template;
 
@@ -32,20 +33,28 @@ class Checkout extends Template
     protected $checkoutSession;
 
     /**
-     * @param Template\Context $context
-     * @param MailChimpHelper  $helper
-     * @param CheckoutSession  $checkoutSession
-     * @param array            $data
+     * @var LeafProductIdResolver
+     */
+    protected $leafProductIdResolver;
+
+    /**
+     * @param Template\Context      $context
+     * @param MailChimpHelper       $helper
+     * @param CheckoutSession       $checkoutSession
+     * @param LeafProductIdResolver $leafProductIdResolver
+     * @param array                 $data
      */
     public function __construct(
         Template\Context $context,
         MailChimpHelper $helper,
         CheckoutSession $checkoutSession,
+        LeafProductIdResolver $leafProductIdResolver,
         array $data = []
     ) {
         parent::__construct($context, $data);
-        $this->helper          = $helper;
-        $this->checkoutSession = $checkoutSession;
+        $this->helper                = $helper;
+        $this->checkoutSession       = $checkoutSession;
+        $this->leafProductIdResolver = $leafProductIdResolver;
     }
 
     /**
@@ -65,6 +74,9 @@ class Checkout extends Template
         $lineItems = [];
         foreach ($quote->getAllVisibleItems() as $item) {
             $productId  = (string)$item->getProductId();
+            // Mailchimp variant identity: the chosen child for a configurable, the
+            // product itself otherwise. Must match what the REST sync publishes.
+            $variantId  = (string)$this->leafProductIdResolver->forQuoteItem($item);
             $product    = $item->getProduct();
             $imageUrl   = '';
             $productUrl = '';
@@ -77,7 +89,7 @@ class Checkout extends Template
             }
             $lineItems[] = [
                 'item'     => [
-                    'id'         => $productId,
+                    'id'         => $variantId,
                     'productId'  => $productId,
                     'title'      => (string)$item->getName(),
                     'price'      => (float)$item->getPrice(),

--- a/Block/Pixel/Order.php
+++ b/Block/Pixel/Order.php
@@ -12,6 +12,7 @@
 namespace Ebizmarts\MailChimp\Block\Pixel;
 
 use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Ebizmarts\MailChimp\Model\Product\LeafProductIdResolver;
 use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Checkout\Model\Session as CheckoutSession;
 use Magento\Framework\View\Element\Template;
@@ -38,10 +39,16 @@ class Order extends Template
     protected $productRepository;
 
     /**
+     * @var LeafProductIdResolver
+     */
+    protected $leafProductIdResolver;
+
+    /**
      * @param Template\Context           $context
      * @param MailChimpHelper            $helper
      * @param CheckoutSession            $checkoutSession
      * @param ProductRepositoryInterface $productRepository
+     * @param LeafProductIdResolver      $leafProductIdResolver
      * @param array                      $data
      */
     public function __construct(
@@ -49,12 +56,14 @@ class Order extends Template
         MailChimpHelper $helper,
         CheckoutSession $checkoutSession,
         ProductRepositoryInterface $productRepository,
+        LeafProductIdResolver $leafProductIdResolver,
         array $data = []
     ) {
         parent::__construct($context, $data);
-        $this->helper            = $helper;
-        $this->checkoutSession   = $checkoutSession;
-        $this->productRepository = $productRepository;
+        $this->helper                = $helper;
+        $this->checkoutSession       = $checkoutSession;
+        $this->productRepository     = $productRepository;
+        $this->leafProductIdResolver = $leafProductIdResolver;
     }
 
     /**
@@ -77,6 +86,10 @@ class Order extends Template
         $lineItems = [];
         foreach ($order->getAllVisibleItems() as $item) {
             $productId  = (string)$item->getProductId();
+            // Mailchimp variant identity: the child order-item row for a
+            // configurable, the parent id for everything else.
+            $leafId     = $this->leafProductIdResolver->forOrderItem($item);
+            $variantId  = $leafId !== null ? (string)$leafId : $productId;
             $imageUrl   = '';
             $productUrl = '';
             try {
@@ -91,7 +104,7 @@ class Order extends Template
             }
             $lineItems[] = [
                 'item'     => [
-                    'id'         => $productId,
+                    'id'         => $variantId,
                     'productId'  => $productId,
                     'title'      => (string)$item->getName(),
                     'price'      => (float)$item->getPrice(),

--- a/Model/Plugin/CustomerData/CartItemVariantId.php
+++ b/Model/Plugin/CustomerData/CartItemVariantId.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Ebizmarts_MailChimp Magento Component
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Model\Plugin\CustomerData;
+
+use Ebizmarts\MailChimp\Model\Product\LeafProductIdResolver;
+use Magento\Checkout\CustomerData\DefaultItem;
+use Magento\Quote\Model\Quote\Item;
+
+/**
+ * Exposes the leaf (variant) product id in the `cart` customer-data section.
+ *
+ * The PRODUCT_ADDED_TO_CART pixel event is fired client side from
+ * Magento_Customer/js/customer-data, and that section only carries
+ * `product_id`, which for a configurable is the PARENT. There is no way to
+ * resolve the chosen child in the browser, so the value is attached here and
+ * read back in view/frontend/web/js/pixel.js.
+ *
+ * Every cart item is rendered by DefaultItem — Magento ships no configurable
+ * specific renderer for this section — so this single plugin covers all types.
+ */
+class CartItemVariantId
+{
+    /**
+     * @var LeafProductIdResolver
+     */
+    protected $leafProductIdResolver;
+
+    /**
+     * @param LeafProductIdResolver $leafProductIdResolver
+     */
+    public function __construct(
+        LeafProductIdResolver $leafProductIdResolver
+    ) {
+        $this->leafProductIdResolver = $leafProductIdResolver;
+    }
+
+    /**
+     * Attach the leaf (variant) product id to the cart section item data.
+     *
+     * @param  DefaultItem $subject
+     * @param  array       $result
+     * @param  Item        $item
+     * @return array
+     */
+    public function afterGetItemData(DefaultItem $subject, $result, Item $item)
+    {
+        if (!is_array($result)) {
+            return $result;
+        }
+
+        $result['mc_variant_id'] = (string)$this->leafProductIdResolver->forQuoteItem($item);
+
+        return $result;
+    }
+}

--- a/Model/Product/LeafProductIdResolver.php
+++ b/Model/Product/LeafProductIdResolver.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Ebizmarts_MailChimp Magento Component
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Model\Product;
+
+use Magento\Quote\Model\Quote\Item as QuoteItem;
+use Magento\Sales\Api\Data\OrderItemInterface;
+
+/**
+ * Resolves the LEAF product id a cart/order line actually references — the
+ * child simple for a configurable, the product itself for every other type.
+ *
+ * Mailchimp's ProductVariantDto needs two different identifiers: `id` is the
+ * variant the shopper selected, `productId` is the parent catalog product.
+ * The pixel used to send the parent in both, so a configurable's variant never
+ * joined against what Mailchimp already stores.
+ *
+ * The value returned here is not invented: this extension's own REST sync
+ * (Model/Api/Product.php) already publishes the child simple's entity id as the
+ * Mailchimp variant id, so the pixel has to send that same value or the join
+ * fails.
+ *
+ * Only CONFIGURABLE products have a leaf distinct from themselves. Simple,
+ * bundle and grouped are self-referencing in the REST variant payload, so
+ * returning the product's own id for them is not a fallback — it is the
+ * correct answer, and the only value that joins.
+ *
+ * Stateless, zero constructor dependencies: no DI cycle risk, no di.xml entry.
+ */
+class LeafProductIdResolver
+{
+    /**
+     * Leaf id for a quote line.
+     *
+     * Falls back to the parent id when the child cannot be resolved (broken or
+     * partial quote data) rather than returning null, so the degraded path is
+     * exactly today's payload and never a dropped line.
+     *
+     * @param  QuoteItem $item
+     * @return int
+     */
+    public function forQuoteItem(QuoteItem $item)
+    {
+        $productId = (int)$item->getProductId();
+
+        if ($item->getProductType() !== 'configurable') {
+            return $productId;
+        }
+
+        $simpleOption = $item->getOptionByCode('simple_product');
+        if ($simpleOption !== null && $simpleOption->getProduct() !== null) {
+            return (int)$simpleOption->getProduct()->getId();
+        }
+
+        return $productId;
+    }
+
+    /**
+     * Leaf id for an order line.
+     *
+     * Child order-item row ONLY. Magento writes one for every configurable
+     * sale and it carries the child's entity id directly, so this stays a pure
+     * read off the already loaded order.
+     *
+     * Deliberately does NOT fall back to product_options['simple_sku']: that
+     * option holds a SKU, not an id, so using it would mean a catalog lookup
+     * per line — an N+1 on the purchase event, the hottest one the pixel emits.
+     *
+     * Returns null when no child row exists (non-configurable lines, or
+     * partial/imported order data); the caller then keeps the parent id.
+     *
+     * @param  OrderItemInterface $item
+     * @return int|null
+     */
+    public function forOrderItem(OrderItemInterface $item)
+    {
+        if ($item->getProductType() !== 'configurable') {
+            return null;
+        }
+
+        try {
+            $children = $item->getChildrenItems();
+        } catch (\Throwable $e) {
+            // Partial order item — caller keeps the parent id.
+            return null;
+        }
+
+        if (!is_array($children)) {
+            return null;
+        }
+
+        foreach ($children as $child) {
+            $childId = (int)$child->getProductId();
+            if ($childId > 0) {
+                return $childId;
+            }
+        }
+
+        return null;
+    }
+}

--- a/Test/Unit/Block/Pixel/CartTest.php
+++ b/Test/Unit/Block/Pixel/CartTest.php
@@ -13,9 +13,13 @@ namespace Ebizmarts\MailChimp\Test\Unit\Block\Pixel;
 
 use Ebizmarts\MailChimp\Block\Pixel\Cart;
 use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Ebizmarts\MailChimp\Model\Product\LeafProductIdResolver;
+use Magento\Catalog\Model\Product;
 use Magento\Checkout\Model\Session as CheckoutSession;
-use Magento\Framework\DataObject;
+use Magento\Framework\UrlInterface;
 use Magento\Framework\View\Element\Template;
+use Magento\Quote\Model\Quote\Item as QuoteItem;
+use Magento\Quote\Model\Quote\Item\Option;
 use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreManagerInterface;
 use PHPUnit\Framework\TestCase;
@@ -23,22 +27,56 @@ use PHPUnit\Framework\TestCase;
 class CartTest extends TestCase
 {
     /**
-     * Uses DataObject to avoid fighting magic-getter mocking on QuoteItem.
+     * Real QuoteItem mocks: the block now hands the item to LeafProductIdResolver,
+     * which type-hints QuoteItem, so a plain DataObject no longer fits.
+     *
+     * @param  string   $productId
+     * @param  string   $name
+     * @param  float    $price
+     * @param  string   $sku
+     * @param  int      $qty
+     * @param  string   $productType
+     * @param  int|null $childProductId
+     * @return QuoteItem
      */
     private function makeItem(
         string $productId,
         string $name,
         float $price,
         string $sku,
-        int $qty
-    ): DataObject {
-        return new DataObject([
-            'product_id' => $productId,
-            'name'       => $name,
-            'price'      => $price,
-            'sku'        => $sku,
-            'qty'        => $qty,
-        ]);
+        int $qty,
+        string $productType = 'simple',
+        $childProductId = null
+    ): QuoteItem {
+        $option = null;
+        if ($childProductId !== null) {
+            $child = $this->createMock(Product::class);
+            $child->method('getId')->willReturn($childProductId);
+
+            $option = $this->getMockBuilder(Option::class)
+                ->disableOriginalConstructor()
+                ->onlyMethods(['getProduct'])
+                ->getMock();
+            $option->method('getProduct')->willReturn($child);
+        }
+
+        $item = $this->getMockBuilder(QuoteItem::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(
+                ['getProductType', 'getOptionByCode', 'getProduct', 'getName', 'getPrice', 'getSku', 'getQty']
+            )
+            ->addMethods(['getProductId'])
+            ->getMock();
+        $item->method('getProductId')->willReturn($productId);
+        $item->method('getProductType')->willReturn($productType);
+        $item->method('getOptionByCode')->willReturn($option);
+        $item->method('getProduct')->willReturn(null);
+        $item->method('getName')->willReturn($name);
+        $item->method('getPrice')->willReturn($price);
+        $item->method('getSku')->willReturn($sku);
+        $item->method('getQty')->willReturn($qty);
+
+        return $item;
     }
 
     private function makeBlock(array $items, float $grandTotal, string $quoteId, string $currency = 'USD'): Cart
@@ -67,9 +105,15 @@ class CartTest extends TestCase
             ->getMock();
         $context->method('getStoreManager')->willReturn($storeManager);
 
+        // getCartData() reads the media base URL; without this the block hits
+        // getBaseUrl() on null.
+        $urlBuilder = $this->createMock(UrlInterface::class);
+        $urlBuilder->method('getBaseUrl')->willReturn('https://example.com/media/');
+        $context->method('getUrlBuilder')->willReturn($urlBuilder);
+
         $helper = $this->createMock(MailChimpHelper::class);
 
-        return new Cart($context, $helper, $checkoutSession);
+        return new Cart($context, $helper, $checkoutSession, new LeafProductIdResolver());
     }
 
     public function testGetCartDataStructure(): void
@@ -114,5 +158,25 @@ class CartTest extends TestCase
         $lineItem = $block->getCartData()['lineItems'][0];
 
         $this->assertSame(150.0, $lineItem['price']); // 50 * 3
+    }
+
+    public function testGetCartDataConfigurableSendsChosenChildAsVariantId(): void
+    {
+        $item     = $this->makeItem('62', 'Chaz Kangeroo Hoodie', 52.0, 'MH01-XS-Black', 1, 'configurable', 47);
+        $block    = $this->makeBlock([$item], 52.0, '13');
+        $lineItem = $block->getCartData()['lineItems'][0];
+
+        $this->assertSame('47', $lineItem['item']['id'], 'id must be the chosen child simple');
+        $this->assertSame('62', $lineItem['item']['productId'], 'productId must stay the parent');
+    }
+
+    public function testGetCartDataConfigurableWithoutResolvableChildFallsBackToParent(): void
+    {
+        $item     = $this->makeItem('62', 'Chaz Kangeroo Hoodie', 52.0, 'MH01', 1, 'configurable', null);
+        $block    = $this->makeBlock([$item], 52.0, '13');
+        $lineItem = $block->getCartData()['lineItems'][0];
+
+        $this->assertSame('62', $lineItem['item']['id']);
+        $this->assertSame('62', $lineItem['item']['productId']);
     }
 }

--- a/Test/Unit/Block/Pixel/CategoryTest.php
+++ b/Test/Unit/Block/Pixel/CategoryTest.php
@@ -54,9 +54,11 @@ class CategoryTest extends TestCase
 
         $result = $block->getCategoryData();
 
-        $this->assertSame('5', $result['id']);
-        $this->assertSame('Women', $result['name']);
-        $this->assertSame('https://example.com/women', $result['url']);
+        // The payload keys are categoryId/categoryName — that is what
+        // view/frontend/web/js/pixel/category.js reads. There is no url field.
+        $this->assertSame('5', $result['categoryId']);
+        $this->assertSame('Women', $result['categoryName']);
+        $this->assertArrayNotHasKey('url', $result);
     }
 
     public function testGetCategoryDataReturnsEmptyArrayWhenNoCategory(): void
@@ -73,8 +75,7 @@ class CategoryTest extends TestCase
 
         $result = $block->getCategoryData();
 
-        $this->assertIsString($result['id']);
-        $this->assertIsString($result['name']);
-        $this->assertIsString($result['url']);
+        $this->assertIsString($result['categoryId']);
+        $this->assertIsString($result['categoryName']);
     }
 }

--- a/Test/Unit/Block/Pixel/CheckoutTest.php
+++ b/Test/Unit/Block/Pixel/CheckoutTest.php
@@ -13,9 +13,13 @@ namespace Ebizmarts\MailChimp\Test\Unit\Block\Pixel;
 
 use Ebizmarts\MailChimp\Block\Pixel\Checkout;
 use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Ebizmarts\MailChimp\Model\Product\LeafProductIdResolver;
+use Magento\Catalog\Model\Product;
 use Magento\Checkout\Model\Session as CheckoutSession;
-use Magento\Framework\DataObject;
+use Magento\Framework\UrlInterface;
 use Magento\Framework\View\Element\Template;
+use Magento\Quote\Model\Quote\Item as QuoteItem;
+use Magento\Quote\Model\Quote\Item\Option;
 use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreManagerInterface;
 use PHPUnit\Framework\TestCase;
@@ -60,6 +64,59 @@ class CheckoutTest extends TestCase
         return $quote;
     }
 
+    /**
+     * Real QuoteItem mocks: the block hands the item to LeafProductIdResolver,
+     * which type-hints QuoteItem, so a plain DataObject no longer fits.
+     *
+     * @param  string   $productId
+     * @param  string   $name
+     * @param  float    $price
+     * @param  string   $sku
+     * @param  int      $qty
+     * @param  string   $productType
+     * @param  int|null $childProductId
+     * @return QuoteItem
+     */
+    private function makeItem(
+        string $productId,
+        string $name,
+        float $price,
+        string $sku,
+        int $qty,
+        string $productType = 'simple',
+        $childProductId = null
+    ): QuoteItem {
+        $option = null;
+        if ($childProductId !== null) {
+            $child = $this->createMock(Product::class);
+            $child->method('getId')->willReturn($childProductId);
+
+            $option = $this->getMockBuilder(Option::class)
+                ->disableOriginalConstructor()
+                ->onlyMethods(['getProduct'])
+                ->getMock();
+            $option->method('getProduct')->willReturn($child);
+        }
+
+        $item = $this->getMockBuilder(QuoteItem::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(
+                ['getProductType', 'getOptionByCode', 'getProduct', 'getName', 'getPrice', 'getSku', 'getQty']
+            )
+            ->addMethods(['getProductId'])
+            ->getMock();
+        $item->method('getProductId')->willReturn($productId);
+        $item->method('getProductType')->willReturn($productType);
+        $item->method('getOptionByCode')->willReturn($option);
+        $item->method('getProduct')->willReturn(null);
+        $item->method('getName')->willReturn($name);
+        $item->method('getPrice')->willReturn($price);
+        $item->method('getSku')->willReturn($sku);
+        $item->method('getQty')->willReturn($qty);
+
+        return $item;
+    }
+
     private function makeBlock(\Magento\Quote\Model\Quote $quote, string $currency = 'USD'): Checkout
     {
         $store = $this->createMock(Store::class);
@@ -76,9 +133,15 @@ class CheckoutTest extends TestCase
             ->getMock();
         $context->method('getStoreManager')->willReturn($storeManager);
 
+        // getCheckoutData() reads the media base URL; without this the block hits
+        // getBaseUrl() on null.
+        $urlBuilder = $this->createMock(UrlInterface::class);
+        $urlBuilder->method('getBaseUrl')->willReturn('https://example.com/media/');
+        $context->method('getUrlBuilder')->willReturn($urlBuilder);
+
         $helper = $this->createMock(MailChimpHelper::class);
 
-        return new Checkout($context, $helper, $checkoutSession);
+        return new Checkout($context, $helper, $checkoutSession, new LeafProductIdResolver());
     }
 
     public function testGetCheckoutDataStructure(): void
@@ -88,7 +151,9 @@ class CheckoutTest extends TestCase
 
         $result = $block->getCheckoutData();
 
-        $this->assertSame('5', $result['id']);
+        // The checkout event namespaces its id to keep it distinct from the cart
+        // event; the raw quote id travels in cartId.
+        $this->assertSame('checkout_5', $result['id']);
         $this->assertSame('5', $result['cartId']);
         $this->assertSame('GBP', $result['currency']);
         $this->assertSame(100.0, $result['subtotalPrice']);
@@ -121,13 +186,7 @@ class CheckoutTest extends TestCase
 
     public function testGetCheckoutDataWithLineItems(): void
     {
-        $item  = new DataObject([
-            'product_id' => '99',
-            'name'       => 'Sneaker',
-            'price'      => 60.0,
-            'sku'        => 'SNKR-1',
-            'qty'        => 1,
-        ]);
+        $item  = $this->makeItem('99', 'Sneaker', 60.0, 'SNKR-1', 1);
         $quote = $this->makeQuote('8', [$item], 60.0, 60.0, null, 0.0, 0.0, 0.0);
         $block = $this->makeBlock($quote);
 
@@ -138,5 +197,17 @@ class CheckoutTest extends TestCase
         $this->assertSame('Sneaker', $lineItems[0]['item']['title']);
         $this->assertSame(60.0, $lineItems[0]['item']['price']);
         $this->assertSame(1, $lineItems[0]['quantity']);
+    }
+
+    public function testGetCheckoutDataConfigurableSendsChosenChildAsVariantId(): void
+    {
+        $item  = $this->makeItem('62', 'Chaz Kangeroo Hoodie', 52.0, 'MH01-XS-Black', 1, 'configurable', 47);
+        $quote = $this->makeQuote('13', [$item], 52.0, 52.0, null, 0.0, 0.0, 0.0);
+        $block = $this->makeBlock($quote);
+
+        $lineItem = $block->getCheckoutData()['lineItems'][0];
+
+        $this->assertSame('47', $lineItem['item']['id'], 'id must be the chosen child simple');
+        $this->assertSame('62', $lineItem['item']['productId'], 'productId must stay the parent');
     }
 }

--- a/Test/Unit/Block/Pixel/OrderTest.php
+++ b/Test/Unit/Block/Pixel/OrderTest.php
@@ -13,16 +13,31 @@ namespace Ebizmarts\MailChimp\Test\Unit\Block\Pixel;
 
 use Ebizmarts\MailChimp\Block\Pixel\Order;
 use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Ebizmarts\MailChimp\Model\Product\LeafProductIdResolver;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Catalog\Model\Product;
 use Magento\Checkout\Model\Session as CheckoutSession;
-use Magento\Framework\DataObject;
+use Magento\Framework\UrlInterface;
 use Magento\Framework\View\Element\Template;
 use Magento\Sales\Model\Order as SalesOrder;
+use Magento\Sales\Model\Order\Item as OrderItem;
 use PHPUnit\Framework\TestCase;
 
 class OrderTest extends TestCase
 {
     /**
-     * Uses DataObject to avoid fighting magic-getter mocking on OrderItem.
+     * Real OrderItem mocks: the block hands the item to LeafProductIdResolver,
+     * which type-hints OrderItemInterface, so a plain DataObject no longer fits.
+     *
+     * @param  string   $productId
+     * @param  string   $name
+     * @param  float    $price
+     * @param  string   $sku
+     * @param  float    $qtyOrdered
+     * @param  float    $rowTotal
+     * @param  string   $productType
+     * @param  int|null $childProductId
+     * @return OrderItem
      */
     private function makeItem(
         string $productId,
@@ -30,16 +45,39 @@ class OrderTest extends TestCase
         float $price,
         string $sku,
         float $qtyOrdered,
-        float $rowTotal
-    ): DataObject {
-        return new DataObject([
-            'product_id'   => $productId,
-            'name'         => $name,
-            'price'        => $price,
-            'sku'          => $sku,
-            'qty_ordered'  => $qtyOrdered,
-            'row_total'    => $rowTotal,
-        ]);
+        float $rowTotal,
+        string $productType = 'simple',
+        $childProductId = null
+    ): OrderItem {
+        $children = [];
+        if ($childProductId !== null) {
+            $child = $this->getMockBuilder(OrderItem::class)
+                ->disableOriginalConstructor()
+                ->onlyMethods(['getProductId'])
+                ->getMock();
+            $child->method('getProductId')->willReturn($childProductId);
+            $children[] = $child;
+        }
+
+        $item = $this->getMockBuilder(OrderItem::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(
+                [
+                    'getProductId', 'getProductType', 'getChildrenItems',
+                    'getName', 'getPrice', 'getSku', 'getQtyOrdered', 'getRowTotal',
+                ]
+            )
+            ->getMock();
+        $item->method('getProductId')->willReturn($productId);
+        $item->method('getProductType')->willReturn($productType);
+        $item->method('getChildrenItems')->willReturn($children);
+        $item->method('getName')->willReturn($name);
+        $item->method('getPrice')->willReturn($price);
+        $item->method('getSku')->willReturn($sku);
+        $item->method('getQtyOrdered')->willReturn($qtyOrdered);
+        $item->method('getRowTotal')->willReturn($rowTotal);
+
+        return $item;
     }
 
     private function makeBlock(?SalesOrder $order): Order
@@ -51,9 +89,28 @@ class OrderTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        // getOrderData() reads the media base URL; without this the block hits
+        // getBaseUrl() on null.
+        $urlBuilder = $this->createMock(UrlInterface::class);
+        $urlBuilder->method('getBaseUrl')->willReturn('https://example.com/media/');
+        $context->method('getUrlBuilder')->willReturn($urlBuilder);
+
         $helper = $this->createMock(MailChimpHelper::class);
 
-        return new Order($context, $helper, $checkoutSession);
+        $product = $this->createMock(Product::class);
+        $product->method('getImage')->willReturn('no_selection');
+        $product->method('getProductUrl')->willReturn('https://example.com/p.html');
+
+        $productRepository = $this->createMock(ProductRepositoryInterface::class);
+        $productRepository->method('getById')->willReturn($product);
+
+        return new Order(
+            $context,
+            $helper,
+            $checkoutSession,
+            $productRepository,
+            new LeafProductIdResolver()
+        );
     }
 
     // All methods listed here ARE declared on Sales\Order (confirmed via reflection)
@@ -149,5 +206,29 @@ class OrderTest extends TestCase
         $block = $this->makeBlock($order);
 
         $this->assertArrayNotHasKey('customerId', $block->getOrderData());
+    }
+
+    public function testGetOrderDataConfigurableSendsChildAsVariantId(): void
+    {
+        $item  = $this->makeItem('62', 'Chaz Kangeroo Hoodie', 52.0, 'MH01-XS-Black', 1.0, 52.0, 'configurable', 47);
+        $order = $this->makeOrder('9', '100000099', 'USD', 52.0, 0.0, 5.0, 57.0, [$item]);
+        $block = $this->makeBlock($order);
+
+        $lineItem = $block->getOrderData()['lineItems'][0];
+
+        $this->assertSame('47', $lineItem['item']['id'], 'id must be the child order-item row');
+        $this->assertSame('62', $lineItem['item']['productId'], 'productId must stay the parent');
+    }
+
+    public function testGetOrderDataConfigurableWithoutChildRowFallsBackToParent(): void
+    {
+        $item  = $this->makeItem('62', 'Chaz Kangeroo Hoodie', 52.0, 'MH01', 1.0, 52.0, 'configurable', null);
+        $order = $this->makeOrder('9', '100000099', 'USD', 52.0, 0.0, 5.0, 57.0, [$item]);
+        $block = $this->makeBlock($order);
+
+        $lineItem = $block->getOrderData()['lineItems'][0];
+
+        $this->assertSame('62', $lineItem['item']['id']);
+        $this->assertSame('62', $lineItem['item']['productId']);
     }
 }

--- a/Test/Unit/Block/Pixel/SearchTest.php
+++ b/Test/Unit/Block/Pixel/SearchTest.php
@@ -15,6 +15,8 @@ use Ebizmarts\MailChimp\Block\Pixel\Search;
 use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
 use Magento\Framework\App\RequestInterface;
 use Magento\Framework\View\Element\Template;
+use Magento\Search\Model\Query;
+use Magento\Search\Model\QueryFactory;
 use PHPUnit\Framework\TestCase;
 
 class SearchTest extends TestCase
@@ -33,14 +35,29 @@ class SearchTest extends TestCase
 
         $helper = $this->createMock(MailChimpHelper::class);
 
-        return new Search($context, $helper);
+        // getSearchData() reads the result count off the current search query.
+        $query = $this->getMockBuilder(Query::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['getNumResults'])
+            ->getMock();
+        $query->method('getNumResults')->willReturn(7);
+
+        $queryFactory = $this->getMockBuilder(QueryFactory::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['get'])
+            ->getMock();
+        $queryFactory->method('get')->willReturn($query);
+
+        return new Search($context, $helper, $queryFactory);
     }
 
     public function testGetSearchDataReturnsQueryWhenPresent(): void
     {
         $block = $this->makeBlock('red shoes');
 
-        $this->assertSame(['query' => 'red shoes'], $block->getSearchData());
+        // The block also reports the result count (added with QueryFactory);
+        // the stubbed query returns 7.
+        $this->assertSame(['query' => 'red shoes', 'resultsCount' => 7], $block->getSearchData());
     }
 
     public function testGetSearchDataReturnsEmptyArrayWhenNoQuery(): void

--- a/Test/Unit/Model/Product/LeafProductIdResolverTest.php
+++ b/Test/Unit/Model/Product/LeafProductIdResolverTest.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Ebizmarts_MailChimp
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Test\Unit\Model\Product;
+
+use Ebizmarts\MailChimp\Model\Product\LeafProductIdResolver;
+use Magento\Catalog\Model\Product;
+use Magento\Quote\Model\Quote\Item as QuoteItem;
+use Magento\Quote\Model\Quote\Item\Option;
+use Magento\Sales\Model\Order\Item as OrderItem;
+use PHPUnit\Framework\TestCase;
+
+class LeafProductIdResolverTest extends TestCase
+{
+    /**
+     * @var LeafProductIdResolver
+     */
+    private $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new LeafProductIdResolver();
+    }
+
+    /**
+     * @param  string      $productType
+     * @param  int         $productId
+     * @param  Option|null $simpleOption
+     * @return QuoteItem
+     */
+    private function quoteItem(string $productType, int $productId, $simpleOption = null): QuoteItem
+    {
+        $item = $this->getMockBuilder(QuoteItem::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getProductType', 'getOptionByCode'])
+            ->addMethods(['getProductId'])
+            ->getMock();
+        $item->method('getProductType')->willReturn($productType);
+        $item->method('getProductId')->willReturn($productId);
+        $item->method('getOptionByCode')->willReturn($simpleOption);
+
+        return $item;
+    }
+
+    /**
+     * @param  int|null $childProductId
+     * @return Option
+     */
+    private function simpleOption($childProductId): Option
+    {
+        $product = null;
+        if ($childProductId !== null) {
+            $product = $this->createMock(Product::class);
+            $product->method('getId')->willReturn($childProductId);
+        }
+
+        $option = $this->getMockBuilder(Option::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getProduct'])
+            ->getMock();
+        $option->method('getProduct')->willReturn($product);
+
+        return $option;
+    }
+
+    public function testQuoteItemSimpleReturnsOwnId(): void
+    {
+        $this->assertSame(10, $this->resolver->forQuoteItem($this->quoteItem('simple', 10)));
+    }
+
+    public function testQuoteItemBundleReturnsOwnId(): void
+    {
+        $this->assertSame(45, $this->resolver->forQuoteItem($this->quoteItem('bundle', 45)));
+    }
+
+    public function testQuoteItemConfigurableReturnsChildId(): void
+    {
+        $item = $this->quoteItem('configurable', 62, $this->simpleOption(47));
+        $this->assertSame(47, $this->resolver->forQuoteItem($item));
+    }
+
+    public function testQuoteItemConfigurableWithoutOptionFallsBackToParent(): void
+    {
+        $item = $this->quoteItem('configurable', 62, null);
+        $this->assertSame(62, $this->resolver->forQuoteItem($item));
+    }
+
+    public function testQuoteItemConfigurableWithOptionButNoProductFallsBackToParent(): void
+    {
+        $item = $this->quoteItem('configurable', 62, $this->simpleOption(null));
+        $this->assertSame(62, $this->resolver->forQuoteItem($item));
+    }
+
+    /**
+     * @param  string $productType
+     * @param  array  $children
+     * @return OrderItem
+     */
+    private function orderItem(string $productType, array $children = []): OrderItem
+    {
+        $item = $this->getMockBuilder(OrderItem::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getProductType', 'getChildrenItems'])
+            ->getMock();
+        $item->method('getProductType')->willReturn($productType);
+        $item->method('getChildrenItems')->willReturn($children);
+
+        return $item;
+    }
+
+    /**
+     * @param  int $productId
+     * @return OrderItem
+     */
+    private function childOrderItem(int $productId): OrderItem
+    {
+        $child = $this->getMockBuilder(OrderItem::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getProductId'])
+            ->getMock();
+        $child->method('getProductId')->willReturn($productId);
+
+        return $child;
+    }
+
+    public function testOrderItemSimpleReturnsNull(): void
+    {
+        $this->assertNull($this->resolver->forOrderItem($this->orderItem('simple')));
+    }
+
+    public function testOrderItemConfigurableReturnsChildId(): void
+    {
+        $item = $this->orderItem('configurable', [$this->childOrderItem(47)]);
+        $this->assertSame(47, $this->resolver->forOrderItem($item));
+    }
+
+    public function testOrderItemConfigurableWithoutChildrenReturnsNull(): void
+    {
+        $this->assertNull($this->resolver->forOrderItem($this->orderItem('configurable', [])));
+    }
+
+    public function testOrderItemSkipsChildrenWithoutProductId(): void
+    {
+        $item = $this->orderItem('configurable', [$this->childOrderItem(0), $this->childOrderItem(47)]);
+        $this->assertSame(47, $this->resolver->forOrderItem($item));
+    }
+}

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -17,4 +17,7 @@
     <type name="Magento\Newsletter\Controller\Manage\Save">
         <plugin name="mailchimp-account-interest-group" type="Ebizmarts\MailChimp\Model\Plugin\Newsletter\Save" sortOrder="10"/>
     </type>
+    <type name="Magento\Checkout\CustomerData\DefaultItem">
+        <plugin name="mailchimp-pixel-cart-item-variant-id" type="Ebizmarts\MailChimp\Model\Plugin\CustomerData\CartItemVariantId" sortOrder="10"/>
+    </type>
 </config>

--- a/view/frontend/web/js/pixel.js
+++ b/view/frontend/web/js/pixel.js
@@ -52,9 +52,14 @@
         ) || 0;
         var imageUrl = (item.product_image && item.product_image.src) ? item.product_image.src : '';
         var productId = String(item.product_id || item.item_id || '');
+        // Mailchimp variant identity. mc_variant_id is attached server side by
+        // Ebizmarts\MailChimp\Model\Plugin\CustomerData\CartItemVariantId, because the
+        // customer-data cart section only carries the PARENT id for a configurable
+        // and the chosen child cannot be resolved in the browser.
+        var variantId = String(item.mc_variant_id || '') || productId;
         var product = {
             item: {
-                id: productId, productId: productId,
+                id: variantId, productId: productId,
                 title: item.product_name || item.name || '',
                 price: unitPrice, currency: currency || '',
                 sku: String(item.product_sku || item.sku || ''),


### PR DESCRIPTION
Corrects the product identity the pixel reports for configurable products, so a variant can be joined against what Mailchimp already stores.

## The defect

The pixel sent the **parent** product id in both `ProductVariantDto.id` and `.productId`, so a configurable's variant identity never reached Mailchimp. Mailchimp's contract is `id` = the variant the shopper selected, `productId` = the parent catalog product.

The correct value was already decided: the REST sync publishes the child simple's entity id as the Mailchimp variant id (`Model/Api/Product.php:399` → `:528`), so Mailchimp already holds those child ids. The pixel had to send the same value or the join fails.

## What changed

- **`Model/Product/LeafProductIdResolver`** (new) — stateless, zero constructor dependencies. `forQuoteItem()` resolves the chosen child through the `simple_product` option; `forOrderItem()` reads the child order-item row. Deliberately does not fall back to `product_options['simple_sku']`, which holds a SKU and would cost a catalog lookup per line on the purchase event.
- **`Block/Pixel/Cart`, `Checkout`, `Order`** — `id` now carries the leaf id, `productId` keeps the parent.
- **`Model/Plugin/CustomerData/CartItemVariantId`** (new) + `etc/frontend/di.xml` — `PRODUCT_ADDED_TO_CART` is fired client side from the customer-data `cart` section, which only carries the parent id and offers no way to resolve the child in the browser. The plugin exposes `mc_variant_id`; `pixel.js` reads it back. Magento ships no configurable-specific renderer for that section, so `DefaultItem` covers every type.
- **`Block/Pixel/Product` is untouched** — nothing is selected on a configurable PDP at page load, so there is no variant to report.

Simple, bundle and grouped keep `id === productId`. That is the correct answer for them, not a fallback: they are self-referencing in the REST variant payload we already send.

## Verified on a storefront

Magento 2.4.8 + Luma sample data. Chaz Kangeroo Hoodie, parent **62**, variant XS/Black = child **47**. Payloads read from the rendered HTML after a real add-to-cart and a real checkout:

| Event | Source | id | productId |
|---|---|---|---|
| `PRODUCT_ADDED_TO_CART` | `/customer/section/load/?sections=cart` | `mc_variant_id=47` | `product_id=62` |
| `CART_VIEWED` | `mailchimp-pixel-cart-data` | 47 | 62 |
| `CHECKOUT_STARTED` | `mailchimp-pixel-checkout-data` | 47 | 62 |
| `PURCHASED` | `mailchimp-pixel-order-data` (order 000000005) | 47 | 62 |
| simple `24-MB01` | `mailchimp-pixel-cart-data` | 1 | 1 |

Bundle (`24-WG080`) and grouped (`24-WG085`) also verified unchanged.

## Test suite

`Test/Unit/Block/Pixel/` was **entirely red on `develop-2.4`** before this branch — 34 tests, 16 errors, 2 failures — for three pre-existing reasons unrelated to each other:

1. Constructors that had gained dependencies without the tests being updated: `Order` needed `ProductRepositoryInterface`, `Search` needed `QueryFactory`. Both fail on the published `103.4.81` tag.
2. The `Template\Context` mock never stubbed `getUrlBuilder()`, so `Cart` and `Checkout` hit `getBaseUrl()` on null.
3. Expectations that predated shipped payload changes: the `checkout_` id prefix, `resultsCount` in the search payload, and `categoryId`/`categoryName` keys (confirmed against `view/frontend/web/js/pixel/category.js`, which reads `category.categoryId`).

Now green: **39 tests, 95 assertions**, plus 9 new tests for the resolver. Item fixtures moved from `DataObject` to real `Quote\Item` / `Order\Item` mocks because the resolver type-hints them.

`phpcs --standard=Magento2`: 0 errors on every file touched here.

## Not included

`Test/Unit/Model/Service/Pixel/PixelStateWriterTest` still has 4 failures, in code this PR does not touch. Three are because the test expects `cacheTypeList->invalidate('config')` while the code calls `cleanType('config')` — that is a behavioural decision, not test hygiene (`cleanType` takes effect immediately; `invalidate` would leave the pixel off until someone refreshes caches), so it needs a deliberate call rather than a test edited to match. The fourth is `enable()` performing four `save()` calls against an expectation of three.

Worth flagging separately: this suite is red on a published tag, which means it is not running in CI.
