### PR TITLE
Write a broadcast notification to the inbox once, not once per store view

### DIFF
--- a/Model/Edge/NotificationDelivery.php
+++ b/Model/Edge/NotificationDelivery.php
@@ -53,6 +53,11 @@ class NotificationDelivery
     private $notifier;
 
     /**
+     * @var array uids already written to the inbox by this process
+     */
+    private $written = [];
+
+    /**
      * @param Client            $client
      * @param MailChimpHelper   $helper
      * @param NotifierInterface $notifier
@@ -102,8 +107,10 @@ class NotificationDelivery
                 continue;
             }
 
+            $uid = isset($item['id']) ? (string)$item['id'] : '';
+
             try {
-                $written = $this->deliver($item);
+                $written = $this->deliverOnce($uid, $item);
             } catch (\Exception $e) {
                 // A message we could not write must not be confirmed, so stop
                 // here and let the unconfirmed uid tell the service the truth.
@@ -114,13 +121,18 @@ class NotificationDelivery
             // Only what actually reached the inbox may be acknowledged. A
             // message with no subject is never written, and confirming it
             // would tell the service it was seen when nobody saw it.
+            //
+            // A message suppressed as a duplicate IS acknowledged, and must be:
+            // it did reach the inbox, once. The service tracks delivery per
+            // store view, so every view has to confirm its own copy or it will
+            // keep offering the same message forever.
             if (!$written) {
                 continue;
             }
 
             // `id` IS the opaque delivery_uid on the wire.
-            if (isset($item['id']) && $item['id'] !== '') {
-                $delivered[] = (string)$item['id'];
+            if ($uid !== '') {
+                $delivered[] = $uid;
             }
         }
 
@@ -201,6 +213,50 @@ class NotificationDelivery
         }
 
         return [];
+    }
+
+    /**
+     * Write a notification to the inbox unless this process already has.
+     *
+     * The service addresses store views, not installations — every target but
+     * a single-view one fans out, so one message arrives once per registered
+     * view of the same install. Magento's inbox is install-wide and has no
+     * scope column, so writing each arrival would put the same message in the
+     * merchant's bell N times.
+     *
+     * Deduplication is per process, which covers the normal case exactly: one
+     * cron run walks every store view. It does not cover views handled by
+     * separate processes.
+     *
+     * Checking the inbox itself instead would cover that, but it cannot be done
+     * through NotifierInterface. Inbox::add() always sets an `internal` key, and
+     * Inbox::parse() skips its duplicate lookup whenever that key is set — so
+     * the notifier never deduplicates. Passing null to reach the other branch
+     * hits `Unknown column 'internal'`, because parse() only unsets the key on
+     * the branch it did not take. Querying the table directly would work, but
+     * would cost the property that made NotifierInterface the right choice
+     * here: it degrades to doing nothing when Magento_AdminNotification is
+     * disabled, rather than fataling.
+     *
+     * @param  string $uid  delivery uid, stable across the views of one message
+     * @param  array  $item
+     * @return bool   whether the merchant now has this message
+     */
+    private function deliverOnce($uid, array $item)
+    {
+        if ($uid !== '' && isset($this->written[$uid])) {
+            return true;
+        }
+
+        if (!$this->deliver($item)) {
+            return false;
+        }
+
+        if ($uid !== '') {
+            $this->written[$uid] = true;
+        }
+
+        return true;
     }
 
     /**

--- a/Test/Unit/Model/Edge/NotificationDeliveryTest.php
+++ b/Test/Unit/Model/Edge/NotificationDeliveryTest.php
@@ -254,4 +254,79 @@ class NotificationDeliveryTest extends TestCase
         (new NotificationDelivery($client, $helper, $this->createMock(NotifierInterface::class)))
             ->handle(1, 'token', ['notifications' => 2], []);
     }
+
+    /**
+     * The service addresses store views, so one message arrives once per
+     * registered view of the same install. Magento's inbox is install-wide,
+     * so writing every arrival would put the same message in the bell N times.
+     */
+    public function testTheSameMessageIsWrittenToTheInboxOnlyOnce(): void
+    {
+        $client = $this->createMock(Client::class);
+        $client->method('pullNotifications')->willReturn(
+            new Response(Response::OK, 200, ['notifications' => [$this->wireItem('notice', 'uid-broadcast')]])
+        );
+
+        $notifier = $this->createMock(NotifierInterface::class);
+        $notifier->expects($this->once())->method('addNotice');
+
+        $delivery = new NotificationDelivery($client, $this->createMock(MailChimpHelper::class), $notifier);
+
+        // Five store views of one install, one cron process, same message.
+        foreach ([1, 2, 3, 4, 5] as $storeId) {
+            $delivery->handle($storeId, 'token', ['notifications' => 1], []);
+        }
+    }
+
+    /**
+     * A suppressed duplicate must still be acknowledged. It did reach the
+     * inbox once, and the service tracks delivery per store view — a view that
+     * never confirms is offered the same message forever.
+     */
+    public function testASuppressedDuplicateIsStillAcknowledgedByEveryStoreView(): void
+    {
+        $client = $this->createMock(Client::class);
+        $client->method('pullNotifications')->willReturn(
+            new Response(Response::OK, 200, ['notifications' => [$this->wireItem('notice', 'uid-broadcast')]])
+        );
+
+        $acked = [];
+        $helper = $this->createMock(MailChimpHelper::class);
+        $helper->method('saveConfigValue')->willReturnCallback(
+            function ($path, $value, $storeId) use (&$acked) {
+                $acked[] = $storeId;
+            }
+        );
+
+        $delivery = new NotificationDelivery($client, $helper, $this->createMock(NotifierInterface::class));
+
+        foreach ([1, 2, 3] as $storeId) {
+            $delivery->handle($storeId, 'token', ['notifications' => 1], []);
+        }
+
+        $this->assertSame([1, 2, 3], $acked, 'every store view has to confirm its own copy');
+    }
+
+    /**
+     * Suppression is by uid, not by content — two genuinely different messages
+     * must both reach the merchant even in the same run.
+     */
+    public function testDifferentMessagesAreNotSuppressed(): void
+    {
+        $client = $this->createMock(Client::class);
+        $client->method('pullNotifications')->willReturn(
+            new Response(
+                Response::OK,
+                200,
+                ['notifications' => [$this->wireItem('notice', 'uid-a'), $this->wireItem('notice', 'uid-b')]]
+            )
+        );
+
+        $notifier = $this->createMock(NotifierInterface::class);
+        $notifier->expects($this->exactly(2))->method('addNotice');
+
+        (new NotificationDelivery($client, $this->createMock(MailChimpHelper::class), $notifier))
+            ->handle(1, 'token', ['notifications' => 2], []);
+    }
+
 }


### PR DESCRIPTION
Closes review point 6 of the hourly-beacon PR (#2341).

**Stacked on that branch, not on `develop-2.4`**, because the class it changes is introduced there and does not exist on the base branch yet. Once #2341 merges this can be retargeted; until then the diff only makes sense against it.

## The problem

The reporting service addresses **store views, not installations**. Its identity is derived per view, so five views are five rows, five tokens and five pulls, and every message target except a single-view one fans out across them.

Magento's `adminnotification_inbox` is install-wide — it has no `store_id` or `website_id` column at all:

```
notification_id  severity  date_added  title  description  url  is_read  is_remove
```

So a message aimed at an account, or at everyone, was written once per view and the merchant saw the same entry in the bell N times.

## Why this side

Targeting one view per install is not something the service can do — it has no concept of a Magento installation, and nothing it holds reconstructs one without guessing. A wrong guess is worse than a duplicate: the message lands on a view nobody reads, or on another merchant on shared hosting. The extension knows which views are one install for free, because it *is* the install.

## The fix

Delivery uids are stable across the views of one message, so the run remembers what it has written and skips repeats. That covers the normal case exactly — one cron process walks every store view.

**A suppressed duplicate is still acknowledged**, and that matters: it did reach the inbox, once. The service tracks delivery per view, so a view that never confirms would be offered the same message forever. Suppressing the write and the ack together would trade a visible bug for an invisible one.

## Why not check the inbox instead

That would also cover views handled by separate processes, which per-process dedupe does not. It cannot be done through `NotifierInterface`:

```php
if (isset($item['internal'])) {
    $row = false;          // skips the duplicate lookup
    unset($item['internal']);
} else {
    $row = $connection->fetchRow($select);
}
if (!$row) {
    $connection->insert($this->getMainTable(), $item);
}
```

`Inbox::add()` always sets `internal`, so the notifier **never** deduplicates — verified: five identical `addNotice()` calls produce five rows. Passing `null` to reach the other branch fails with `Unknown column 'internal'`, because `parse()` only unsets the key on the branch it did not take. The lookup is reachable only from `Inbox::parse()` called directly with items that have no `internal` key, which is what the RSS feed does.

Querying the table directly would work, but would cost the property that made `NotifierInterface` the right choice: it degrades to doing nothing when `Magento_AdminNotification` is disabled, rather than fataling.

## Tests

Three, and I'd rather be precise about what each proves:

- one message across five store views reaches the inbox once — **fails against the code before this change** (`addNotice` invoked 5 times, expected 1);
- every view still acknowledges its own copy — passes either way, guarding against fixing the duplicate by breaking the ack;
- two genuinely different messages are both delivered — passes either way, guarding against over-suppressing.

**124 tests, 231 assertions, green.**

## Known limit

Per-process dedupe does not cover store views processed by separate cron processes. That is the case the inbox check would have caught, and it is left open deliberately rather than solved by giving up the graceful degradation. Notification volume is zero today; worth revisiting if that changes.