### PR TITLE
Let merchants opt out of sharing account contact details

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -204,6 +204,15 @@
                     </depends>
                 </field>
             </group>
+            <group id="telemetry" translate="label comment" type="text" sortOrder="105" showInDefault="1" showInWebsite="1" showInStore="1">
+                <label>Diagnostics</label>
+                <comment>Helps us find and fix problems with the Mailchimp connection.</comment>
+                <field id="share_contact" translate="label comment" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Include your account contact details</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment><![CDATA[The extension reports how the Mailchimp API is performing for your store &mdash; how many requests were made, how many failed and how long they took &mdash; so problems can be diagnosed without asking you for logs. No customer or order data is ever included. Set this to No to leave the account owner's name and email address out of those reports; everything else keeps working.]]></comment>
+                </field>
+            </group>
             <group id="ecommerce" translate="label" type="text" sortOrder="110" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Ecommerce Configuration</label>
                 <field id="active" translate="label" type="select" sortOrder="110" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -14,6 +14,9 @@
                 <notification_url>https://logs-mc4mage.ebizmarts.com/batches</notification_url>
                 <register_url>https://users-mc4mage.ebizmarts.com</register_url>
             </statistics>
+            <telemetry>
+                <share_contact>1</share_contact>
+            </telemetry>
             <pixel>
                 <enabled_for_store>0</enabled_for_store>
                 <script_url></script_url>


### PR DESCRIPTION
The extension reports how the Mailchimp API is performing for a store — how many requests were made, how many failed, how long they took — so connection problems can be diagnosed without asking the merchant to collect logs. Those reports can carry the account owner's name and email address.

A setting that suppresses that pair is read from configuration, but nothing ever wrote it: no field in `system.xml`, no default in `config.xml`. A merchant could only change it from the command line or with a direct database write, which is a control that exists on paper and not in practice.

## What this adds

| | |
|---|---|
| `etc/adminhtml/system.xml` | a **Diagnostics** group with one Yes/No field, *"Include your account contact details"* |
| `etc/config.xml` | the matching default, `1` |

Path: `mailchimp/telemetry/share_contact`. Scope matches the rest of the section — default, website and store view.

## Two choices worth a look

**The default is Yes rather than absent.** An absent value already reads as on, so declaring it changes nothing functionally. It makes the state visible in the admin rather than implied, and it means a merchant who has never touched the setting sees what it is currently doing.

**Not gated behind the extension being active.** Every other field in the section carries `<depends><field id="*/*/active">1</field></depends>`. This one deliberately does not: a control over what personal data is shared should stay readable and changeable whether or not the integration is currently switched on. Happy to align it with the rest if you would rather be consistent than deliberate here.

## Wording

The comment is written for a merchant rather than for us: it says what is collected, why, and what No actually does — and states plainly that no customer or order data is ever included, because that is the first question the field will raise.

## Verified

`system.xml` validates against `vendor/magento/module-config/etc/system_file.xsd`, and after a cache flush the value resolves through the same generic configuration read the reporting code uses:

```
getConfigValue('mailchimp/telemetry/share_contact', 1) → '1'
```

Returning `'1'` rather than `null` matters: the reading side treats a null as "this extension is too old to know about the setting", never as a merchant saying no.