### PR TITLE
Keep tests out of release archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Keep development-only paths out of release archives.
+#
+# `export-ignore` applies to `git archive`, which is what GitHub builds release
+# tarballs from and what Composer downloads on a dist install. It does NOT
+# affect `git clone`, so a developer cloning the repo — or an app/code install
+# done by cloning — still gets everything listed here.
+
+/Test               export-ignore
+/.gitattributes     export-ignore


### PR DESCRIPTION
The unit tests ship inside every release tarball and every Composer dist install today, where nothing runs them. They are development material: useful in the repository, dead weight in a merchant's `vendor` directory.

## What changes

A `.gitattributes` marking `/Test` as `export-ignore`.

Measured against `develop-2.4`:

| | Test files in archive | gzipped size |
|---|---|---|
| before | 21 | 230,266 bytes |
| after | 0 | 220,292 bytes |

221 runtime files are still present, `registration.php`, `composer.json`, `LICENSE.txt`, `etc/`, `Model/` and `view/` among them.

## Scope, and what this deliberately does not do

`export-ignore` applies to `git archive`, which is what GitHub builds release tarballs from and what Composer downloads on a dist install. **Cloning is unaffected**, so development workflows — and an `app/code` install done by cloning the repository, which is how the module is often set up for development — still get the tests.

I left the rest of the repository alone. `ISSUE_TEMPLATE.md`, `CONTRIBUTING.md` and `modman` are also arguably repository furniture rather than package content, but excluding them is a separate judgement — `modman` in particular is still a deployment path for some installs and dropping it from an archive would be a behaviour change, not a cleanup. Happy to add any of them if you would rather do it in one pass.

`.gitattributes` excludes itself, since it has no meaning outside the repository.