### PR TITLE
Report extension status to the ebizmarts service once an hour

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Keep development-only paths out of release archives.
+#
+# `export-ignore` applies to `git archive`, which is what GitHub builds release
+# tarballs from and what Composer downloads on a dist install. It does NOT
+# affect `git clone`, so a developer cloning the repo — or an app/code install
+# done by cloning — still gets everything listed here.
+
+/Test               export-ignore
+/.gitattributes     export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,0 @@
-# Keep development-only paths out of release archives.
-#
-# `export-ignore` applies to `git archive`, which is what GitHub builds release
-# tarballs from and what Composer downloads on a dist install. It does NOT
-# affect `git clone`, so a developer cloning the repo — or an app/code install
-# done by cloning — still gets everything listed here.
-
-/Test               export-ignore
-/.gitattributes     export-ignore

--- a/Cron/EdgeBeacon.php
+++ b/Cron/EdgeBeacon.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Ebizmarts_MailChimp Magento Component
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Cron;
+
+use Ebizmarts\MailChimp\Model\Edge\Beacon;
+
+/**
+ * Hourly entry point for the status reporting beacon.
+ */
+class EdgeBeacon
+{
+    /**
+     * @var Beacon
+     */
+    private $beacon;
+
+    /**
+     * @param Beacon $beacon
+     */
+    public function __construct(
+        Beacon $beacon
+    ) {
+        $this->beacon = $beacon;
+    }
+
+    /**
+     * @return void
+     */
+    public function execute()
+    {
+        $this->beacon->execute();
+    }
+}

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -539,6 +539,46 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     }
 
     /**
+     * Write a config value now and leave the cache flush to the caller.
+     *
+     * saveConfigValue() flushes on every call, and a flush is not cheap: the
+     * config module intercepts it to re-read the whole system config and then
+     * serialise and encrypt every scope in turn, under a lock. That cost grows
+     * with the number of store views, so a job that writes once per view pays
+     * it once per view — quadratic work for what should be one refresh.
+     *
+     * Callers that write several values in one pass should use this and then
+     * call flushConfigCache() once. Nothing they write is visible to a read
+     * until they do, so this is only safe where the caller does not read back
+     * what it has just written.
+     *
+     * @param  string      $path
+     * @param  string      $value
+     * @param  int|null    $storeId
+     * @param  string|null $scope
+     * @return void
+     */
+    public function saveConfigValueWithoutCacheFlush($path, $value, $storeId = null, $scope = null)
+    {
+        $this->saveConfigValueAtomic(
+            (string)$path,
+            (string)$value,
+            (string)($scope ?: \Magento\Store\Model\ScopeInterface::SCOPE_STORES),
+            (int)$storeId
+        );
+    }
+
+    /**
+     * Refresh the config cache once, after a run of deferred writes.
+     *
+     * @return void
+     */
+    public function flushConfigCache()
+    {
+        $this->_cacheTypeList->cleanType('config');
+    }
+
+    /**
      * Atomically upsert a single config row using INSERT … ON DUPLICATE KEY UPDATE.
      *
      * core_config_data has a UNIQUE KEY on (scope, scope_id, path), so a plain

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -73,9 +73,17 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
 
     /**
      * Whether the merchant lets the account owner's name and address travel
-     * with diagnostics. Shared with the API library, which reads the same path
-     * for the same purpose: one switch in the admin has to govern both, or it
-     * tells the merchant something that is not true.
+     * with diagnostics.
+     *
+     * The path is shared with the API library on purpose: one switch in the
+     * admin has to govern every lane that reports, or it describes only part
+     * of what leaves the server.
+     *
+     * The library reads it from the release that first gives it anything to
+     * report — the constant and the reporting arrived in the same commit
+     * there, so no version of it can send contact details while ignoring this.
+     * Until that release is the one installed, the switch governs this
+     * extension's reports and there is nothing else for it to govern.
      */
     const XML_TELEMETRY_SHARE_CONTACT = 'mailchimp/telemetry/share_contact';
 

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -61,6 +61,16 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     const XML_REGISTER_URL            = 'mailchimp/statistics/register_url';
     const XML_STATISTICS_TOKEN        = 'mailchimp/register/token';
 
+    /**
+     * Status reporting beacon. The token is per store view; the cron expression is
+     * per install; the delivery uid is the last notification actually written
+     * to the admin inbox. Deliberately NOT mailchimp/register/token, which
+     * holds a token from the previous relay and is meaningless to this service.
+     */
+    const XML_EDGE_TOKEN              = 'mailchimp/register/edge_token';
+    const XML_EDGE_BEACON_CRON        = 'mailchimp/register/beacon_cron';
+    const XML_EDGE_DELIVERY_UID       = 'mailchimp/register/last_delivery_uid';
+
     const XML_PIXEL_ENABLED_FOR_STORE = 'mailchimp/pixel/enabled_for_store';
     const XML_PIXEL_SCRIPT_URL        = 'mailchimp/pixel/script_url';
     const XML_PIXEL_SCRIPT_FRAGMENT   = 'mailchimp/pixel/script_fragment';

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -71,6 +71,14 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     const XML_EDGE_BEACON_CRON        = 'mailchimp/register/beacon_cron';
     const XML_EDGE_DELIVERY_UID       = 'mailchimp/register/last_delivery_uid';
 
+    /**
+     * Whether the merchant lets the account owner's name and address travel
+     * with diagnostics. Shared with the API library, which reads the same path
+     * for the same purpose: one switch in the admin has to govern both, or it
+     * tells the merchant something that is not true.
+     */
+    const XML_TELEMETRY_SHARE_CONTACT = 'mailchimp/telemetry/share_contact';
+
     const XML_PIXEL_ENABLED_FOR_STORE = 'mailchimp/pixel/enabled_for_store';
     const XML_PIXEL_SCRIPT_URL        = 'mailchimp/pixel/script_url';
     const XML_PIXEL_SCRIPT_FRAGMENT   = 'mailchimp/pixel/script_fragment';

--- a/Model/Edge/Beacon.php
+++ b/Model/Edge/Beacon.php
@@ -218,7 +218,11 @@ class Beacon
             // Mailchimp outage must not make every installation look dead.
             $account = $this->accountBlock($storeId);
             if ($account !== null) {
-                $body['account'] = $account;
+                // Top level, not nested: the receiving side reads these as
+                // first-class keys and drops anything it does not recognise, so
+                // an `account` wrapper would be accepted with a 200 and thrown
+                // away. Same shape the register already sends.
+                $body = array_merge($body, $account);
             }
         }
 
@@ -318,7 +322,11 @@ class Beacon
      */
     private function shouldSendAccountBlock($storeId, $storeUrl)
     {
-        $slot = crc32($storeId . $storeUrl) % self::ACCOUNT_BLOCK_PERIOD_HOURS;
+        // Sign-masked: crc32() returns a NEGATIVE int on 32-bit PHP builds, and a
+        // negative slot can never equal an hour, so those installs would never
+        // refresh their account data. Silent, and 32-bit builds still exist on
+        // older shared hosting.
+        $slot = (crc32($storeId . $storeUrl) & 0x7fffffff) % self::ACCOUNT_BLOCK_PERIOD_HOURS;
         $hour = (int)$this->helper->getGmtDate('G');
 
         return $hour % self::ACCOUNT_BLOCK_PERIOD_HOURS === $slot;
@@ -349,7 +357,9 @@ class Beacon
 
         // Concatenation, not addition: on PHP 8 "abc" + "def" is a TypeError,
         // and for all-numeric ids it would silently produce a different slot.
-        $minute = crc32($accountId . $storeUrl) % 60;
+        // Sign-masked for the same reason as the slot above: a negative minute
+        // writes an invalid cron expression, and the job then never runs at all.
+        $minute = (crc32($accountId . $storeUrl) & 0x7fffffff) % 60;
 
         $this->helper->saveConfigValue(
             MailChimpHelper::XML_EDGE_BEACON_CRON,

--- a/Model/Edge/Beacon.php
+++ b/Model/Edge/Beacon.php
@@ -68,6 +68,11 @@ class Beacon
     private $scopeConfig;
 
     /**
+     * @var bool the cron slot has been settled for this process
+     */
+    private $slotClaimed = false;
+
+    /**
      * @param StoreManagerInterface    $storeManager
      * @param MailChimpHelper          $helper
      * @param Client                   $client
@@ -256,7 +261,10 @@ class Beacon
             );
         }
 
-        $this->notifications->handle($storeId, $token, $response->getData());
+        // The acks just sent are gone as far as the service is concerned, so
+        // nothing is still pending. Passed in rather than re-read: see
+        // NotificationDelivery::rememberForAck.
+        $this->notifications->handle($storeId, $token, $response->getData(), []);
     }
 
     /**
@@ -350,8 +358,21 @@ class Beacon
      */
     private function claimBeaconSlot($accountId, $storeUrl)
     {
+        // The read below cannot be trusted to see a write made earlier in this
+        // same process: within one request the config a scope has already
+        // loaded is refreshed only as a side effect of the cache-warming path,
+        // which is skipped when the config cache type is disabled. On a fresh
+        // multi-store-view install every view registers on the first tick, each
+        // read returns empty, and each writes a different minute — the last one
+        // winning, after N full config-cache flushes. This flag makes the claim
+        // once per process regardless.
+        if ($this->slotClaimed) {
+            return;
+        }
+
         $existing = $this->scopeConfig->getValue(MailChimpHelper::XML_EDGE_BEACON_CRON);
         if ($existing) {
+            $this->slotClaimed = true;
             return;
         }
 
@@ -367,6 +388,8 @@ class Beacon
             0,
             'default'
         );
+
+        $this->slotClaimed = true;
     }
 
     /**

--- a/Model/Edge/Beacon.php
+++ b/Model/Edge/Beacon.php
@@ -268,6 +268,31 @@ class Beacon
     }
 
     /**
+     * Whether the account owner's name and address may travel with a report.
+     *
+     * Only an explicit no counts as a refusal. An absent value means the
+     * question has never been answered on this installation — which is what an
+     * upgrade from a version that predates the switch looks like — and that is
+     * not the same as declining. config.xml supplies the default, so in
+     * practice the absent case only arises if configuration cannot be read at
+     * all, and failing open there matches how the API library reads the very
+     * same path.
+     *
+     * @param  int $storeId
+     * @return bool
+     */
+    private function contactAllowed($storeId)
+    {
+        $value = $this->helper->getConfigValue(MailChimpHelper::XML_TELEMETRY_SHARE_CONTACT, $storeId);
+
+        if ($value === null || $value === '') {
+            return true;
+        }
+
+        return (bool)$value;
+    }
+
+    /**
      * Delivery uids waiting to be acknowledged, queued by the last pull.
      *
      * @param  int $storeId
@@ -303,13 +328,18 @@ class Beacon
             return null;
         }
 
+        $fields = ['account_id', 'account_name', 'pricing_plan_type', 'total_subscribers'];
+
+        // Everything that names or reaches the person behind the account is
+        // sent only while the merchant allows it. The admin switch says it
+        // leaves the owner's name and address out of these reports, and a
+        // switch that is not obeyed is worse than no switch at all.
+        if ($this->contactAllowed($storeId)) {
+            $fields = array_merge($fields, ['email', 'first_name', 'last_name', 'username']);
+        }
+
         $block = [];
-        foreach (
-            [
-                'account_id', 'account_name', 'email', 'first_name',
-                'last_name', 'username', 'pricing_plan_type', 'total_subscribers',
-            ] as $field
-        ) {
+        foreach ($fields as $field) {
             if (isset($root[$field])) {
                 $block[$field] = $root[$field];
             }

--- a/Model/Edge/Beacon.php
+++ b/Model/Edge/Beacon.php
@@ -1,0 +1,386 @@
+<?php
+/**
+ * Ebizmarts_MailChimp Magento Component
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Model\Edge;
+
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\ProductMetadataInterface;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Store\Model\StoreManagerInterface;
+
+/**
+ * Hourly status report to the ebizmarts service: register once, then ping forever.
+ *
+ * Additive by design. Nothing here touches the existing registration to
+ * users-mc4mage, the hourly batch push or enable_support.
+ */
+class Beacon
+{
+    /**
+     * The account block rides two pings a day, twelve hours apart. The slot is
+     * derived from the store identity rather than persisted, so there is no
+     * "last refresh" timestamp to write on every tick.
+     */
+    const ACCOUNT_BLOCK_PERIOD_HOURS = 12;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @var MailChimpHelper
+     */
+    private $helper;
+
+    /**
+     * @var Client
+     */
+    private $client;
+
+    /**
+     * @var LivenessSignals
+     */
+    private $signals;
+
+    /**
+     * @var NotificationDelivery
+     */
+    private $notifications;
+
+    /**
+     * @var ProductMetadataInterface
+     */
+    private $productMetadata;
+
+    /**
+     * @var ScopeConfigInterface
+     */
+    private $scopeConfig;
+
+    /**
+     * @param StoreManagerInterface    $storeManager
+     * @param MailChimpHelper          $helper
+     * @param Client                   $client
+     * @param LivenessSignals          $signals
+     * @param NotificationDelivery     $notifications
+     * @param ProductMetadataInterface $productMetadata
+     * @param ScopeConfigInterface     $scopeConfig
+     */
+    public function __construct(
+        StoreManagerInterface $storeManager,
+        MailChimpHelper $helper,
+        Client $client,
+        LivenessSignals $signals,
+        NotificationDelivery $notifications,
+        ProductMetadataInterface $productMetadata,
+        ScopeConfigInterface $scopeConfig
+    ) {
+        $this->storeManager    = $storeManager;
+        $this->helper          = $helper;
+        $this->client          = $client;
+        $this->signals         = $signals;
+        $this->notifications   = $notifications;
+        $this->productMetadata = $productMetadata;
+        $this->scopeConfig     = $scopeConfig;
+    }
+
+    /**
+     * One tick: every store view that has an API key and an active extension.
+     *
+     * A failure on one store view never aborts the loop.
+     *
+     * @return void
+     */
+    public function execute()
+    {
+        foreach ($this->storeManager->getStores() as $store) {
+            $storeId = (int)$store->getId();
+
+            if (!$this->helper->isMailChimpEnabled($storeId) || !$this->helper->getApiKey($storeId)) {
+                continue;
+            }
+
+            try {
+                $this->processStore($storeId, (string)$store->getBaseUrl());
+            } catch (\Exception $e) {
+                $this->helper->log('Edge beacon failed for store ' . $storeId . ': ' . $e->getMessage());
+            }
+        }
+    }
+
+    /**
+     * Register when there is no token, then ping regardless.
+     *
+     * @param  int    $storeId
+     * @param  string $storeUrl
+     * @return void
+     */
+    private function processStore($storeId, $storeUrl)
+    {
+        $token = (string)$this->helper->getConfigValue(MailChimpHelper::XML_EDGE_TOKEN, $storeId);
+
+        if ($token === '') {
+            $token = $this->register($storeId, $storeUrl);
+            if ($token === null) {
+                // Nothing written. The remote upsert is idempotent, so the next
+                // hourly tick simply tries again.
+                return;
+            }
+        }
+
+        $this->ping($storeId, $storeUrl, $token);
+    }
+
+    /**
+     * Register the store view and store the token it returns.
+     *
+     * The account fields cost one GET / against Mailchimp, and only here.
+     *
+     * @param  int    $storeId
+     * @param  string $storeUrl
+     * @return string|null
+     */
+    private function register($storeId, $storeUrl)
+    {
+        $account = $this->accountBlock($storeId);
+        if ($account === null) {
+            // Without the account we have no identity to register under.
+            return null;
+        }
+
+        $body = array_merge(
+            ['store_url' => $storeUrl],
+            $account,
+            $this->versionBlock()
+        );
+
+        $response = $this->client->register($body);
+        if (!$response->isOk()) {
+            return null;
+        }
+
+        $data  = $response->getData();
+        $token = isset($data['token']) ? (string)$data['token'] : '';
+        if ($token === '') {
+            $this->helper->log('Edge beacon registered store ' . $storeId . ' but no token came back');
+            return null;
+        }
+
+        $this->helper->saveConfigValue(
+            MailChimpHelper::XML_EDGE_TOKEN,
+            $token,
+            $storeId,
+            ScopeInterface::SCOPE_STORES
+        );
+
+        $this->claimBeaconSlot(isset($account['account_id']) ? (string)$account['account_id'] : '', $storeUrl);
+
+        return $token;
+    }
+
+    /**
+     * Send the status report and act on the reply.
+     *
+     * @param  int    $storeId
+     * @param  string $storeUrl
+     * @param  string $token
+     * @return void
+     */
+    private function ping($storeId, $storeUrl, $token)
+    {
+        $body = array_merge(
+            ['store_url' => $storeUrl],
+            $this->versionBlock(),
+            $this->signals->forStore($storeId)
+        );
+
+        // Two-step ack, opportunistic: the service acknowledges each uid
+        // included in the ping. `read[]` is deliberately
+        // never sent - we can prove a message reached the inbox, not that the
+        // merchant opened it.
+        $pendingAcks = $this->pendingAcks($storeId);
+        if (!empty($pendingAcks)) {
+            $body['received'] = $pendingAcks;
+        }
+
+        if ($this->shouldSendAccountBlock($storeId, $storeUrl)) {
+            // Deliberately outside any try that wraps the ping itself: a
+            // Mailchimp outage must not make every installation look dead.
+            $account = $this->accountBlock($storeId);
+            if ($account !== null) {
+                $body['account'] = $account;
+            }
+        }
+
+        $response = $this->client->ping($token, $body);
+
+        if ($response->isUnauthorized()) {
+            // The only condition that clears the token. Next tick re-registers.
+            $this->helper->saveConfigValue(
+                MailChimpHelper::XML_EDGE_TOKEN,
+                '',
+                $storeId,
+                ScopeInterface::SCOPE_STORES
+            );
+            return;
+        }
+
+        if ($response->isRateLimited() || !$response->isOk()) {
+            // Token untouched, and the acks stay queued: a ping that never
+            // landed has not confirmed anything.
+            return;
+        }
+
+        // Cleared only once the service has actually seen them, and before the
+        // pull below can queue a fresh batch.
+        if (!empty($pendingAcks)) {
+            $this->helper->saveConfigValue(
+                MailChimpHelper::XML_EDGE_DELIVERY_UID,
+                '',
+                $storeId,
+                ScopeInterface::SCOPE_STORES
+            );
+        }
+
+        $this->notifications->handle($storeId, $token, $response->getData());
+    }
+
+    /**
+     * Delivery uids waiting to be acknowledged, queued by the last pull.
+     *
+     * @param  int $storeId
+     * @return array
+     */
+    private function pendingAcks($storeId)
+    {
+        $pending = (string)$this->helper->getConfigValue(MailChimpHelper::XML_EDGE_DELIVERY_UID, $storeId);
+        if ($pending === '') {
+            return [];
+        }
+
+        return array_values(array_filter(explode(',', $pending)));
+    }
+
+    /**
+     * The Mailchimp account block, or null when the call fails.
+     *
+     * @param  int $storeId
+     * @return array|null
+     */
+    private function accountBlock($storeId)
+    {
+        try {
+            $api  = $this->helper->getApi($storeId);
+            $root = $api->root->info();
+        } catch (\Exception $e) {
+            $this->helper->log('Edge beacon could not read the Mailchimp account: ' . $e->getMessage());
+            return null;
+        }
+
+        if (!is_array($root)) {
+            return null;
+        }
+
+        $block = [];
+        foreach (
+            [
+                'account_id', 'account_name', 'email', 'first_name',
+                'last_name', 'username', 'pricing_plan_type', 'total_subscribers',
+            ] as $field
+        ) {
+            if (isset($root[$field])) {
+                $block[$field] = $root[$field];
+            }
+        }
+
+        return $block;
+    }
+
+    /**
+     * Whether this tick is one of the store's two daily account slots.
+     *
+     * Derived from the store identity, so it needs no persisted state and a
+     * given store always refreshes at the same two hours.
+     *
+     * @param  int    $storeId
+     * @param  string $storeUrl
+     * @return bool
+     */
+    private function shouldSendAccountBlock($storeId, $storeUrl)
+    {
+        $slot = crc32($storeId . $storeUrl) % self::ACCOUNT_BLOCK_PERIOD_HOURS;
+        $hour = (int)$this->helper->getGmtDate('G');
+
+        return $hour % self::ACCOUNT_BLOCK_PERIOD_HOURS === $slot;
+    }
+
+    /**
+     * Write the install's beacon minute, once.
+     *
+     * The stagger is per installation: one install, one slot, one write. The first
+     * store view to register successfully claims it and later ones leave it
+     * alone, so the value never flaps.
+     *
+     * It has to live in DEFAULT scope: Magento's scheduler reads config_path
+     * with no store id (ProcessCronQueueObserver::getConfigSchedule), so a
+     * value written per store view would never be seen and the job would sit
+     * on its bootstrap minute forever, looking configured.
+     *
+     * @param  string $accountId
+     * @param  string $storeUrl
+     * @return void
+     */
+    private function claimBeaconSlot($accountId, $storeUrl)
+    {
+        $existing = $this->scopeConfig->getValue(MailChimpHelper::XML_EDGE_BEACON_CRON);
+        if ($existing) {
+            return;
+        }
+
+        // Concatenation, not addition: on PHP 8 "abc" + "def" is a TypeError,
+        // and for all-numeric ids it would silently produce a different slot.
+        $minute = crc32($accountId . $storeUrl) % 60;
+
+        $this->helper->saveConfigValue(
+            MailChimpHelper::XML_EDGE_BEACON_CRON,
+            $minute . ' * * * *',
+            0,
+            'default'
+        );
+    }
+
+    /**
+     * Version facts, on both register and ping.
+     *
+     * @return array
+     */
+    private function versionBlock()
+    {
+        try {
+            $moduleVersion = (string)$this->helper->getModuleVersion();
+        } catch (\Exception $e) {
+            $moduleVersion = '';
+        }
+
+        // The key names are the service's, not ours: it projects the body onto a
+        // closed whitelist and silently drops anything outside it. `module_version`
+        // and `magento_version` are also the two it promotes to their own columns
+        // and writes on EVERY ping, so a merchant upgrading mid-day shows up on the
+        // next beacon rather than waiting for a profile change.
+        return [
+            'module_version'  => $moduleVersion,
+            'magento_version' => (string)$this->productMetadata->getVersion(),
+            'php_version'     => PHP_VERSION,
+        ];
+    }
+}

--- a/Model/Edge/Beacon.php
+++ b/Model/Edge/Beacon.php
@@ -73,6 +73,11 @@ class Beacon
     private $slotClaimed = false;
 
     /**
+     * @var bool a config value was written and the cache still shows the old one
+     */
+    private $configDirty = false;
+
+    /**
      * @param StoreManagerInterface    $storeManager
      * @param MailChimpHelper          $helper
      * @param Client                   $client
@@ -120,6 +125,17 @@ class Beacon
             } catch (\Exception $e) {
                 $this->helper->log('Edge beacon failed for store ' . $storeId . ': ' . $e->getMessage());
             }
+        }
+
+        // One refresh for the whole run rather than one per value written.
+        // A flush re-reads the entire config and then serialises and encrypts
+        // every scope under a lock, so its cost grows with the number of store
+        // views; flushing per write would make a token expiry across N views
+        // pay that N times over. Nothing above reads back what it wrote, so
+        // deferring to here changes no behaviour.
+        if ($this->configDirty) {
+            $this->helper->flushConfigCache();
+            $this->configDirty = false;
         }
     }
 
@@ -181,12 +197,13 @@ class Beacon
             return null;
         }
 
-        $this->helper->saveConfigValue(
+        $this->helper->saveConfigValueWithoutCacheFlush(
             MailChimpHelper::XML_EDGE_TOKEN,
             $token,
             $storeId,
             ScopeInterface::SCOPE_STORES
         );
+        $this->configDirty = true;
 
         $this->claimBeaconSlot(isset($account['account_id']) ? (string)$account['account_id'] : '', $storeUrl);
 
@@ -235,12 +252,13 @@ class Beacon
 
         if ($response->isUnauthorized()) {
             // The only condition that clears the token. Next tick re-registers.
-            $this->helper->saveConfigValue(
+            $this->helper->saveConfigValueWithoutCacheFlush(
                 MailChimpHelper::XML_EDGE_TOKEN,
                 '',
                 $storeId,
                 ScopeInterface::SCOPE_STORES
             );
+            $this->configDirty = true;
             return;
         }
 
@@ -253,12 +271,13 @@ class Beacon
         // Cleared only once the service has actually seen them, and before the
         // pull below can queue a fresh batch.
         if (!empty($pendingAcks)) {
-            $this->helper->saveConfigValue(
+            $this->helper->saveConfigValueWithoutCacheFlush(
                 MailChimpHelper::XML_EDGE_DELIVERY_UID,
                 '',
                 $storeId,
                 ScopeInterface::SCOPE_STORES
             );
+            $this->configDirty = true;
         }
 
         // The acks just sent are gone as far as the service is concerned, so
@@ -412,7 +431,7 @@ class Beacon
         // writes an invalid cron expression, and the job then never runs at all.
         $minute = (crc32($accountId . $storeUrl) & 0x7fffffff) % 60;
 
-        $this->helper->saveConfigValue(
+        $this->helper->saveConfigValueWithoutCacheFlush(
             MailChimpHelper::XML_EDGE_BEACON_CRON,
             $minute . ' * * * *',
             0,
@@ -420,6 +439,7 @@ class Beacon
         );
 
         $this->slotClaimed = true;
+        $this->configDirty = true;
     }
 
     /**

--- a/Model/Edge/Beacon.php
+++ b/Model/Edge/Beacon.php
@@ -113,29 +113,43 @@ class Beacon
      */
     public function execute()
     {
-        foreach ($this->storeManager->getStores() as $store) {
-            $storeId = (int)$store->getId();
+        try {
+            foreach ($this->storeManager->getStores() as $store) {
+                $storeId = (int)$store->getId();
 
-            if (!$this->helper->isMailChimpEnabled($storeId) || !$this->helper->getApiKey($storeId)) {
-                continue;
+                if (!$this->helper->isMailChimpEnabled($storeId) || !$this->helper->getApiKey($storeId)) {
+                    continue;
+                }
+
+                try {
+                    $this->processStore($storeId, (string)$store->getBaseUrl());
+                } catch (\Exception $e) {
+                    $this->helper->log('Edge beacon failed for store ' . $storeId . ': ' . $e->getMessage());
+                } catch (\Throwable $t) {
+                    // On PHP 7+ an Error is not an Exception, so catching only
+                    // Exception here let a TypeError out of the API path abort
+                    // the run and take every remaining store view with it.
+                    // One store view's problem is not the other views'.
+                    $this->helper->log('Edge beacon failed for store ' . $storeId . ': ' . $t->getMessage());
+                }
             }
-
-            try {
-                $this->processStore($storeId, (string)$store->getBaseUrl());
-            } catch (\Exception $e) {
-                $this->helper->log('Edge beacon failed for store ' . $storeId . ': ' . $e->getMessage());
+        } finally {
+            // One refresh for the whole run rather than one per value written.
+            // A flush re-reads the entire config and then serialises and
+            // encrypts every scope under a lock, so its cost grows with the
+            // number of store views; flushing per write would make a token
+            // expiry across N views pay that N times over. Nothing above reads
+            // back what it wrote, so deferring to here changes no behaviour.
+            //
+            // In `finally` because the deferred writes are already in the
+            // database. Anything that leaves this method without flushing —
+            // and something reaching here uncaught is exactly that case —
+            // would leave a cleared token stored while the config cache keeps
+            // serving the old one, until something unrelated happens to flush.
+            if ($this->configDirty) {
+                $this->helper->flushConfigCache();
+                $this->configDirty = false;
             }
-        }
-
-        // One refresh for the whole run rather than one per value written.
-        // A flush re-reads the entire config and then serialises and encrypts
-        // every scope under a lock, so its cost grows with the number of store
-        // views; flushing per write would make a token expiry across N views
-        // pay that N times over. Nothing above reads back what it wrote, so
-        // deferring to here changes no behaviour.
-        if ($this->configDirty) {
-            $this->helper->flushConfigCache();
-            $this->configDirty = false;
         }
     }
 
@@ -341,6 +355,11 @@ class Beacon
         } catch (\Exception $e) {
             $this->helper->log('Edge beacon could not read the Mailchimp account: ' . $e->getMessage());
             return null;
+        } catch (\Throwable $t) {
+            // Reading the account must not be able to end the run: an Error
+            // here is a broken API path, not a reason to stop reporting.
+            $this->helper->log('Edge beacon could not read the Mailchimp account: ' . $t->getMessage());
+            return null;
         }
 
         if (!is_array($root)) {
@@ -467,6 +486,8 @@ class Beacon
         try {
             $moduleVersion = (string)$this->helper->getModuleVersion();
         } catch (\Exception $e) {
+            $moduleVersion = '';
+        } catch (\Throwable $t) {
             $moduleVersion = '';
         }
 

--- a/Model/Edge/Beacon.php
+++ b/Model/Edge/Beacon.php
@@ -347,14 +347,29 @@ class Beacon
             return null;
         }
 
-        $fields = ['account_id', 'account_name', 'pricing_plan_type', 'total_subscribers'];
+        $fields = ['account_id', 'pricing_plan_type', 'total_subscribers'];
 
         // Everything that names or reaches the person behind the account is
         // sent only while the merchant allows it. The admin switch says it
         // leaves the owner's name and address out of these reports, and a
         // switch that is not obeyed is worse than no switch at all.
+        //
+        // account_name is in that list even though it is the account's name
+        // rather than a field about a person. Accounts opened by a business
+        // carry a company there, but accounts opened by an individual commonly
+        // carry their name — and a field that may or may not name someone has
+        // to be treated as though it does once they have asked us not to. The
+        // API library reads the same switch and withholds the same value, so
+        // gating it here is also what keeps one switch from meaning two things.
+        //
+        // account_id still travels, so reports remain countable and joinable
+        // with the account opted out. What is lost is a human-readable name on
+        // a dashboard, which is precisely what was declined.
         if ($this->contactAllowed($storeId)) {
-            $fields = array_merge($fields, ['email', 'first_name', 'last_name', 'username']);
+            $fields = array_merge(
+                $fields,
+                ['account_name', 'email', 'first_name', 'last_name', 'username']
+            );
         }
 
         $block = [];

--- a/Model/Edge/Client.php
+++ b/Model/Edge/Client.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * Ebizmarts_MailChimp Magento Component
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Model\Edge;
+
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Ebizmarts\MailChimp\Model\HTTP\Client\CurlFactory;
+
+/**
+ * HTTP client for the ebizmarts reporting service.
+ *
+ * The base URL is a constant rather than config on purpose: it is not a
+ * merchant setting and nothing should be able to point a store's beacon
+ * somewhere else through the admin.
+ */
+class Client
+{
+    const BASE_URL           = 'https://apps.ebizmarts.com/mc4magento/v1';
+    const PATH_REGISTER      = '/legacy/register';
+    const PATH_PING          = '/legacy/ping';
+    const PATH_NOTIFICATIONS = '/notifications';
+
+    /**
+     * A beacon runs inside a cron tick that iterates every store view, so a
+     * hung service must not stall every installation. Well below the default 300.
+     */
+    const TIMEOUT = 15;
+
+    /**
+     * @var CurlFactory
+     */
+    private $curlFactory;
+
+    /**
+     * @var MailChimpHelper
+     */
+    private $helper;
+
+    /**
+     * @param CurlFactory     $curlFactory
+     * @param MailChimpHelper $helper
+     */
+    public function __construct(
+        CurlFactory $curlFactory,
+        MailChimpHelper $helper
+    ) {
+        $this->curlFactory = $curlFactory;
+        $this->helper      = $helper;
+    }
+
+    /**
+     * Register a store view. No authentication; the service returns the token.
+     *
+     * Idempotent upsert on the service, so retrying is safe.
+     *
+     * @param  array $body
+     * @return Response
+     */
+    public function register(array $body)
+    {
+        return $this->send(self::PATH_REGISTER, $body, null);
+    }
+
+    /**
+     * Send the status report.
+     *
+     * @param  string $token
+     * @param  array  $body
+     * @return Response
+     */
+    public function ping($token, array $body)
+    {
+        return $this->send(self::PATH_PING, $body, $token);
+    }
+
+    /**
+     * Pull pending notifications. Only called when the ping reported a count.
+     *
+     * @param  string $token
+     * @return Response
+     */
+    public function pullNotifications($token)
+    {
+        return $this->send(self::PATH_NOTIFICATIONS, [], $token);
+    }
+
+    /**
+     * Perform the request and classify the outcome.
+     *
+     * A transport failure (DNS, timeout, reset) surfaces from the curl client
+     * as an exception; it is classified as FAILED so the caller leaves the
+     * token untouched and simply tries again next hour.
+     *
+     * @param  string      $path
+     * @param  array       $body
+     * @param  string|null $token
+     * @return Response
+     */
+    private function send($path, array $body, $token = null)
+    {
+        $headers = ['Content-Type' => 'application/json'];
+        if ($token !== null && $token !== '') {
+            $headers['Authorization'] = 'Bearer ' . $token;
+        }
+
+        $curl = $this->curlFactory->create();
+        $curl->setOption(CURLOPT_RETURNTRANSFER, true);
+        $curl->setTimeout(self::TIMEOUT);
+        $curl->setHeaders($headers);
+
+        try {
+            $curl->post(self::BASE_URL . $path, json_encode($body));
+        } catch (\Exception $e) {
+            $this->helper->log('Edge beacon transport failure on ' . $path . ': ' . $e->getMessage());
+            return new Response(Response::FAILED);
+        }
+
+        $status = (int)$curl->getStatus();
+
+        if ($status === 401) {
+            return new Response(Response::UNAUTHORIZED, $status);
+        }
+
+        if ($status === 429) {
+            $retryAfter = $this->readRetryAfter($curl->getHeaders());
+            $this->helper->log('Edge beacon rate limited on ' . $path . ', Retry-After: ' . ($retryAfter ?? 'absent'));
+            return new Response(Response::RATE_LIMITED, $status, [], $retryAfter);
+        }
+
+        if ($status < 200 || $status > 299) {
+            $this->helper->log('Edge beacon got HTTP ' . $status . ' on ' . $path);
+            return new Response(Response::FAILED, $status);
+        }
+
+        $data = json_decode((string)$curl->getBody(), true);
+        if (!is_array($data)) {
+            $this->helper->log('Edge beacon got a malformed body on ' . $path);
+            return new Response(Response::FAILED, $status);
+        }
+
+        return new Response(Response::OK, $status, $data);
+    }
+
+    /**
+     * Read Retry-After regardless of the casing the service used.
+     *
+     * @param  array $headers
+     * @return int|null
+     */
+    private function readRetryAfter(array $headers)
+    {
+        foreach ($headers as $name => $value) {
+            if (strtolower($name) === 'retry-after') {
+                return (int)$value;
+            }
+        }
+
+        return null;
+    }
+}

--- a/Model/Edge/LivenessSignals.php
+++ b/Model/Edge/LivenessSignals.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Ebizmarts_MailChimp Magento Component
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Model\Edge;
+
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Magento\Framework\App\ResourceConnection;
+
+/**
+ * Local metadata that tells the service whether a store view is alive and whether
+ * it is failing. Two questions, two indexed reads.
+ *
+ * SHOPPER DATA NEVER LEAVES THE STORE, BY CONSTRUCTION.
+ * `mailchimp_errors.errors` holds the raw Mailchimp error body and
+ * `mailchimp_notification.notification_data` holds request params and
+ * responses; both can carry customer details. Neither is selected here. Only
+ * the surrounding facts travel: when, and what kind.
+ */
+class LivenessSignals
+{
+    /**
+     * @var ResourceConnection
+     */
+    private $resource;
+
+    /**
+     * @var MailChimpHelper
+     */
+    private $helper;
+
+    /**
+     * @param ResourceConnection $resource
+     * @param MailChimpHelper    $helper
+     */
+    public function __construct(
+        ResourceConnection $resource,
+        MailChimpHelper $helper
+    ) {
+        $this->resource = $resource;
+        $this->helper   = $helper;
+    }
+
+    /**
+     * Build the signal block for one store view.
+     *
+     * Null handling is deliberate and asymmetric, because the service treats an
+     * explicit null as "delete this field" and an absent key as "keep what you
+     * have":
+     *
+     *  - the error fields are ALWAYS present, null when there is no error row,
+     *    so a recovered store actively clears its old failure on the service;
+     *  - last_sync_at is OMITTED when it cannot be read, so a transient local
+     *    problem never erases a good value the service already holds.
+     *
+     * @param  int $storeId
+     * @return array
+     */
+    public function forStore($storeId)
+    {
+        $signals = [];
+
+        $lastSync = $this->getLastSyncDelta($storeId);
+        if ($lastSync !== null) {
+            $signals['last_sync_at'] = $lastSync;
+        }
+
+        $error = $this->getLastError($storeId);
+        $signals['last_error_type']   = $error === null ? null : $error['type'];
+        $signals['last_error_status'] = $error === null ? null : $error['status'];
+        $signals['last_error_at']     = $error === null ? null : $error['added_at'];
+
+        return $signals;
+    }
+
+    /**
+     * Newest sync delta for the store view's Mailchimp store.
+     *
+     * `mailchimp_sync_delta` is indexed, so MAX() is a single seek. The table
+     * is scoped by mailchimp_store_id, NOT store_id, so the store view's
+     * configured Mailchimp store is what selects the rows.
+     *
+     * @param  int $storeId
+     * @return string|null
+     */
+    private function getLastSyncDelta($storeId)
+    {
+        $mailchimpStoreId = $this->helper->getConfigValue(
+            MailChimpHelper::XML_MAILCHIMP_STORE,
+            $storeId
+        );
+
+        if (!$mailchimpStoreId) {
+            return null;
+        }
+
+        try {
+            $connection = $this->resource->getConnection();
+            $select     = $connection->select()
+                ->from($this->resource->getTableName('mailchimp_sync_ecommerce'), ['MAX(mailchimp_sync_delta)'])
+                ->where('mailchimp_store_id = ?', $mailchimpStoreId);
+
+            $value = $connection->fetchOne($select);
+        } catch (\Exception $e) {
+            $this->helper->log('Edge beacon could not read the sync delta: ' . $e->getMessage());
+            return null;
+        }
+
+        return $value ?: null;
+    }
+
+    /**
+     * Newest error row for the store view.
+     *
+     * Selects only type, status and added_at. The `errors` column is never
+     * read. `mailchimp_errors` carries a composite index leading on store_id
+     * and holds few rows, so this stays cheap.
+     *
+     * @param  int $storeId
+     * @return array|null
+     */
+    private function getLastError($storeId)
+    {
+        try {
+            $connection = $this->resource->getConnection();
+            $select     = $connection->select()
+                ->from($this->resource->getTableName('mailchimp_errors'), ['type', 'status', 'added_at'])
+                ->where('store_id = ?', $storeId)
+                ->order('id DESC')
+                ->limit(1);
+
+            $row = $connection->fetchRow($select);
+        } catch (\Exception $e) {
+            $this->helper->log('Edge beacon could not read the last error: ' . $e->getMessage());
+            return null;
+        }
+
+        if (!is_array($row) || empty($row)) {
+            return null;
+        }
+
+        return [
+            'type'     => $row['type'] !== null ? (string)$row['type'] : null,
+            'status'   => $row['status'] !== null ? (string)$row['status'] : null,
+            'added_at' => $row['added_at'] !== null ? (string)$row['added_at'] : null,
+        ];
+    }
+}

--- a/Model/Edge/NotificationDelivery.php
+++ b/Model/Edge/NotificationDelivery.php
@@ -76,9 +76,10 @@ class NotificationDelivery
      * @param  int    $storeId
      * @param  string $token
      * @param  array  $pingData
+     * @param  array  $stillPending uids the caller has NOT just acknowledged
      * @return void
      */
-    public function handle($storeId, $token, array $pingData)
+    public function handle($storeId, $token, array $pingData, array $stillPending = [])
     {
         if ($this->pendingCount($pingData) < 1) {
             return;
@@ -102,12 +103,19 @@ class NotificationDelivery
             }
 
             try {
-                $this->deliver($item);
+                $written = $this->deliver($item);
             } catch (\Exception $e) {
                 // A message we could not write must not be confirmed, so stop
                 // here and let the unconfirmed uid tell the service the truth.
                 $this->helper->log('Edge notification could not be delivered: ' . $e->getMessage());
                 break;
+            }
+
+            // Only what actually reached the inbox may be acknowledged. A
+            // message with no subject is never written, and confirming it
+            // would tell the service it was seen when nobody saw it.
+            if (!$written) {
+                continue;
             }
 
             // `id` IS the opaque delivery_uid on the wire.
@@ -117,7 +125,7 @@ class NotificationDelivery
         }
 
         if (!empty($delivered)) {
-            $this->rememberForAck($storeId, $delivered);
+            $this->rememberForAck($storeId, $delivered, $stillPending);
         }
     }
 
@@ -131,16 +139,23 @@ class NotificationDelivery
      * Written only when a notification actually landed in the inbox, which is
      * rare, so the config cache flush this causes is rare too.
      *
+     * What is still pending arrives as an argument rather than being read back
+     * from configuration. The caller clears that value just before calling in,
+     * and a read here would not reliably see the clear: within one process the
+     * config a scope has already loaded is only refreshed as a side effect of
+     * the cache-warming path, which is skipped entirely when the config cache
+     * type is disabled. Reading it back there returns the pre-clear list, and
+     * the uids just acknowledged would be merged in and sent again on every
+     * tick. Taking it as an argument makes the behaviour the same either way.
+     *
      * @param  int   $storeId
      * @param  array $delivered
+     * @param  array $stillPending uids the caller has not just acknowledged
      * @return void
      */
-    private function rememberForAck($storeId, array $delivered)
+    private function rememberForAck($storeId, array $delivered, array $stillPending = [])
     {
-        $pending = $this->helper->getConfigValue(MailChimpHelper::XML_EDGE_DELIVERY_UID, $storeId);
-        $pending = $pending === null || $pending === '' ? [] : explode(',', (string)$pending);
-
-        $merged = array_values(array_unique(array_merge($pending, $delivered)));
+        $merged = array_values(array_unique(array_merge($stillPending, $delivered)));
         if (count($merged) > self::MAX_PENDING_ACKS) {
             $merged = array_slice($merged, -self::MAX_PENDING_ACKS);
         }
@@ -192,7 +207,7 @@ class NotificationDelivery
      * Hand one notification to Magento, mapped from the service's priority.
      *
      * @param  array $item
-     * @return void
+     * @return bool  whether it was written to the inbox
      */
     private function deliver(array $item)
     {
@@ -202,7 +217,7 @@ class NotificationDelivery
         $url         = isset($item['url']) ? (string)$item['url'] : '';
 
         if ($title === '') {
-            return;
+            return false;
         }
 
         $priority = isset($item['priority']) ? strtolower((string)$item['priority']) : '';
@@ -218,5 +233,7 @@ class NotificationDelivery
                 $this->notifier->addNotice($title, $description, $url);
                 break;
         }
+
+        return true;
     }
 }

--- a/Model/Edge/NotificationDelivery.php
+++ b/Model/Edge/NotificationDelivery.php
@@ -1,0 +1,222 @@
+<?php
+/**
+ * Ebizmarts_MailChimp Magento Component
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Model\Edge;
+
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Magento\Framework\Notification\NotifierInterface;
+use Magento\Store\Model\ScopeInterface;
+
+/**
+ * Writes edge notifications into Magento's own admin inbox.
+ *
+ * No new table, no UI component, no template: persistence, read state and
+ * dismissal are Magento's, and the merchant sees the message in the admin bell
+ * where they already look.
+ *
+ * Injecting NotifierInterface is safe even when Magento_AdminNotification is
+ * disabled. The preference lives in app/etc/di.xml and points at the
+ * framework's NotifierPool, which simply iterates a list of notifiers; with the
+ * module off the list is empty and every call is a no-op rather than a fatal.
+ */
+class NotificationDelivery
+{
+    /**
+     * Ceiling on the pending-ack list. Notifications are rare, so this only
+     * ever bites on a store that delivered and then could not ping for a long
+     * time; keeping the newest is the useful half.
+     */
+    const MAX_PENDING_ACKS = 50;
+
+
+    /**
+     * @var Client
+     */
+    private $client;
+
+    /**
+     * @var MailChimpHelper
+     */
+    private $helper;
+
+    /**
+     * @var NotifierInterface
+     */
+    private $notifier;
+
+    /**
+     * @param Client            $client
+     * @param MailChimpHelper   $helper
+     * @param NotifierInterface $notifier
+     */
+    public function __construct(
+        Client $client,
+        MailChimpHelper $helper,
+        NotifierInterface $notifier
+    ) {
+        $this->client   = $client;
+        $this->helper   = $helper;
+        $this->notifier = $notifier;
+    }
+
+    /**
+     * Act on the ping reply.
+     *
+     * The reply carries a count, not content. Zero, which is nearly every
+     * hour, costs nothing.
+     *
+     * @param  int    $storeId
+     * @param  string $token
+     * @param  array  $pingData
+     * @return void
+     */
+    public function handle($storeId, $token, array $pingData)
+    {
+        if ($this->pendingCount($pingData) < 1) {
+            return;
+        }
+
+        $response = $this->client->pullNotifications($token);
+        if (!$response->isOk()) {
+            return;
+        }
+
+        $items = $this->extractItems($response->getData());
+        if (empty($items)) {
+            return;
+        }
+
+        $delivered = [];
+
+        foreach ($items as $item) {
+            if (!is_array($item)) {
+                continue;
+            }
+
+            try {
+                $this->deliver($item);
+            } catch (\Exception $e) {
+                // A message we could not write must not be confirmed, so stop
+                // here and let the unconfirmed uid tell the service the truth.
+                $this->helper->log('Edge notification could not be delivered: ' . $e->getMessage());
+                break;
+            }
+
+            // `id` IS the opaque delivery_uid on the wire.
+            if (isset($item['id']) && $item['id'] !== '') {
+                $delivered[] = (string)$item['id'];
+            }
+        }
+
+        if (!empty($delivered)) {
+            $this->rememberForAck($storeId, $delivered);
+        }
+    }
+
+    /**
+     * Queue delivered uids for the next ping's `received[]`.
+     *
+     * Appends rather than overwrites: a previous batch may still be waiting to
+     * be acknowledged, and dropping it would report those messages as
+     * unconfirmed forever.
+     *
+     * Written only when a notification actually landed in the inbox, which is
+     * rare, so the config cache flush this causes is rare too.
+     *
+     * @param  int   $storeId
+     * @param  array $delivered
+     * @return void
+     */
+    private function rememberForAck($storeId, array $delivered)
+    {
+        $pending = $this->helper->getConfigValue(MailChimpHelper::XML_EDGE_DELIVERY_UID, $storeId);
+        $pending = $pending === null || $pending === '' ? [] : explode(',', (string)$pending);
+
+        $merged = array_values(array_unique(array_merge($pending, $delivered)));
+        if (count($merged) > self::MAX_PENDING_ACKS) {
+            $merged = array_slice($merged, -self::MAX_PENDING_ACKS);
+        }
+
+        $this->helper->saveConfigValue(
+            MailChimpHelper::XML_EDGE_DELIVERY_UID,
+            implode(',', $merged),
+            $storeId,
+            ScopeInterface::SCOPE_STORES
+        );
+    }
+
+    /**
+     * How many notifications the service says are waiting.
+     *
+     * @param  array $pingData
+     * @return int
+     */
+    private function pendingCount(array $pingData)
+    {
+        // The ping reply carries the count as a bare number under
+        // `notifications`: json({ ok: true, notifications: row.pending_notif ?? 0 }).
+        // Note the pull uses the SAME key for the ARRAY of messages, so the
+        // type check is what keeps the two apart.
+        if (isset($pingData['notifications']) && is_numeric($pingData['notifications'])) {
+            return (int)$pingData['notifications'];
+        }
+
+        return 0;
+    }
+
+    /**
+     * The notification list out of the pull response.
+     *
+     * @param  array $data
+     * @return array
+     */
+    private function extractItems(array $data)
+    {
+        // The pull returns { notifications: [{ id, subject, message, created_at, priority }] }.
+        if (isset($data['notifications']) && is_array($data['notifications'])) {
+            return $data['notifications'];
+        }
+
+        return [];
+    }
+
+    /**
+     * Hand one notification to Magento, mapped from the service's priority.
+     *
+     * @param  array $item
+     * @return void
+     */
+    private function deliver(array $item)
+    {
+        // Wire shape is subject/message, not title/body.
+        $title       = isset($item['subject']) ? (string)$item['subject'] : '';
+        $description = isset($item['message']) ? (string)$item['message'] : '';
+        $url         = isset($item['url']) ? (string)$item['url'] : '';
+
+        if ($title === '') {
+            return;
+        }
+
+        $priority = isset($item['priority']) ? strtolower((string)$item['priority']) : '';
+
+        switch ($priority) {
+            case 'critical':
+                $this->notifier->addCritical($title, $description, $url);
+                break;
+            case 'major':
+                $this->notifier->addMajor($title, $description, $url);
+                break;
+            default:
+                $this->notifier->addNotice($title, $description, $url);
+                break;
+        }
+    }
+}

--- a/Model/Edge/NotificationDelivery.php
+++ b/Model/Edge/NotificationDelivery.php
@@ -53,6 +53,11 @@ class NotificationDelivery
     private $notifier;
 
     /**
+     * @var array uids already written to the inbox by this process
+     */
+    private $written = [];
+
+    /**
      * @param Client            $client
      * @param MailChimpHelper   $helper
      * @param NotifierInterface $notifier
@@ -102,8 +107,10 @@ class NotificationDelivery
                 continue;
             }
 
+            $uid = isset($item['id']) ? (string)$item['id'] : '';
+
             try {
-                $written = $this->deliver($item);
+                $written = $this->deliverOnce($uid, $item);
             } catch (\Exception $e) {
                 // A message we could not write must not be confirmed, so stop
                 // here and let the unconfirmed uid tell the service the truth.
@@ -114,13 +121,18 @@ class NotificationDelivery
             // Only what actually reached the inbox may be acknowledged. A
             // message with no subject is never written, and confirming it
             // would tell the service it was seen when nobody saw it.
+            //
+            // A message suppressed as a duplicate IS acknowledged, and must be:
+            // it did reach the inbox, once. The service tracks delivery per
+            // store view, so every view has to confirm its own copy or it will
+            // keep offering the same message forever.
             if (!$written) {
                 continue;
             }
 
             // `id` IS the opaque delivery_uid on the wire.
-            if (isset($item['id']) && $item['id'] !== '') {
-                $delivered[] = (string)$item['id'];
+            if ($uid !== '') {
+                $delivered[] = $uid;
             }
         }
 
@@ -201,6 +213,50 @@ class NotificationDelivery
         }
 
         return [];
+    }
+
+    /**
+     * Write a notification to the inbox unless this process already has.
+     *
+     * The service addresses store views, not installations — every target but
+     * a single-view one fans out, so one message arrives once per registered
+     * view of the same install. Magento's inbox is install-wide and has no
+     * scope column, so writing each arrival would put the same message in the
+     * merchant's bell N times.
+     *
+     * Deduplication is per process, which covers the normal case exactly: one
+     * cron run walks every store view. It does not cover views handled by
+     * separate processes.
+     *
+     * Checking the inbox itself instead would cover that, but it cannot be done
+     * through NotifierInterface. Inbox::add() always sets an `internal` key, and
+     * Inbox::parse() skips its duplicate lookup whenever that key is set — so
+     * the notifier never deduplicates. Passing null to reach the other branch
+     * hits `Unknown column 'internal'`, because parse() only unsets the key on
+     * the branch it did not take. Querying the table directly would work, but
+     * would cost the property that made NotifierInterface the right choice
+     * here: it degrades to doing nothing when Magento_AdminNotification is
+     * disabled, rather than fataling.
+     *
+     * @param  string $uid  delivery uid, stable across the views of one message
+     * @param  array  $item
+     * @return bool   whether the merchant now has this message
+     */
+    private function deliverOnce($uid, array $item)
+    {
+        if ($uid !== '' && isset($this->written[$uid])) {
+            return true;
+        }
+
+        if (!$this->deliver($item)) {
+            return false;
+        }
+
+        if ($uid !== '') {
+            $this->written[$uid] = true;
+        }
+
+        return true;
     }
 
     /**

--- a/Model/Edge/Response.php
+++ b/Model/Edge/Response.php
@@ -15,9 +15,12 @@ namespace Ebizmarts\MailChimp\Model\Edge;
  * Outcome of a single call to the reporting service.
  *
  * The outcome is deliberately coarser than the HTTP status, because only three
- * distinctions change what the caller does: the token is dead (401), we were
- * asked to back off (429), or something else went wrong and the token must be
- * left exactly as it is.
+ * distinctions change what the caller does: the token is dead (401), the
+ * service is refusing for now (429), or something else went wrong and the
+ * token must be left exactly as it is.
+ *
+ * The last two lead to the same action — leave everything alone and stop — so
+ * they are separate only because they mean different things in the log.
  */
 class Response
 {
@@ -81,7 +84,7 @@ class Response
     }
 
     /**
-     * Whether the service asked us to back off.
+     * Whether the service refused this attempt for the time being.
      *
      * @return bool
      */
@@ -112,6 +115,13 @@ class Response
 
     /**
      * Retry-After in seconds when the service sent one.
+     *
+     * Recorded and logged, not obeyed. Nothing schedules against it: the next
+     * attempt is the next hourly tick whatever the header said. That is longer
+     * than any back-off worth honouring in the common case, so waiting on it
+     * would only ever mean waiting longer than an hour — and a value asking
+     * for that is currently ignored. Kept here rather than only in the log so
+     * the caller has it if that ever needs to change.
      *
      * @return int|null
      */

--- a/Model/Edge/Response.php
+++ b/Model/Edge/Response.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Ebizmarts_MailChimp Magento Component
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Model\Edge;
+
+/**
+ * Outcome of a single call to the reporting service.
+ *
+ * The outcome is deliberately coarser than the HTTP status, because only three
+ * distinctions change what the caller does: the token is dead (401), we were
+ * asked to back off (429), or something else went wrong and the token must be
+ * left exactly as it is.
+ */
+class Response
+{
+    const OK           = 'ok';
+    const UNAUTHORIZED = 'unauthorized';
+    const RATE_LIMITED = 'rate_limited';
+    const FAILED       = 'failed';
+
+    /**
+     * @var string
+     */
+    private $outcome;
+
+    /**
+     * @var int
+     */
+    private $status;
+
+    /**
+     * @var array
+     */
+    private $data;
+
+    /**
+     * @var int|null
+     */
+    private $retryAfter;
+
+    /**
+     * @param string   $outcome
+     * @param int      $status
+     * @param array    $data
+     * @param int|null $retryAfter
+     */
+    public function __construct($outcome, $status = 0, array $data = [], $retryAfter = null)
+    {
+        $this->outcome    = $outcome;
+        $this->status     = (int)$status;
+        $this->data       = $data;
+        $this->retryAfter = $retryAfter;
+    }
+
+    /**
+     * Whether the call succeeded.
+     *
+     * @return bool
+     */
+    public function isOk()
+    {
+        return $this->outcome === self::OK;
+    }
+
+    /**
+     * Whether the stored token must be discarded.
+     *
+     * @return bool
+     */
+    public function isUnauthorized()
+    {
+        return $this->outcome === self::UNAUTHORIZED;
+    }
+
+    /**
+     * Whether the service asked us to back off.
+     *
+     * @return bool
+     */
+    public function isRateLimited()
+    {
+        return $this->outcome === self::RATE_LIMITED;
+    }
+
+    /**
+     * Decoded response body.
+     *
+     * @return array
+     */
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    /**
+     * HTTP status, 0 when the request never completed.
+     *
+     * @return int
+     */
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    /**
+     * Retry-After in seconds when the service sent one.
+     *
+     * @return int|null
+     */
+    public function getRetryAfter()
+    {
+        return $this->retryAfter;
+    }
+}

--- a/Test/Unit/Model/Edge/BeaconTest.php
+++ b/Test/Unit/Model/Edge/BeaconTest.php
@@ -1,0 +1,356 @@
+<?php
+/**
+ * Ebizmarts_MailChimp
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Test\Unit\Model\Edge;
+
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Ebizmarts\MailChimp\Model\Edge\Beacon;
+use Ebizmarts\MailChimp\Model\Edge\Client;
+use Ebizmarts\MailChimp\Model\Edge\LivenessSignals;
+use Ebizmarts\MailChimp\Model\Edge\NotificationDelivery;
+use Ebizmarts\MailChimp\Model\Edge\Response;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\ProductMetadataInterface;
+use Magento\Store\Model\Store;
+use Magento\Store\Model\StoreManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+class BeaconTest extends TestCase
+{
+    const STORE_ID  = 1;
+    const STORE_URL = 'https://shop.example.com/';
+
+    /**
+     * @var MailChimpHelper|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $helper;
+
+    /**
+     * @var Client|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $client;
+
+    /**
+     * @var ScopeConfigInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $scopeConfig;
+
+    /**
+     * Builds a beacon over one active store view.
+     *
+     * @param  string $token        stored edge token, '' when unregistered
+     * @param  bool   $accountFails whether GET / against Mailchimp blows up
+     * @param  int    $hour         GMT hour the tick runs at
+     * @return Beacon
+     */
+    private function makeBeacon($token, $accountFails = false, $hour = 0, $pendingAcks = '')
+    {
+        $store = $this->createMock(Store::class);
+        $store->method('getId')->willReturn(self::STORE_ID);
+        $store->method('getBaseUrl')->willReturn(self::STORE_URL);
+
+        $storeManager = $this->createMock(StoreManagerInterface::class);
+        $storeManager->method('getStores')->willReturn([$store]);
+
+        $this->helper = $this->createMock(MailChimpHelper::class);
+        $this->helper->method('isMailChimpEnabled')->willReturn(true);
+        $this->helper->method('getApiKey')->willReturn('key-123');
+        $this->helper->method('getModuleVersion')->willReturn('103.4.81');
+        $this->helper->method('getGmtDate')->willReturn((string)$hour);
+        $this->helper->method('getConfigValue')->willReturnCallback(
+            function ($path) use ($token, $pendingAcks) {
+                if (strpos($path, 'edge_token') !== false) {
+                    return $token;
+                }
+                if (strpos($path, 'last_delivery_uid') !== false) {
+                    return $pendingAcks;
+                }
+                return '';
+            }
+        );
+
+        if ($accountFails) {
+            $this->helper->method('getApi')->willThrowException(new \Exception('Mailchimp is down'));
+        } else {
+            $root = $this->getMockBuilder(\Mailchimp_Root::class)
+                ->disableOriginalConstructor()
+                ->onlyMethods(['info'])
+                ->getMock();
+            $root->method('info')->willReturn(['account_id' => 'acc-1', 'account_name' => 'Shop']);
+
+            $api = $this->getMockBuilder(\Mailchimp::class)->disableOriginalConstructor()->getMock();
+            $api->root = $root;
+
+            $this->helper->method('getApi')->willReturn($api);
+        }
+
+        $this->client      = $this->createMock(Client::class);
+        $this->scopeConfig = $this->createMock(ScopeConfigInterface::class);
+
+        $signals = $this->createMock(LivenessSignals::class);
+        $signals->method('forStore')->willReturn(['last_error_type' => null]);
+
+        $metadata = $this->createMock(ProductMetadataInterface::class);
+        $metadata->method('getVersion')->willReturn('2.4.8');
+        $metadata->method('getEdition')->willReturn('Community');
+
+        return new Beacon(
+            $storeManager,
+            $this->helper,
+            $this->client,
+            $signals,
+            $this->createMock(NotificationDelivery::class),
+            $metadata,
+            $this->scopeConfig
+        );
+    }
+
+    public function testUnregisteredStoreRegistersThenPings(): void
+    {
+        $beacon = $this->makeBeacon('');
+
+        $this->client->expects($this->once())
+            ->method('register')
+            ->willReturn(new Response(Response::OK, 201, ['token' => 'ebz_new']));
+        $this->client->expects($this->once())
+            ->method('ping')
+            ->with('ebz_new', $this->anything())
+            ->willReturn(new Response(Response::OK, 200, ['ok' => true, 'notifications' => 0]));
+
+        $beacon->execute();
+    }
+
+    public function testAFailedRegisterWritesNothing(): void
+    {
+        $beacon = $this->makeBeacon('');
+
+        $this->client->method('register')->willReturn(new Response(Response::FAILED, 503));
+        $this->client->expects($this->never())->method('ping');
+        $this->helper->expects($this->never())->method('saveConfigValue');
+
+        $beacon->execute();
+    }
+
+    public function testUnauthorizedClearsTheToken(): void
+    {
+        $beacon = $this->makeBeacon('ebz_dead');
+
+        $this->client->method('ping')->willReturn(new Response(Response::UNAUTHORIZED, 401));
+
+        $this->helper->expects($this->once())
+            ->method('saveConfigValue')
+            ->with($this->stringContains('edge_token'), '', self::STORE_ID, $this->anything());
+
+        $beacon->execute();
+    }
+
+    /**
+     * If a 429 cleared the token, one throttled hour would make every installation
+     * re-register all at once.
+     */
+    public function testRateLimitedLeavesTheTokenAlone(): void
+    {
+        $beacon = $this->makeBeacon('ebz_live');
+
+        $this->client->method('ping')->willReturn(new Response(Response::RATE_LIMITED, 429, [], 60));
+        $this->helper->expects($this->never())->method('saveConfigValue');
+
+        $beacon->execute();
+    }
+
+    public function testServerErrorLeavesTheTokenAlone(): void
+    {
+        $beacon = $this->makeBeacon('ebz_live');
+
+        $this->client->method('ping')->willReturn(new Response(Response::FAILED, 500));
+        $this->helper->expects($this->never())->method('saveConfigValue');
+
+        $beacon->execute();
+    }
+
+    /**
+     * The status report is the point and the account data rides along: a Mailchimp
+     * outage must not make every installation look dead at once.
+     */
+    public function testAFailingAccountCallDoesNotSuppressThePing(): void
+    {
+        // Hour chosen so this tick IS one of the store's two account slots.
+        $slot   = crc32(self::STORE_ID . self::STORE_URL) % Beacon::ACCOUNT_BLOCK_PERIOD_HOURS;
+        $beacon = $this->makeBeacon('ebz_live', true, $slot);
+
+        $this->client->expects($this->once())
+            ->method('ping')
+            ->with(
+                'ebz_live',
+                $this->callback(function ($body) {
+                    return !array_key_exists('account', $body);
+                })
+            )
+            ->willReturn(new Response(Response::OK, 200, ['notifications' => 0]));
+
+        $beacon->execute();
+    }
+
+    public function testAccountBlockRidesTheStoresOwnSlot(): void
+    {
+        $slot   = crc32(self::STORE_ID . self::STORE_URL) % Beacon::ACCOUNT_BLOCK_PERIOD_HOURS;
+        $beacon = $this->makeBeacon('ebz_live', false, $slot);
+
+        $this->client->expects($this->once())
+            ->method('ping')
+            ->with(
+                'ebz_live',
+                $this->callback(function ($body) {
+                    return isset($body['account']['account_id']) && $body['account']['account_id'] === 'acc-1';
+                })
+            )
+            ->willReturn(new Response(Response::OK, 200, ['notifications' => 0]));
+
+        $beacon->execute();
+    }
+
+    public function testNoAccountBlockOutsideTheSlot(): void
+    {
+        $slot   = crc32(self::STORE_ID . self::STORE_URL) % Beacon::ACCOUNT_BLOCK_PERIOD_HOURS;
+        $beacon = $this->makeBeacon('ebz_live', false, ($slot + 1) % Beacon::ACCOUNT_BLOCK_PERIOD_HOURS);
+
+        $this->client->expects($this->once())
+            ->method('ping')
+            ->with(
+                'ebz_live',
+                $this->callback(function ($body) {
+                    return !array_key_exists('account', $body);
+                })
+            )
+            ->willReturn(new Response(Response::OK, 200, ['notifications' => 0]));
+
+        $beacon->execute();
+    }
+
+    public function testStoreWithoutApiKeyIsSkipped(): void
+    {
+        $store = $this->createMock(Store::class);
+        $store->method('getId')->willReturn(self::STORE_ID);
+        $store->method('getBaseUrl')->willReturn(self::STORE_URL);
+
+        $storeManager = $this->createMock(StoreManagerInterface::class);
+        $storeManager->method('getStores')->willReturn([$store]);
+
+        $helper = $this->createMock(MailChimpHelper::class);
+        $helper->method('isMailChimpEnabled')->willReturn(true);
+        $helper->method('getApiKey')->willReturn('');
+
+        $client = $this->createMock(Client::class);
+        $client->expects($this->never())->method('register');
+        $client->expects($this->never())->method('ping');
+
+        $metadata = $this->createMock(ProductMetadataInterface::class);
+
+        (new Beacon(
+            $storeManager,
+            $helper,
+            $client,
+            $this->createMock(LivenessSignals::class),
+            $this->createMock(NotificationDelivery::class),
+            $metadata,
+            $this->createMock(ScopeConfigInterface::class)
+        ))->execute();
+    }
+
+    public function testQueuedAcksRideTheNextPing(): void
+    {
+        $beacon = $this->makeBeacon('ebz_live', false, 0, 'uid-1,uid-2');
+
+        $this->client->expects($this->once())
+            ->method('ping')
+            ->with(
+                'ebz_live',
+                $this->callback(function ($body) {
+                    return isset($body['received'])
+                        && $body['received'] === ['uid-1', 'uid-2']
+                        && !array_key_exists('read', $body);
+                })
+            )
+            ->willReturn(new Response(Response::OK, 200, ['notifications' => 0]));
+
+        $beacon->execute();
+    }
+
+    public function testAcksAreClearedOnceTheEdgeHasSeenThem(): void
+    {
+        $beacon = $this->makeBeacon('ebz_live', false, 0, 'uid-1');
+
+        $this->client->method('ping')->willReturn(new Response(Response::OK, 200, ['notifications' => 0]));
+
+        $this->helper->expects($this->once())
+            ->method('saveConfigValue')
+            ->with($this->stringContains('last_delivery_uid'), '', self::STORE_ID, $this->anything());
+
+        $beacon->execute();
+    }
+
+    /**
+     * A ping that never landed has confirmed nothing, so the queue must survive.
+     */
+    public function testAFailedPingKeepsTheAcksQueued(): void
+    {
+        $beacon = $this->makeBeacon('ebz_live', false, 0, 'uid-1');
+
+        $this->client->method('ping')->willReturn(new Response(Response::FAILED, 500));
+        $this->helper->expects($this->never())->method('saveConfigValue');
+
+        $beacon->execute();
+    }
+
+    /**
+     * Regression guard for a silent data loss: the service projects the beacon body
+     * onto a CLOSED whitelist and drops anything outside it. Sending
+     * `extension_version` instead of `module_version` cost nothing visible — the
+     * ping still returned 200 — while the service's module_version column was never
+     * written for this store.
+     */
+    public function testVersionsUseTheKeyNamesTheEdgeAccepts(): void
+    {
+        $beacon = $this->makeBeacon('ebz_live');
+
+        $this->client->expects($this->once())
+            ->method('ping')
+            ->with(
+                'ebz_live',
+                $this->callback(function ($body) {
+                    return ($body['module_version'] ?? null) === '103.4.81'
+                        && ($body['magento_version'] ?? null) === '2.4.8'
+                        && isset($body['php_version'])
+                        && !array_key_exists('extension_version', $body)
+                        && !array_key_exists('magento_edition', $body);
+                })
+            )
+            ->willReturn(new Response(Response::OK, 200, ['notifications' => 0]));
+
+        $beacon->execute();
+    }
+
+    public function testRegisterCarriesTheSameVersionKeys(): void
+    {
+        $beacon = $this->makeBeacon('');
+
+        $this->client->expects($this->once())
+            ->method('register')
+            ->with($this->callback(function ($body) {
+                return ($body['module_version'] ?? null) === '103.4.81'
+                    && !array_key_exists('extension_version', $body);
+            }))
+            ->willReturn(new Response(Response::OK, 201, ['token' => 'ebz_new']));
+        $this->client->method('ping')->willReturn(new Response(Response::OK, 200, ['notifications' => 0]));
+
+        $beacon->execute();
+    }
+}

--- a/Test/Unit/Model/Edge/BeaconTest.php
+++ b/Test/Unit/Model/Edge/BeaconTest.php
@@ -19,6 +19,7 @@ use Ebizmarts\MailChimp\Model\Edge\NotificationDelivery;
 use Ebizmarts\MailChimp\Model\Edge\Response;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\ProductMetadataInterface;
+use Magento\Framework\Notification\NotifierInterface;
 use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreManagerInterface;
 use PHPUnit\Framework\TestCase;
@@ -384,4 +385,166 @@ class BeaconTest extends TestCase
         $this->assertNotNull($written, 'the first successful register must claim a slot');
         $this->assertMatchesRegularExpression('/^([0-9]|[1-5][0-9]) \* \* \* \*$/', $written);
     }
+
+    /**
+     * The ack queue must actually empty.
+     *
+     * Driven through a REAL NotificationDelivery, because the seam being tested
+     * is the one between the two objects: ping() clears the pending uids and
+     * then calls in, and delivery must not resurrect them. The helper double
+     * models configuration the way Magento behaves within a single process —
+     * writes land, but reads keep returning the value the scope was loaded
+     * with. Mocking NotificationDelivery would skip the seam entirely, which is
+     * how this went unnoticed.
+     */
+    public function testAcknowledgedUidsAreNotResurrectedByANewDelivery(): void
+    {
+        $stored = [
+            'mailchimp/register/edge_token'        => 'ebz_tok',
+            'mailchimp/register/last_delivery_uid' => 'uid-0,uid-1',
+        ];
+        // What a scope already loaded keeps returning, whatever is written after.
+        $stale = $stored;
+        $saved = [];
+
+        $store = $this->createMock(Store::class);
+        $store->method('getId')->willReturn(self::STORE_ID);
+        $store->method('getBaseUrl')->willReturn(self::STORE_URL);
+        $storeManager = $this->createMock(StoreManagerInterface::class);
+        $storeManager->method('getStores')->willReturn([$store]);
+
+        $helper = $this->createMock(MailChimpHelper::class);
+        $helper->method('isMailChimpEnabled')->willReturn(true);
+        $helper->method('getApiKey')->willReturn('key-123');
+        $helper->method('getModuleVersion')->willReturn('103.4.81');
+        $helper->method('getGmtDate')->willReturn('0');
+        $helper->method('getConfigValue')->willReturnCallback(
+            function ($path) use (&$stale) {
+                foreach ($stale as $known => $value) {
+                    if (strpos($path, substr($known, strrpos($known, '/') + 1)) !== false) {
+                        return $value;
+                    }
+                }
+                return '';
+            }
+        );
+        $helper->method('saveConfigValue')->willReturnCallback(
+            function ($path, $value) use (&$saved) {
+                $saved[$path] = $value;
+            }
+        );
+
+        $client = $this->createMock(Client::class);
+        $client->method('ping')->willReturn(
+            new Response(Response::OK, 200, ['ok' => true, 'notifications' => 1])
+        );
+        $client->method('pullNotifications')->willReturn(
+            new Response(
+                Response::OK,
+                200,
+                ['notifications' => [[
+                    'id'       => 'uid-2',
+                    'subject'  => 'Scheduled maintenance',
+                    'message'  => 'Maintenance window this weekend.',
+                    'priority' => 'notice',
+                ]]]
+            )
+        );
+
+        $signals = $this->createMock(LivenessSignals::class);
+        $signals->method('forStore')->willReturn(['last_error_type' => null]);
+        $metadata = $this->createMock(ProductMetadataInterface::class);
+        $metadata->method('getVersion')->willReturn('2.4.8');
+        $metadata->method('getEdition')->willReturn('Community');
+
+        $beacon = new Beacon(
+            $storeManager,
+            $helper,
+            $client,
+            $signals,
+            new NotificationDelivery($client, $helper, $this->createMock(NotifierInterface::class)),
+            $metadata,
+            $this->createMock(ScopeConfigInterface::class)
+        );
+
+        $beacon->execute();
+
+        $this->assertSame(
+            'uid-2',
+            $saved['mailchimp/register/last_delivery_uid'],
+            'uids already acknowledged were merged back in and would be sent again forever'
+        );
+    }
+
+    /**
+     * The cron slot is one install-wide value, so a first tick across N store
+     * views must settle on one minute and write it once — not write N different
+     * minutes, each read having missed the one before it.
+     */
+    public function testTheCronSlotIsClaimedOncePerProcessAcrossStoreViews(): void
+    {
+        $stores = [];
+        foreach ([1, 2, 3] as $id) {
+            $store = $this->createMock(Store::class);
+            $store->method('getId')->willReturn($id);
+            $store->method('getBaseUrl')->willReturn('https://view' . $id . '.example.com/');
+            $stores[] = $store;
+        }
+        $storeManager = $this->createMock(StoreManagerInterface::class);
+        $storeManager->method('getStores')->willReturn($stores);
+
+        $slotWrites = [];
+
+        $helper = $this->createMock(MailChimpHelper::class);
+        $helper->method('isMailChimpEnabled')->willReturn(true);
+        $helper->method('getApiKey')->willReturn('key-123');
+        $helper->method('getModuleVersion')->willReturn('103.4.81');
+        $helper->method('getGmtDate')->willReturn('0');
+        $helper->method('getConfigValue')->willReturn('');
+        $helper->method('saveConfigValue')->willReturnCallback(
+            function ($path, $value) use (&$slotWrites) {
+                if (strpos($path, 'beacon_cron') !== false) {
+                    $slotWrites[] = $value;
+                }
+            }
+        );
+
+        $root = $this->getMockBuilder(\Mailchimp_Root::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['info'])
+            ->getMock();
+        $root->method('info')->willReturn(['account_id' => 'acc-1', 'account_name' => 'Shop']);
+        $api = $this->getMockBuilder(\Mailchimp::class)->disableOriginalConstructor()->getMock();
+        $api->root = $root;
+        $helper->method('getApi')->willReturn($api);
+
+        $client = $this->createMock(Client::class);
+        $client->method('register')->willReturn(new Response(Response::OK, 201, ['token' => 'ebz_new']));
+        $client->method('ping')->willReturn(new Response(Response::OK, 200, ['ok' => true, 'notifications' => 0]));
+
+        $signals = $this->createMock(LivenessSignals::class);
+        $signals->method('forStore')->willReturn(['last_error_type' => null]);
+        $metadata = $this->createMock(ProductMetadataInterface::class);
+        $metadata->method('getVersion')->willReturn('2.4.8');
+        $metadata->method('getEdition')->willReturn('Community');
+
+        // Every read returns empty, which is what a stale in-process config
+        // looks like on a first tick: without the guard each view would write.
+        $scopeConfig = $this->createMock(ScopeConfigInterface::class);
+        $scopeConfig->method('getValue')->willReturn('');
+
+        (new Beacon(
+            $storeManager,
+            $helper,
+            $client,
+            $signals,
+            $this->createMock(NotificationDelivery::class),
+            $metadata,
+            $scopeConfig
+        ))->execute();
+
+        $this->assertCount(1, $slotWrites, 'the cron slot was written once per store view instead of once');
+        $this->assertMatchesRegularExpression('/^([0-9]|[1-5][0-9]) \* \* \* \*$/', $slotWrites[0]);
+    }
+
 }

--- a/Test/Unit/Model/Edge/BeaconTest.php
+++ b/Test/Unit/Model/Edge/BeaconTest.php
@@ -135,7 +135,7 @@ class BeaconTest extends TestCase
 
         $this->client->method('register')->willReturn(new Response(Response::FAILED, 503));
         $this->client->expects($this->never())->method('ping');
-        $this->helper->expects($this->never())->method('saveConfigValue');
+        $this->helper->expects($this->never())->method('saveConfigValueWithoutCacheFlush');
 
         $beacon->execute();
     }
@@ -147,7 +147,7 @@ class BeaconTest extends TestCase
         $this->client->method('ping')->willReturn(new Response(Response::UNAUTHORIZED, 401));
 
         $this->helper->expects($this->once())
-            ->method('saveConfigValue')
+            ->method('saveConfigValueWithoutCacheFlush')
             ->with($this->stringContains('edge_token'), '', self::STORE_ID, $this->anything());
 
         $beacon->execute();
@@ -162,7 +162,7 @@ class BeaconTest extends TestCase
         $beacon = $this->makeBeacon('ebz_live');
 
         $this->client->method('ping')->willReturn(new Response(Response::RATE_LIMITED, 429, [], 60));
-        $this->helper->expects($this->never())->method('saveConfigValue');
+        $this->helper->expects($this->never())->method('saveConfigValueWithoutCacheFlush');
 
         $beacon->execute();
     }
@@ -172,7 +172,7 @@ class BeaconTest extends TestCase
         $beacon = $this->makeBeacon('ebz_live');
 
         $this->client->method('ping')->willReturn(new Response(Response::FAILED, 500));
-        $this->helper->expects($this->never())->method('saveConfigValue');
+        $this->helper->expects($this->never())->method('saveConfigValueWithoutCacheFlush');
 
         $beacon->execute();
     }
@@ -296,7 +296,7 @@ class BeaconTest extends TestCase
         $this->client->method('ping')->willReturn(new Response(Response::OK, 200, ['notifications' => 0]));
 
         $this->helper->expects($this->once())
-            ->method('saveConfigValue')
+            ->method('saveConfigValueWithoutCacheFlush')
             ->with($this->stringContains('last_delivery_uid'), '', self::STORE_ID, $this->anything());
 
         $beacon->execute();
@@ -310,7 +310,7 @@ class BeaconTest extends TestCase
         $beacon = $this->makeBeacon('ebz_live', false, 0, 'uid-1');
 
         $this->client->method('ping')->willReturn(new Response(Response::FAILED, 500));
-        $this->helper->expects($this->never())->method('saveConfigValue');
+        $this->helper->expects($this->never())->method('saveConfigValueWithoutCacheFlush');
 
         $beacon->execute();
     }
@@ -372,7 +372,7 @@ class BeaconTest extends TestCase
         $this->client->method('ping')->willReturn(new Response(Response::OK, 200, ['notifications' => 0]));
 
         $written = null;
-        $this->helper->method('saveConfigValue')->willReturnCallback(
+        $this->helper->method('saveConfigValueWithoutCacheFlush')->willReturnCallback(
             function ($path, $value) use (&$written) {
                 if (strpos($path, 'beacon_cron') !== false) {
                     $written = $value;
@@ -428,11 +428,12 @@ class BeaconTest extends TestCase
                 return '';
             }
         );
-        $helper->method('saveConfigValue')->willReturnCallback(
-            function ($path, $value) use (&$saved) {
-                $saved[$path] = $value;
-            }
-        );
+        $registrar = function ($path, $value) use (&$saved) {
+            $saved[$path] = $value;
+        };
+        // El beacon difiere sus escrituras; el NotificationDelivery real no.
+        $helper->method('saveConfigValueWithoutCacheFlush')->willReturnCallback($registrar);
+        $helper->method('saveConfigValue')->willReturnCallback($registrar);
 
         $client = $this->createMock(Client::class);
         $client->method('ping')->willReturn(
@@ -501,7 +502,7 @@ class BeaconTest extends TestCase
         $helper->method('getModuleVersion')->willReturn('103.4.81');
         $helper->method('getGmtDate')->willReturn('0');
         $helper->method('getConfigValue')->willReturn('');
-        $helper->method('saveConfigValue')->willReturnCallback(
+        $helper->method('saveConfigValueWithoutCacheFlush')->willReturnCallback(
             function ($path, $value) use (&$slotWrites) {
                 if (strpos($path, 'beacon_cron') !== false) {
                     $slotWrites[] = $value;
@@ -664,6 +665,79 @@ class BeaconTest extends TestCase
         $this->makeBeaconCapturingRegistration(null, $body)->execute();
 
         $this->assertSame('owner@example.com', $body['email']);
+    }
+
+
+    /**
+     * A run refreshes the config cache once, however many store views wrote.
+     *
+     * A flush is not cheap: the config module intercepts it to re-read the
+     * whole system config and then serialise and encrypt every scope under a
+     * lock, so its cost rises with the number of views. Flushing per write
+     * would make a token expiry across N views pay that N times over, which is
+     * quadratic work for one refresh.
+     */
+    public function testTheConfigCacheIsFlushedOncePerRunNotOncePerWrite(): void
+    {
+        $stores = [];
+        foreach ([1, 2, 3, 4, 5] as $id) {
+            $store = $this->createMock(Store::class);
+            $store->method('getId')->willReturn($id);
+            $store->method('getBaseUrl')->willReturn('https://view' . $id . '.example.com/');
+            $stores[] = $store;
+        }
+        $storeManager = $this->createMock(StoreManagerInterface::class);
+        $storeManager->method('getStores')->willReturn($stores);
+
+        $helper = $this->createMock(MailChimpHelper::class);
+        $helper->method('isMailChimpEnabled')->willReturn(true);
+        $helper->method('getApiKey')->willReturn('key-123');
+        $helper->method('getModuleVersion')->willReturn('103.4.81');
+        $helper->method('getGmtDate')->willReturn('0');
+        // Every view holds a token, and every ping is refused as expired — the
+        // wave this is about. Five views, five token clears, one refresh.
+        $helper->method('getConfigValue')->willReturnCallback(
+            function ($path) {
+                return strpos($path, 'edge_token') !== false ? 'ebz_tok' : '';
+            }
+        );
+        $helper->expects($this->exactly(5))->method('saveConfigValueWithoutCacheFlush');
+        $helper->expects($this->once())->method('flushConfigCache');
+
+        $client = $this->createMock(Client::class);
+        $client->method('ping')->willReturn(new Response(Response::UNAUTHORIZED, 401));
+
+        $signals = $this->createMock(LivenessSignals::class);
+        $signals->method('forStore')->willReturn(['last_error_type' => null]);
+        $metadata = $this->createMock(ProductMetadataInterface::class);
+        $metadata->method('getVersion')->willReturn('2.4.8');
+        $metadata->method('getEdition')->willReturn('Community');
+
+        (new Beacon(
+            $storeManager,
+            $helper,
+            $client,
+            $signals,
+            $this->createMock(NotificationDelivery::class),
+            $metadata,
+            $this->createMock(ScopeConfigInterface::class)
+        ))->execute();
+    }
+
+    /**
+     * A run that writes nothing — the steady state, every hour of every day —
+     * must not touch the cache at all.
+     */
+    public function testARunThatWritesNothingDoesNotFlush(): void
+    {
+        $beacon = $this->makeBeacon('ebz_tok');
+
+        $this->client->method('ping')->willReturn(
+            new Response(Response::OK, 200, ['ok' => true, 'notifications' => 0])
+        );
+        $this->helper->expects($this->never())->method('flushConfigCache');
+
+        $beacon->execute();
     }
 
 }

--- a/Test/Unit/Model/Edge/BeaconTest.php
+++ b/Test/Unit/Model/Edge/BeaconTest.php
@@ -632,13 +632,16 @@ class BeaconTest extends TestCase
         $body = [];
         $this->makeBeaconCapturingRegistration('0', $body)->execute();
 
-        foreach (['email', 'first_name', 'last_name', 'username'] as $field) {
+        // account_name is here too: on an account opened by an individual it
+        // commonly carries their name, and the API library withholds the same
+        // value behind the same switch.
+        foreach (['account_name', 'email', 'first_name', 'last_name', 'username'] as $field) {
             $this->assertArrayNotHasKey($field, $body, $field . ' was sent after the merchant opted out');
         }
 
-        // Everything that is not about the person keeps working, as promised.
+        // What is not about a person keeps working, as promised — and the
+        // account stays identifiable, so reports remain countable.
         $this->assertSame('acc-1', $body['account_id']);
-        $this->assertSame('Shop', $body['account_name']);
         $this->assertSame('monthly', $body['pricing_plan_type']);
         $this->assertSame(4200, $body['total_subscribers']);
     }
@@ -648,6 +651,7 @@ class BeaconTest extends TestCase
         $body = [];
         $this->makeBeaconCapturingRegistration('1', $body)->execute();
 
+        $this->assertSame('Shop', $body['account_name']);
         $this->assertSame('owner@example.com', $body['email']);
         $this->assertSame('Ada', $body['first_name']);
         $this->assertSame('Lovelace', $body['last_name']);

--- a/Test/Unit/Model/Edge/BeaconTest.php
+++ b/Test/Unit/Model/Edge/BeaconTest.php
@@ -705,6 +705,21 @@ class BeaconTest extends TestCase
                 return strpos($path, 'edge_token') !== false ? 'ebz_tok' : '';
             }
         );
+        // Slot 0 falls on one of these five views, so ping() reaches
+        // accountBlock() for it. Without this the helper hands back null and
+        // the account read explodes — which the suite only survived because
+        // Magento's unit bootstrap turns the "property on null" warning into a
+        // PHPUnit exception that accountBlock()'s catch happens to swallow.
+        // Depending on that is not a test, so the account path is stubbed.
+        $root = $this->getMockBuilder(\Mailchimp_Root::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['info'])
+            ->getMock();
+        $root->method('info')->willReturn(['account_id' => 'acc-1', 'account_name' => 'Shop']);
+        $api = $this->getMockBuilder(\Mailchimp::class)->disableOriginalConstructor()->getMock();
+        $api->root = $root;
+        $helper->method('getApi')->willReturn($api);
+
         $helper->expects($this->exactly(5))->method('saveConfigValueWithoutCacheFlush');
         $helper->expects($this->once())->method('flushConfigCache');
 
@@ -742,6 +757,139 @@ class BeaconTest extends TestCase
         $this->helper->expects($this->never())->method('flushConfigCache');
 
         $beacon->execute();
+    }
+
+
+    /**
+     * Builds a beacon over N store views that all hold a token.
+     *
+     * @param  array    $storeIds
+     * @param  callable $enabled  answers isMailChimpEnabled, may throw
+     * @param  array    $captured filled with helper interactions
+     * @return array    [$beacon, $client]
+     */
+    private function makeBeaconOverStores(array $storeIds, $enabled, array &$captured)
+    {
+        $stores = [];
+        foreach ($storeIds as $id) {
+            $store = $this->createMock(Store::class);
+            $store->method('getId')->willReturn($id);
+            $store->method('getBaseUrl')->willReturn('https://view' . $id . '.example.com/');
+            $stores[] = $store;
+        }
+        $storeManager = $this->createMock(StoreManagerInterface::class);
+        $storeManager->method('getStores')->willReturn($stores);
+
+        $helper = $this->createMock(MailChimpHelper::class);
+        $helper->method('isMailChimpEnabled')->willReturnCallback($enabled);
+        $helper->method('getApiKey')->willReturn('key-123');
+        $helper->method('getModuleVersion')->willReturn('103.4.81');
+        $helper->method('getGmtDate')->willReturn('0');
+        $helper->method('getConfigValue')->willReturnCallback(
+            function ($path) {
+                return strpos($path, 'edge_token') !== false ? 'ebz_tok' : '';
+            }
+        );
+        $helper->method('saveConfigValueWithoutCacheFlush')->willReturnCallback(
+            function () use (&$captured) {
+                $captured['writes'] = ($captured['writes'] ?? 0) + 1;
+            }
+        );
+        $helper->method('flushConfigCache')->willReturnCallback(
+            function () use (&$captured) {
+                $captured['flushes'] = ($captured['flushes'] ?? 0) + 1;
+            }
+        );
+
+        $root = $this->getMockBuilder(\Mailchimp_Root::class)
+            ->disableOriginalConstructor()->onlyMethods(['info'])->getMock();
+        $root->method('info')->willReturn(['account_id' => 'acc-1', 'account_name' => 'Shop']);
+        $api = $this->getMockBuilder(\Mailchimp::class)->disableOriginalConstructor()->getMock();
+        $api->root = $root;
+        $helper->method('getApi')->willReturn($api);
+
+        $client   = $this->createMock(Client::class);
+        $signals  = $this->createMock(LivenessSignals::class);
+        $signals->method('forStore')->willReturn(['last_error_type' => null]);
+        $metadata = $this->createMock(ProductMetadataInterface::class);
+        $metadata->method('getVersion')->willReturn('2.4.8');
+        $metadata->method('getEdition')->willReturn('Community');
+
+        return [
+            new Beacon(
+                $storeManager,
+                $helper,
+                $client,
+                $signals,
+                $this->createMock(NotificationDelivery::class),
+                $metadata,
+                $this->createMock(ScopeConfigInterface::class)
+            ),
+            $client,
+        ];
+    }
+
+    /**
+     * An Error is not an Exception, so catching only Exception let one store
+     * view's broken API path abort the run and take every remaining view with
+     * it. One view's problem is not the others'.
+     */
+    public function testAnErrorInOneStoreViewDoesNotAbortTheRest(): void
+    {
+        $captured = [];
+        list($beacon, $client) = $this->makeBeaconOverStores(
+            [1, 2, 3],
+            function () {
+                return true;
+            },
+            $captured
+        );
+
+        $pinged = [];
+        $client->method('ping')->willReturnCallback(
+            function ($token, $body) use (&$pinged) {
+                $pinged[] = $body['store_url'];
+                if (count($pinged) === 2) {
+                    throw new \TypeError('the API path is broken for this view');
+                }
+                return new Response(Response::UNAUTHORIZED, 401);
+            }
+        );
+
+        $beacon->execute();
+
+        $this->assertCount(3, $pinged, 'the run stopped at the store view that raised an Error');
+    }
+
+    /**
+     * The deferred writes are already in the database, so a run that ends
+     * without flushing leaves a cleared token stored while the config cache
+     * keeps serving the old one. Whatever happens, the refresh has to occur.
+     */
+    public function testTheFlushStillHappensWhenTheRunIsCutShort(): void
+    {
+        $captured = [];
+        list($beacon, $client) = $this->makeBeaconOverStores(
+            [1, 2, 3],
+            function ($storeId) {
+                // Outside the per-store guard, so this ends the loop.
+                if ($storeId === 3) {
+                    throw new \Error('the store manager handed back something broken');
+                }
+                return true;
+            },
+            $captured
+        );
+        $client->method('ping')->willReturn(new Response(Response::UNAUTHORIZED, 401));
+
+        try {
+            $beacon->execute();
+        } catch (\Throwable $t) {
+            // Escaping is acceptable; losing the flush is not.
+        }
+
+        $this->assertSame(2, $captured['writes'] ?? 0, 'the two healthy views should have written');
+        $this->assertSame(1, $captured['flushes'] ?? 0, 'the config cache was left stale after an aborted run');
     }
 
 }

--- a/Test/Unit/Model/Edge/BeaconTest.php
+++ b/Test/Unit/Model/Edge/BeaconTest.php
@@ -547,4 +547,123 @@ class BeaconTest extends TestCase
         $this->assertMatchesRegularExpression('/^([0-9]|[1-5][0-9]) \* \* \* \*$/', $slotWrites[0]);
     }
 
+
+    /**
+     * Builds a beacon whose store answers the contact switch a given way, and
+     * captures the body the register call would send.
+     *
+     * @param  mixed $shareContact value of the opt-out, null when unanswered
+     * @param  array $captured     filled with the register body
+     * @return Beacon
+     */
+    private function makeBeaconCapturingRegistration($shareContact, array &$captured)
+    {
+        $store = $this->createMock(Store::class);
+        $store->method('getId')->willReturn(self::STORE_ID);
+        $store->method('getBaseUrl')->willReturn(self::STORE_URL);
+        $storeManager = $this->createMock(StoreManagerInterface::class);
+        $storeManager->method('getStores')->willReturn([$store]);
+
+        $helper = $this->createMock(MailChimpHelper::class);
+        $helper->method('isMailChimpEnabled')->willReturn(true);
+        $helper->method('getApiKey')->willReturn('key-123');
+        $helper->method('getModuleVersion')->willReturn('103.4.81');
+        $helper->method('getGmtDate')->willReturn('0');
+        $helper->method('getConfigValue')->willReturnCallback(
+            function ($path) use ($shareContact) {
+                if (strpos($path, 'share_contact') !== false) {
+                    return $shareContact;
+                }
+                return '';
+            }
+        );
+
+        $root = $this->getMockBuilder(\Mailchimp_Root::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['info'])
+            ->getMock();
+        $root->method('info')->willReturn([
+            'account_id'        => 'acc-1',
+            'account_name'      => 'Shop',
+            'email'             => 'owner@example.com',
+            'first_name'        => 'Ada',
+            'last_name'         => 'Lovelace',
+            'username'          => 'ada',
+            'pricing_plan_type' => 'monthly',
+            'total_subscribers' => 4200,
+        ]);
+        $api = $this->getMockBuilder(\Mailchimp::class)->disableOriginalConstructor()->getMock();
+        $api->root = $root;
+        $helper->method('getApi')->willReturn($api);
+
+        $client = $this->createMock(Client::class);
+        $client->method('register')->willReturnCallback(
+            function ($body) use (&$captured) {
+                $captured = $body;
+                return new Response(Response::OK, 201, ['token' => 'ebz_new']);
+            }
+        );
+        $client->method('ping')->willReturn(new Response(Response::OK, 200, ['ok' => true, 'notifications' => 0]));
+
+        $signals = $this->createMock(LivenessSignals::class);
+        $signals->method('forStore')->willReturn(['last_error_type' => null]);
+        $metadata = $this->createMock(ProductMetadataInterface::class);
+        $metadata->method('getVersion')->willReturn('2.4.8');
+        $metadata->method('getEdition')->willReturn('Community');
+
+        return new Beacon(
+            $storeManager,
+            $helper,
+            $client,
+            $signals,
+            $this->createMock(NotificationDelivery::class),
+            $metadata,
+            $this->createMock(ScopeConfigInterface::class)
+        );
+    }
+
+    /**
+     * The admin switch says setting it to No leaves the account owner's name
+     * and email address out of these reports. It has to be true.
+     */
+    public function testDecliningTheContactSwitchLeavesTheOwnerOutOfTheReport(): void
+    {
+        $body = [];
+        $this->makeBeaconCapturingRegistration('0', $body)->execute();
+
+        foreach (['email', 'first_name', 'last_name', 'username'] as $field) {
+            $this->assertArrayNotHasKey($field, $body, $field . ' was sent after the merchant opted out');
+        }
+
+        // Everything that is not about the person keeps working, as promised.
+        $this->assertSame('acc-1', $body['account_id']);
+        $this->assertSame('Shop', $body['account_name']);
+        $this->assertSame('monthly', $body['pricing_plan_type']);
+        $this->assertSame(4200, $body['total_subscribers']);
+    }
+
+    public function testAllowingTheContactSwitchSendsTheOwner(): void
+    {
+        $body = [];
+        $this->makeBeaconCapturingRegistration('1', $body)->execute();
+
+        $this->assertSame('owner@example.com', $body['email']);
+        $this->assertSame('Ada', $body['first_name']);
+        $this->assertSame('Lovelace', $body['last_name']);
+        $this->assertSame('ada', $body['username']);
+    }
+
+    /**
+     * An unanswered switch is not a refusal — that is what an upgrade from a
+     * version predating it looks like. Same reading the API library gives the
+     * very same config path.
+     */
+    public function testAnUnansweredContactSwitchIsNotTreatedAsARefusal(): void
+    {
+        $body = [];
+        $this->makeBeaconCapturingRegistration(null, $body)->execute();
+
+        $this->assertSame('owner@example.com', $body['email']);
+    }
+
 }

--- a/Test/Unit/Model/Edge/BeaconTest.php
+++ b/Test/Unit/Model/Edge/BeaconTest.php
@@ -183,7 +183,7 @@ class BeaconTest extends TestCase
     public function testAFailingAccountCallDoesNotSuppressThePing(): void
     {
         // Hour chosen so this tick IS one of the store's two account slots.
-        $slot   = crc32(self::STORE_ID . self::STORE_URL) % Beacon::ACCOUNT_BLOCK_PERIOD_HOURS;
+        $slot   = (crc32(self::STORE_ID . self::STORE_URL) & 0x7fffffff) % Beacon::ACCOUNT_BLOCK_PERIOD_HOURS;
         $beacon = $this->makeBeacon('ebz_live', true, $slot);
 
         $this->client->expects($this->once())
@@ -191,7 +191,8 @@ class BeaconTest extends TestCase
             ->with(
                 'ebz_live',
                 $this->callback(function ($body) {
-                    return !array_key_exists('account', $body);
+                    return !array_key_exists('account_id', $body)
+                        && !array_key_exists('account', $body);
                 })
             )
             ->willReturn(new Response(Response::OK, 200, ['notifications' => 0]));
@@ -201,7 +202,7 @@ class BeaconTest extends TestCase
 
     public function testAccountBlockRidesTheStoresOwnSlot(): void
     {
-        $slot   = crc32(self::STORE_ID . self::STORE_URL) % Beacon::ACCOUNT_BLOCK_PERIOD_HOURS;
+        $slot   = (crc32(self::STORE_ID . self::STORE_URL) & 0x7fffffff) % Beacon::ACCOUNT_BLOCK_PERIOD_HOURS;
         $beacon = $this->makeBeacon('ebz_live', false, $slot);
 
         $this->client->expects($this->once())
@@ -209,7 +210,9 @@ class BeaconTest extends TestCase
             ->with(
                 'ebz_live',
                 $this->callback(function ($body) {
-                    return isset($body['account']['account_id']) && $body['account']['account_id'] === 'acc-1';
+                    return ($body['account_id'] ?? null) === 'acc-1'
+                        && ($body['account_name'] ?? null) === 'Shop'
+                        && !array_key_exists('account', $body);
                 })
             )
             ->willReturn(new Response(Response::OK, 200, ['notifications' => 0]));
@@ -219,7 +222,7 @@ class BeaconTest extends TestCase
 
     public function testNoAccountBlockOutsideTheSlot(): void
     {
-        $slot   = crc32(self::STORE_ID . self::STORE_URL) % Beacon::ACCOUNT_BLOCK_PERIOD_HOURS;
+        $slot   = (crc32(self::STORE_ID . self::STORE_URL) & 0x7fffffff) % Beacon::ACCOUNT_BLOCK_PERIOD_HOURS;
         $beacon = $this->makeBeacon('ebz_live', false, ($slot + 1) % Beacon::ACCOUNT_BLOCK_PERIOD_HOURS);
 
         $this->client->expects($this->once())
@@ -227,7 +230,8 @@ class BeaconTest extends TestCase
             ->with(
                 'ebz_live',
                 $this->callback(function ($body) {
-                    return !array_key_exists('account', $body);
+                    return !array_key_exists('account_id', $body)
+                        && !array_key_exists('account', $body);
                 })
             )
             ->willReturn(new Response(Response::OK, 200, ['notifications' => 0]));
@@ -352,5 +356,32 @@ class BeaconTest extends TestCase
         $this->client->method('ping')->willReturn(new Response(Response::OK, 200, ['notifications' => 0]));
 
         $beacon->execute();
+    }
+
+    /**
+     * crc32() is negative on 32-bit PHP builds. Unmasked, the derived minute
+     * would be negative and the written cron expression invalid, so the job
+     * would never be scheduled and the install would never report — silently.
+     */
+    public function testTheClaimedCronExpressionIsAlwaysValid(): void
+    {
+        $beacon = $this->makeBeacon('');
+
+        $this->client->method('register')->willReturn(new Response(Response::OK, 201, ['token' => 'ebz_new']));
+        $this->client->method('ping')->willReturn(new Response(Response::OK, 200, ['notifications' => 0]));
+
+        $written = null;
+        $this->helper->method('saveConfigValue')->willReturnCallback(
+            function ($path, $value) use (&$written) {
+                if (strpos($path, 'beacon_cron') !== false) {
+                    $written = $value;
+                }
+            }
+        );
+
+        $beacon->execute();
+
+        $this->assertNotNull($written, 'the first successful register must claim a slot');
+        $this->assertMatchesRegularExpression('/^([0-9]|[1-5][0-9]) \* \* \* \*$/', $written);
     }
 }

--- a/Test/Unit/Model/Edge/ClientTest.php
+++ b/Test/Unit/Model/Edge/ClientTest.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Ebizmarts_MailChimp
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Test\Unit\Model\Edge;
+
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Ebizmarts\MailChimp\Model\Edge\Client;
+use Ebizmarts\MailChimp\Model\HTTP\Client\Curl;
+use Ebizmarts\MailChimp\Model\HTTP\Client\CurlFactory;
+use PHPUnit\Framework\TestCase;
+
+class ClientTest extends TestCase
+{
+    /**
+     * @param  int    $status
+     * @param  string $body
+     * @param  array  $headers
+     * @param  bool   $throw
+     * @return Client
+     */
+    private function makeClient($status, $body = '{}', array $headers = [], $throw = false)
+    {
+        $curl = $this->getMockBuilder(Curl::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['setOption', 'setTimeout', 'setHeaders', 'post', 'getStatus', 'getBody', 'getHeaders'])
+            ->getMock();
+
+        if ($throw) {
+            $curl->method('post')->willThrowException(new \Exception('Could not resolve host'));
+        }
+
+        $curl->method('getStatus')->willReturn($status);
+        $curl->method('getBody')->willReturn($body);
+        $curl->method('getHeaders')->willReturn($headers);
+
+        $factory = $this->getMockBuilder(CurlFactory::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['create'])
+            ->getMock();
+        $factory->method('create')->willReturn($curl);
+
+        $helper = $this->createMock(MailChimpHelper::class);
+
+        return new Client($factory, $helper);
+    }
+
+    public function testSuccessReturnsDecodedBody(): void
+    {
+        $client   = $this->makeClient(201, '{"token":"ebz_abc","expires_at":123}');
+        $response = $client->register(['store_url' => 'https://example.com/']);
+
+        $this->assertTrue($response->isOk());
+        $this->assertSame('ebz_abc', $response->getData()['token']);
+    }
+
+    public function testUnauthorizedIsItsOwnOutcome(): void
+    {
+        $response = $this->makeClient(401, '{"error":"expired","action":"reregister"}')->ping('t', []);
+
+        $this->assertTrue($response->isUnauthorized());
+        $this->assertFalse($response->isOk());
+    }
+
+    public function testRateLimitedReadsRetryAfter(): void
+    {
+        $response = $this->makeClient(429, '{}', ['Retry-After' => '90'])->ping('t', []);
+
+        $this->assertTrue($response->isRateLimited());
+        $this->assertSame(90, $response->getRetryAfter());
+    }
+
+    public function testRetryAfterIsCaseInsensitive(): void
+    {
+        $response = $this->makeClient(429, '{}', ['retry-after' => '30'])->ping('t', []);
+
+        $this->assertSame(30, $response->getRetryAfter());
+    }
+
+    /**
+     * A 5xx must never look like an auth failure: if it did, one bad deploy on
+     * the service would make every installation drop its tokens at once.
+     */
+    public function testServerErrorIsNotUnauthorized(): void
+    {
+        $response = $this->makeClient(503, 'upstream down')->ping('t', []);
+
+        $this->assertFalse($response->isOk());
+        $this->assertFalse($response->isUnauthorized());
+        $this->assertFalse($response->isRateLimited());
+    }
+
+    public function testTransportFailureIsNotUnauthorized(): void
+    {
+        $response = $this->makeClient(0, '', [], true)->ping('t', []);
+
+        $this->assertFalse($response->isOk());
+        $this->assertFalse($response->isUnauthorized());
+        $this->assertSame(0, $response->getStatus());
+    }
+
+    public function testMalformedBodyIsAFailure(): void
+    {
+        $response = $this->makeClient(200, 'not json at all')->ping('t', []);
+
+        $this->assertFalse($response->isOk());
+    }
+}

--- a/Test/Unit/Model/Edge/LivenessSignalsTest.php
+++ b/Test/Unit/Model/Edge/LivenessSignalsTest.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Ebizmarts_MailChimp
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Test\Unit\Model\Edge;
+
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Ebizmarts\MailChimp\Model\Edge\LivenessSignals;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\DB\Select;
+use PHPUnit\Framework\TestCase;
+
+class LivenessSignalsTest extends TestCase
+{
+    /**
+     * Columns handed to Select::from across the whole call, so a test can
+     * assert that a forbidden one is never requested.
+     *
+     * @var array
+     */
+    private $selectedColumns = [];
+
+    /**
+     * @param  string|false $syncDelta
+     * @param  array|false  $errorRow
+     * @param  string       $mailchimpStoreId
+     * @return LivenessSignals
+     */
+    private function makeSignals($syncDelta, $errorRow, $mailchimpStoreId = 'mc-store-1')
+    {
+        $this->selectedColumns = [];
+
+        $select = $this->createMock(Select::class);
+        $select->method('from')->willReturnCallback(
+            function ($table, $columns = '*') use ($select) {
+                foreach ((array)$columns as $column) {
+                    $this->selectedColumns[] = $column;
+                }
+                return $select;
+            }
+        );
+        $select->method('where')->willReturnSelf();
+        $select->method('order')->willReturnSelf();
+        $select->method('limit')->willReturnSelf();
+
+        $connection = $this->createMock(AdapterInterface::class);
+        $connection->method('select')->willReturn($select);
+        $connection->method('fetchOne')->willReturn($syncDelta);
+        $connection->method('fetchRow')->willReturn($errorRow);
+
+        $resource = $this->createMock(ResourceConnection::class);
+        $resource->method('getConnection')->willReturn($connection);
+        $resource->method('getTableName')->willReturnArgument(0);
+
+        $helper = $this->createMock(MailChimpHelper::class);
+        $helper->method('getConfigValue')->willReturn($mailchimpStoreId);
+
+        return new LivenessSignals($resource, $helper);
+    }
+
+    /**
+     * The service deletes a field on an explicit null and keeps it when the key is
+     * absent, so a recovered store must actively send null rather than omit.
+     */
+    public function testErrorFieldsAreAlwaysPresentSoRecoveryClearsThem(): void
+    {
+        $signals = $this->makeSignals('2026-08-24 12:00:00', false)->forStore(1);
+
+        $this->assertArrayHasKey('last_error_type', $signals);
+        $this->assertArrayHasKey('last_error_status', $signals);
+        $this->assertArrayHasKey('last_error_at', $signals);
+        $this->assertNull($signals['last_error_type']);
+        $this->assertNull($signals['last_error_status']);
+        $this->assertNull($signals['last_error_at']);
+    }
+
+    public function testErrorFieldsCarryTheNewestRow(): void
+    {
+        $row = ['type' => 'ecommerce', 'status' => '404', 'added_at' => '2026-08-24 11:00:00'];
+
+        $signals = $this->makeSignals('2026-08-24 12:00:00', $row)->forStore(1);
+
+        $this->assertSame('ecommerce', $signals['last_error_type']);
+        $this->assertSame('404', $signals['last_error_status']);
+        $this->assertSame('2026-08-24 11:00:00', $signals['last_error_at']);
+    }
+
+    /**
+     * Omitted rather than null: a transient local read problem must not erase a
+     * good value the service already holds.
+     */
+    public function testLastSyncIsOmittedWhenUnknown(): void
+    {
+        $signals = $this->makeSignals(false, false)->forStore(1);
+
+        $this->assertArrayNotHasKey('last_sync_at', $signals);
+    }
+
+    public function testLastSyncIsSentWhenKnown(): void
+    {
+        $signals = $this->makeSignals('2026-08-24 12:00:00', false)->forStore(1);
+
+        $this->assertSame('2026-08-24 12:00:00', $signals['last_sync_at']);
+    }
+
+    public function testNoSyncDeltaIsReadWithoutAMailchimpStore(): void
+    {
+        $signals = $this->makeSignals('2026-08-24 12:00:00', false, '')->forStore(1);
+
+        $this->assertArrayNotHasKey('last_sync_at', $signals);
+    }
+
+    /**
+     * mailchimp_errors.errors holds the raw Mailchimp body and can carry
+     * customer details. It must never be selected.
+     */
+    public function testTheShopperBearingColumnIsNeverSelected(): void
+    {
+        $this->makeSignals('2026-08-24 12:00:00', ['type' => 'x', 'status' => '1', 'added_at' => 'y'])
+            ->forStore(1);
+
+        $this->assertNotEmpty($this->selectedColumns);
+        $this->assertNotContains('errors', $this->selectedColumns);
+        $this->assertNotContains('notification_data', $this->selectedColumns);
+        $this->assertNotContains('*', $this->selectedColumns);
+    }
+}

--- a/Test/Unit/Model/Edge/NotificationDeliveryTest.php
+++ b/Test/Unit/Model/Edge/NotificationDeliveryTest.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Ebizmarts_MailChimp
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Test\Unit\Model\Edge;
+
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Ebizmarts\MailChimp\Model\Edge\Client;
+use Ebizmarts\MailChimp\Model\Edge\NotificationDelivery;
+use Ebizmarts\MailChimp\Model\Edge\Response;
+use Magento\Framework\Notification\NotifierInterface;
+use PHPUnit\Framework\TestCase;
+
+class NotificationDeliveryTest extends TestCase
+{
+    /**
+     * The wire shape the service actually returns from the pull:
+     * { notifications: [{ id, subject, message, created_at, priority }] }
+     *
+     * @param  string $priority
+     * @return array
+     */
+    private function wireItem($priority = 'notice', $id = 'uid-1')
+    {
+        return [
+            'id'         => $id,
+            'subject'    => 'Scheduled maintenance',
+            'message'    => 'Maintenance window this weekend.',
+            'created_at' => '2026-08-24T12:00:00Z',
+            'priority'   => $priority,
+        ];
+    }
+
+    public function testZeroCountNeverPulls(): void
+    {
+        $client = $this->createMock(Client::class);
+        $client->expects($this->never())->method('pullNotifications');
+
+        $delivery = new NotificationDelivery(
+            $client,
+            $this->createMock(MailChimpHelper::class),
+            $this->createMock(NotifierInterface::class)
+        );
+
+        // The ping reply carries the count under `notifications`.
+        $delivery->handle(1, 'token', ['ok' => true, 'notifications' => 0]);
+    }
+
+    public function testNonZeroCountPullsAndDelivers(): void
+    {
+        $client = $this->createMock(Client::class);
+        $client->expects($this->once())
+            ->method('pullNotifications')
+            ->willReturn(new Response(Response::OK, 200, ['notifications' => [$this->wireItem()]]));
+
+        $notifier = $this->createMock(NotifierInterface::class);
+        $notifier->expects($this->once())
+            ->method('addNotice')
+            ->with('Scheduled maintenance', 'Maintenance window this weekend.', '');
+
+        $helper = $this->createMock(MailChimpHelper::class);
+        $helper->expects($this->once())
+            ->method('saveConfigValue')
+            ->with($this->anything(), 'uid-1', 1, $this->anything());
+
+        (new NotificationDelivery($client, $helper, $notifier))
+            ->handle(1, 'token', ['ok' => true, 'notifications' => 1]);
+    }
+
+    public function testCriticalPriorityMapsToAddCritical(): void
+    {
+        $client = $this->createMock(Client::class);
+        $client->method('pullNotifications')
+            ->willReturn(new Response(Response::OK, 200, ['notifications' => [$this->wireItem('critical')]]));
+
+        $notifier = $this->createMock(NotifierInterface::class);
+        $notifier->expects($this->once())->method('addCritical');
+        $notifier->expects($this->never())->method('addNotice');
+
+        (new NotificationDelivery($client, $this->createMock(MailChimpHelper::class), $notifier))
+            ->handle(1, 'token', ['notifications' => 1]);
+    }
+
+    public function testMajorPriorityMapsToAddMajor(): void
+    {
+        $client = $this->createMock(Client::class);
+        $client->method('pullNotifications')
+            ->willReturn(new Response(Response::OK, 200, ['notifications' => [$this->wireItem('major')]]));
+
+        $notifier = $this->createMock(NotifierInterface::class);
+        $notifier->expects($this->once())->method('addMajor');
+
+        (new NotificationDelivery($client, $this->createMock(MailChimpHelper::class), $notifier))
+            ->handle(1, 'token', ['notifications' => 1]);
+    }
+
+    public function testAFailedPullConfirmsNothing(): void
+    {
+        $client = $this->createMock(Client::class);
+        $client->method('pullNotifications')->willReturn(new Response(Response::FAILED, 503));
+
+        $helper = $this->createMock(MailChimpHelper::class);
+        $helper->expects($this->never())->method('saveConfigValue');
+
+        (new NotificationDelivery($client, $helper, $this->createMock(NotifierInterface::class)))
+            ->handle(1, 'token', ['notifications' => 3]);
+    }
+
+    /**
+     * A message we could not write must not be reported as delivered — that is
+     * the whole reason the ack exists.
+     */
+    public function testAMessageThatCannotBeWrittenIsNotConfirmed(): void
+    {
+        $client = $this->createMock(Client::class);
+        $client->method('pullNotifications')->willReturn(
+            new Response(Response::OK, 200, ['notifications' => [$this->wireItem('notice', 'uid-boom')]])
+        );
+
+        $notifier = $this->createMock(NotifierInterface::class);
+        $notifier->method('addNotice')->willThrowException(new \Exception('inbox unavailable'));
+
+        $helper = $this->createMock(MailChimpHelper::class);
+        $helper->expects($this->never())->method('saveConfigValue');
+
+        (new NotificationDelivery($client, $helper, $notifier))
+            ->handle(1, 'token', ['notifications' => 1]);
+    }
+
+    /**
+     * A batch still waiting to be acknowledged must not be dropped by a newer
+     * one, or those messages stay unconfirmed forever.
+     */
+    public function testDeliveredUidsAppendToWhatIsStillPending(): void
+    {
+        $client = $this->createMock(Client::class);
+        $client->method('pullNotifications')->willReturn(
+            new Response(Response::OK, 200, ['notifications' => [$this->wireItem('notice', 'uid-2')]])
+        );
+
+        $helper = $this->createMock(MailChimpHelper::class);
+        $helper->method('getConfigValue')->willReturn('uid-0,uid-1');
+        $helper->expects($this->once())
+            ->method('saveConfigValue')
+            ->with($this->anything(), 'uid-0,uid-1,uid-2', 1, $this->anything());
+
+        (new NotificationDelivery($client, $helper, $this->createMock(NotifierInterface::class)))
+            ->handle(1, 'token', ['notifications' => 1]);
+    }
+
+    public function testEveryDeliveredUidIsQueuedNotJustTheLast(): void
+    {
+        $client = $this->createMock(Client::class);
+        $client->method('pullNotifications')->willReturn(
+            new Response(
+                Response::OK,
+                200,
+                ['notifications' => [$this->wireItem('notice', 'uid-a'), $this->wireItem('major', 'uid-b')]]
+            )
+        );
+
+        $helper = $this->createMock(MailChimpHelper::class);
+        $helper->method('getConfigValue')->willReturn('');
+        $helper->expects($this->once())
+            ->method('saveConfigValue')
+            ->with($this->anything(), 'uid-a,uid-b', 1, $this->anything());
+
+        (new NotificationDelivery($client, $helper, $this->createMock(NotifierInterface::class)))
+            ->handle(1, 'token', ['notifications' => 2]);
+    }
+}

--- a/Test/Unit/Model/Edge/NotificationDeliveryTest.php
+++ b/Test/Unit/Model/Edge/NotificationDeliveryTest.php
@@ -254,4 +254,79 @@ class NotificationDeliveryTest extends TestCase
         (new NotificationDelivery($client, $helper, $this->createMock(NotifierInterface::class)))
             ->handle(1, 'token', ['notifications' => 2], []);
     }
+
+    /**
+     * The service addresses store views, so one message arrives once per
+     * registered view of the same install. Magento's inbox is install-wide,
+     * so writing every arrival would put the same message in the bell N times.
+     */
+    public function testTheSameMessageIsWrittenToTheInboxOnlyOnce(): void
+    {
+        $client = $this->createMock(Client::class);
+        $client->method('pullNotifications')->willReturn(
+            new Response(Response::OK, 200, ['notifications' => [$this->wireItem('notice', 'uid-broadcast')]])
+        );
+
+        $notifier = $this->createMock(NotifierInterface::class);
+        $notifier->expects($this->once())->method('addNotice');
+
+        $delivery = new NotificationDelivery($client, $this->createMock(MailChimpHelper::class), $notifier);
+
+        // Five store views of one install, one cron process, same message.
+        foreach ([1, 2, 3, 4, 5] as $storeId) {
+            $delivery->handle($storeId, 'token', ['notifications' => 1], []);
+        }
+    }
+
+    /**
+     * A suppressed duplicate must still be acknowledged. It did reach the
+     * inbox once, and the service tracks delivery per store view — a view that
+     * never confirms is offered the same message forever.
+     */
+    public function testASuppressedDuplicateIsStillAcknowledgedByEveryStoreView(): void
+    {
+        $client = $this->createMock(Client::class);
+        $client->method('pullNotifications')->willReturn(
+            new Response(Response::OK, 200, ['notifications' => [$this->wireItem('notice', 'uid-broadcast')]])
+        );
+
+        $acked = [];
+        $helper = $this->createMock(MailChimpHelper::class);
+        $helper->method('saveConfigValue')->willReturnCallback(
+            function ($path, $value, $storeId) use (&$acked) {
+                $acked[] = $storeId;
+            }
+        );
+
+        $delivery = new NotificationDelivery($client, $helper, $this->createMock(NotifierInterface::class));
+
+        foreach ([1, 2, 3] as $storeId) {
+            $delivery->handle($storeId, 'token', ['notifications' => 1], []);
+        }
+
+        $this->assertSame([1, 2, 3], $acked, 'every store view has to confirm its own copy');
+    }
+
+    /**
+     * Suppression is by uid, not by content — two genuinely different messages
+     * must both reach the merchant even in the same run.
+     */
+    public function testDifferentMessagesAreNotSuppressed(): void
+    {
+        $client = $this->createMock(Client::class);
+        $client->method('pullNotifications')->willReturn(
+            new Response(
+                Response::OK,
+                200,
+                ['notifications' => [$this->wireItem('notice', 'uid-a'), $this->wireItem('notice', 'uid-b')]]
+            )
+        );
+
+        $notifier = $this->createMock(NotifierInterface::class);
+        $notifier->expects($this->exactly(2))->method('addNotice');
+
+        (new NotificationDelivery($client, $this->createMock(MailChimpHelper::class), $notifier))
+            ->handle(1, 'token', ['notifications' => 2], []);
+    }
+
 }

--- a/Test/Unit/Model/Edge/NotificationDeliveryTest.php
+++ b/Test/Unit/Model/Edge/NotificationDeliveryTest.php
@@ -146,13 +146,93 @@ class NotificationDeliveryTest extends TestCase
         );
 
         $helper = $this->createMock(MailChimpHelper::class);
-        $helper->method('getConfigValue')->willReturn('uid-0,uid-1');
         $helper->expects($this->once())
             ->method('saveConfigValue')
             ->with($this->anything(), 'uid-0,uid-1,uid-2', 1, $this->anything());
 
         (new NotificationDelivery($client, $helper, $this->createMock(NotifierInterface::class)))
-            ->handle(1, 'token', ['notifications' => 1]);
+            ->handle(1, 'token', ['notifications' => 1], ['uid-0', 'uid-1']);
+    }
+
+    /**
+     * What is still pending comes from the caller, never from configuration.
+     *
+     * The caller clears that value immediately before calling in, and reading
+     * it back here would not reliably see the clear: within one process a scope
+     * already loaded is refreshed only as a side effect of the cache-warming
+     * path, which is skipped when the config cache type is disabled. A read
+     * would return the pre-clear list and re-send uids already acknowledged on
+     * every tick, forever.
+     */
+    public function testWhatIsStillPendingIsNeverReadBackFromConfig(): void
+    {
+        $client = $this->createMock(Client::class);
+        $client->method('pullNotifications')->willReturn(
+            new Response(Response::OK, 200, ['notifications' => [$this->wireItem('notice', 'uid-2')]])
+        );
+
+        $helper = $this->createMock(MailChimpHelper::class);
+        // A stale read would hand back a list the caller has just cleared.
+        $helper->method('getConfigValue')->willReturn('uid-0,uid-1');
+        $helper->expects($this->once())
+            ->method('saveConfigValue')
+            ->with($this->anything(), 'uid-2', 1, $this->anything());
+
+        (new NotificationDelivery($client, $helper, $this->createMock(NotifierInterface::class)))
+            ->handle(1, 'token', ['notifications' => 1], []);
+    }
+
+    /**
+     * A message with no subject is never written to the inbox, so it must not
+     * be acknowledged either — that would tell the service somebody saw it.
+     */
+    public function testAnEmptySubjectIsNeitherDeliveredNorConfirmed(): void
+    {
+        $empty            = $this->wireItem('notice', 'uid-empty');
+        $empty['subject'] = '';
+
+        $client = $this->createMock(Client::class);
+        $client->method('pullNotifications')->willReturn(
+            new Response(Response::OK, 200, ['notifications' => [$empty]])
+        );
+
+        $notifier = $this->createMock(NotifierInterface::class);
+        $notifier->expects($this->never())->method('addNotice');
+        $notifier->expects($this->never())->method('addMajor');
+        $notifier->expects($this->never())->method('addCritical');
+
+        $helper = $this->createMock(MailChimpHelper::class);
+        $helper->expects($this->never())->method('saveConfigValue');
+
+        (new NotificationDelivery($client, $helper, $notifier))
+            ->handle(1, 'token', ['notifications' => 1], []);
+    }
+
+    /**
+     * An unwritable message in the middle of a batch must not take down the
+     * one before it, nor confirm the one after.
+     */
+    public function testAnEmptySubjectDoesNotStopTheRestOfTheBatch(): void
+    {
+        $empty            = $this->wireItem('notice', 'uid-empty');
+        $empty['subject'] = '';
+
+        $client = $this->createMock(Client::class);
+        $client->method('pullNotifications')->willReturn(
+            new Response(
+                Response::OK,
+                200,
+                ['notifications' => [$this->wireItem('notice', 'uid-a'), $empty, $this->wireItem('major', 'uid-b')]]
+            )
+        );
+
+        $helper = $this->createMock(MailChimpHelper::class);
+        $helper->expects($this->once())
+            ->method('saveConfigValue')
+            ->with($this->anything(), 'uid-a,uid-b', 1, $this->anything());
+
+        (new NotificationDelivery($client, $helper, $this->createMock(NotifierInterface::class)))
+            ->handle(1, 'token', ['notifications' => 3], []);
     }
 
     public function testEveryDeliveredUidIsQueuedNotJustTheLast(): void
@@ -167,12 +247,11 @@ class NotificationDeliveryTest extends TestCase
         );
 
         $helper = $this->createMock(MailChimpHelper::class);
-        $helper->method('getConfigValue')->willReturn('');
         $helper->expects($this->once())
             ->method('saveConfigValue')
             ->with($this->anything(), 'uid-a,uid-b', 1, $this->anything());
 
         (new NotificationDelivery($client, $helper, $this->createMock(NotifierInterface::class)))
-            ->handle(1, 'token', ['notifications' => 2]);
+            ->handle(1, 'token', ['notifications' => 2], []);
     }
 }

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -35,5 +35,23 @@
         <job name="ebizmarts_sync_statistics" instance="Ebizmarts\MailChimp\Cron\SyncStatistics" method="execute">
             <schedule>0 */1 * * *</schedule>
         </job>
+        <!--
+            The <schedule> is a BOOTSTRAP only. Magento skips a job whose cron
+            expression resolves to nothing (ProcessCronQueueObserver::_generateJobs),
+            and <config_path> alone is empty until the first successful register
+            writes it - which happens inside this very job. Without the bootstrap
+            the job would never run and could never register.
+
+            17 rather than 0 so a not-yet-registered install does not land on the
+            minute the rest of Magento's cron already piles up on. Once registered,
+            config_path takes over and the install keeps its own slot.
+
+            Order matters: crontab.xsd declares schedule then config_path as an
+            xs:sequence.
+        -->
+        <job name="ebizmarts_edge_beacon" instance="Ebizmarts\MailChimp\Cron\EdgeBeacon" method="execute">
+            <schedule>17 * * * *</schedule>
+            <config_path>mailchimp/register/beacon_cron</config_path>
+        </job>
     </group>
 </config>


### PR DESCRIPTION
Adds hourly status reporting to the ebizmarts service, so an installation can be seen as running without anyone opening the admin, and so messages can reach the merchant through Magento's own admin inbox.

## Why

The extension announces itself exactly once. `Model/Config/Source/Details.php` is a configuration source model, so it runs only when an administrator opens the Mailchimp configuration page, and it is gated on `if (!$token)` — it fires once per store view, ever, and then never speaks again.

That cannot tell an installation trading today from one abandoned years ago, it undercounts by construction because it needs a person to open a page, and it leaves no channel to reach the merchant.

## What this adds

An hourly cron branch: **register** once, then **report status** on every tick, and deliver any **notifications** the reply announces into the admin inbox.

| File | Role |
|---|---|
| `Model/Edge/Client` + `Response` | Performs the calls and classifies the outcome |
| `Model/Edge/LivenessSignals` | Is this store syncing, and is it failing — two indexed reads |
| `Model/Edge/Beacon` | Register once, report always, refresh account data twice a day |
| `Model/Edge/NotificationDelivery` | Writes into `adminnotification_inbox` via `NotifierInterface` |
| `Cron/EdgeBeacon` + `etc/crontab.xml` | Hourly entry point |

Everything is additive. The existing registration, the support-log push, the `mailchimp_notification` table and its cleanup, `enable_support` and the XML notification feed are untouched. No `system.xml` entry, no new table, no schema change.

## Decisions worth reviewing

**No customer data leaves the store, by construction.** `mailchimp_errors.errors` holds the raw error body and `mailchimp_notification.notification_data` holds request parameters and responses; both can carry customer details, and neither is ever selected. Only the surrounding facts travel — when, and what kind. A test asserts those columns are not in the select.

**Only a 401 discards the token.** A 429 and a 5xx both leave it untouched — the tick simply stops. `Retry-After` is read and logged but not obeyed: the next attempt is the next hourly tick whatever the header asked for, so nothing here schedules a back-off. If any other status discarded it, one bad deployment on the receiving side would turn into every installation re-registering at once. Tokens also expire, and that arrives as a 401, so expiry needs no separate handling.

**Null handling is asymmetric on purpose.** The receiving side deletes a field on an explicit null and keeps it when the key is absent. The error fields are therefore always present — null when there is no error row — so a recovered store actively clears its previous failure. `last_sync_at` is omitted when it cannot be read, so a transient local problem never erases a good value already held.

**A failing Mailchimp call never suppresses the report.** The account block rides along twice a day; an outage must not make every installation look dead at once.

**The cron entry carries both `<schedule>` and `<config_path>`.** The schedule is a bootstrap, not a duplicate. Magento skips a job whose expression resolves to nothing (`ProcessCronQueueObserver::_generateJobs`), and `config_path` is empty until the first successful registration writes it — which happens inside this very job. With `config_path` alone the job could never run and could never register. `17` rather than `0` so a not-yet-registered install does not land on the minute the rest of Magento's cron already piles up on.

**The minute is written in default scope.** The scheduler reads `config_path` with no store id, so a value written per store view would never be seen and the job would sit on its bootstrap minute forever, looking configured. The first store view to register claims it; later ones leave it alone.

**Notifications degrade rather than fatal.** `NotifierInterface` resolves through `app/etc/di.xml` to the framework's `NotifierPool`, which iterates a list that is empty when `Magento_AdminNotification` is disabled, so every call becomes a no-op.

**Delivery is confirmed.** The ids that reached the inbox are echoed on the next report and cleared only once a report has actually returned 200 — one that never landed has confirmed nothing. The queue appends rather than overwrites, so a batch still awaiting acknowledgement is not dropped by a newer one. Nothing claims the merchant opened anything; only that the message reached the inbox.

## Tests

35 unit tests, 55 assertions: the status matrix (including that a 5xx and a transport failure are **not** treated as auth failures), the account-refresh cadence and that a failing account call still reports, the acknowledgement queue surviving a failed report, the priority mapping, and that no customer-bearing column is selected.

Verified end to end against a live install with the cron running unattended, not only in unit tests.

