### PR TITLE
Update PixelStateWriter tests to the behaviour that shipped

### DIFF
--- a/Test/Unit/Model/Service/Pixel/PixelStateWriterTest.php
+++ b/Test/Unit/Model/Service/Pixel/PixelStateWriterTest.php
@@ -45,19 +45,20 @@ class PixelStateWriterTest extends TestCase
         $callOrder = [];
 
         $this->configWriter
-            ->expects($this->exactly(3))
+            ->expects($this->exactly(4))
             ->method('save')
             ->willReturnCallback(function (string $path) use (&$callOrder) {
                 $callOrder[] = $path;
             });
 
-        $this->cacheTypeList->expects($this->once())->method('invalidate')->with('config');
+        $this->cacheTypeList->expects($this->once())->method('cleanType')->with('config');
 
         $this->writer->enable($storeId, $scriptUrl, $scriptFragment);
 
         $this->assertSame(
             [
                 MailChimpHelper::XML_PIXEL_SCRIPT_URL,
+                MailChimpHelper::XML_MAILCHIMP_JS_URL,
                 MailChimpHelper::XML_PIXEL_SCRIPT_FRAGMENT,
                 MailChimpHelper::XML_PIXEL_ENABLED_FOR_STORE,
             ],
@@ -108,7 +109,7 @@ class PixelStateWriterTest extends TestCase
                 $callOrder[] = $path;
             });
 
-        $this->cacheTypeList->expects($this->once())->method('invalidate')->with('config');
+        $this->cacheTypeList->expects($this->once())->method('cleanType')->with('config');
 
         $this->writer->disable($storeId);
 
@@ -139,7 +140,7 @@ class PixelStateWriterTest extends TestCase
     public function testEnableInvalidatesConfigCache(): void
     {
         $this->configWriter->method('save');
-        $this->cacheTypeList->expects($this->once())->method('invalidate')->with('config');
+        $this->cacheTypeList->expects($this->once())->method('cleanType')->with('config');
 
         $this->writer->enable(1, 'https://example.com/pixel.js', '<script></script>');
     }
@@ -147,7 +148,7 @@ class PixelStateWriterTest extends TestCase
     public function testDisableInvalidatesConfigCache(): void
     {
         $this->configWriter->method('save');
-        $this->cacheTypeList->expects($this->once())->method('invalidate')->with('config');
+        $this->cacheTypeList->expects($this->once())->method('cleanType')->with('config');
 
         $this->writer->disable(1);
     }

--- a/Test/Unit/Model/Service/Pixel/PixelStateWriterTest.php
+++ b/Test/Unit/Model/Service/Pixel/PixelStateWriterTest.php
@@ -137,7 +137,7 @@ class PixelStateWriterTest extends TestCase
         $this->assertSame(0,  $saved[MailChimpHelper::XML_PIXEL_ENABLED_FOR_STORE]);
     }
 
-    public function testEnableInvalidatesConfigCache(): void
+    public function testEnableCleansConfigCacheType(): void
     {
         $this->configWriter->method('save');
         $this->cacheTypeList->expects($this->once())->method('cleanType')->with('config');
@@ -145,7 +145,7 @@ class PixelStateWriterTest extends TestCase
         $this->writer->enable(1, 'https://example.com/pixel.js', '<script></script>');
     }
 
-    public function testDisableInvalidatesConfigCache(): void
+    public function testDisableCleansConfigCacheType(): void
     {
         $this->configWriter->method('save');
         $this->cacheTypeList->expects($this->once())->method('cleanType')->with('config');


### PR DESCRIPTION
The last four red tests in the module. Both causes are the test lagging the code, not the code being wrong, so nothing in `Model/` changes here.

## `invalidate` vs `cleanType` — 3 tests

The tests assert `cacheTypeList->invalidate('config')`; the writer calls `cleanType('config')`.

These are not interchangeable. `cleanType` clears the cache; `invalidate` only marks it and keeps serving the stale value until someone refreshes it from the admin. The writer does the one that makes a freshly toggled pixel take effect immediately, which is the behaviour a merchant expects after flipping a switch — so the assertion was demanding the weaker of the two, not catching a defect.

## `enable()` performs four config writes, not three — 1 test

```
mailchimp/pixel/script_url
mailchimp/general/mailchimp_js_url    ← the test never knew about this one
mailchimp/pixel/script_fragment
mailchimp/pixel/enabled_for_store
```

`XML_MAILCHIMP_JS_URL` was added to `enable()` at some point and the test was not updated. The ordering assertion now includes it in its real position.

`disable()` genuinely performs three writes, so its `exactly(3)` is untouched.

## Result

```
OK (75 tests, 149 assertions)
```

The module's unit suite now passes in full for the first time — no errors, no failures. Worth stating plainly: these tests were red on the published `103.4.81` tag, alongside the ones already fixed in #2340, which means the suite is not running in CI. That is the underlying problem and it outlives this PR.