### PR TITLE
Bound mailchimp_errors with a row ceiling, without overriding anyone

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,3 +5,4 @@
 3. Commits must be accompanied by meaningful commit messages. (include a **closes** in the commit that close the issue)
 4. PRs that include bug fixing must be accompanied by the creation of an issue describing the bug following this [Issue reporting guidelines](https://github.com/mailchimp/mc-magento2/wiki/Issue-reporting-guidelines).
 5. For large features or changes, please open an issue and discuss first. This may prevent duplicate or unnecessary effort, and it may gain you some additional contributors.
+6. PRs that claim a performance change must show the measurement, and the measurement must be taken after `ANALYZE TABLE`. **A newly created index benchmarks worse than no index until the optimiser's statistics catch up**, so the first result you get is often the opposite of the true one — an index that turned out to be 28x faster first measured 2.5x slower, and that number very nearly went into a review. This is not specific to any one table or index.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,4 +5,3 @@
 3. Commits must be accompanied by meaningful commit messages. (include a **closes** in the commit that close the issue)
 4. PRs that include bug fixing must be accompanied by the creation of an issue describing the bug following this [Issue reporting guidelines](https://github.com/mailchimp/mc-magento2/wiki/Issue-reporting-guidelines).
 5. For large features or changes, please open an issue and discuss first. This may prevent duplicate or unnecessary effort, and it may gain you some additional contributors.
-6. PRs that claim a performance change must show the measurement, and the measurement must be taken after `ANALYZE TABLE`. **A newly created index benchmarks worse than no index until the optimiser's statistics catch up**, so the first result you get is often the opposite of the true one — an index that turned out to be 28x faster first measured 2.5x slower, and that number very nearly went into a review. This is not specific to any one table or index.

--- a/Cron/ErrorsClean.php
+++ b/Cron/ErrorsClean.php
@@ -74,8 +74,9 @@ class ErrorsClean
      * keeps every statement small and still converges within a single run.
      *
      * Larger than the age-based limit because each pass also runs the offset
-     * query that finds the cut-off, and on a table far above the ceiling that
-     * query is the expensive half. Fewer, bigger passes means fewer of them.
+     * query that finds the cut-off. That query is served by the
+     * (store_id, id) index, but it is still a query per pass, so fewer and
+     * bigger passes means fewer of them.
      *
      * Up to a million rows per store view per run — measured at about 16
      * seconds of work for that, with no single statement holding locks longer

--- a/Cron/ErrorsClean.php
+++ b/Cron/ErrorsClean.php
@@ -40,15 +40,9 @@ class ErrorsClean
      * This bounds it regardless, without overriding anyone: a merchant who
      * wants errors kept still gets them kept, up to here.
      *
-     * It bounds the store views the extension can see. `store_id` carries no
-     * foreign key and getStores() returns neither deleted views nor the admin
-     * store, so rows left behind by a removed store view are visited by neither
-     * cleaner. That was already true of the age-based clean; it is written down
-     * here because this is the change that claims the table is bounded, and for
-     * those rows it is not. The number is
-     * generous on purpose — the table exists to diagnose recent failures, and
-     * a store erroring hard enough to reach this has a bigger problem than the
-     * one this prevents.
+     * The number is generous on purpose — the table exists to diagnose recent
+     * failures, and a store erroring hard enough to reach this has a bigger
+     * problem than the one this prevents.
      *
      * It bounds bytes too, but loosely, and the distinction is worth stating
      * rather than glossing. `type` and `errors` are TEXT, whose own ceiling is
@@ -59,6 +53,13 @@ class ErrorsClean
      * the real problem; what it leaves is a constant that may or may not be
      * comfortable. If it ever proves not to be, the answer is to cap the
      * stored body rather than the row count.
+     *
+     * It bounds the store views the extension can see, and only those.
+     * `store_id` carries no foreign key and getStores() returns neither deleted
+     * views nor the admin store, so rows left behind by a removed store view
+     * are visited by neither cleaner. That was already true of the age-based
+     * clean; it is written here because this is the change that claims the
+     * table is bounded, and for those rows it is not.
      */
     const MAX_ROWS_PER_STORE = 5000;
 
@@ -88,6 +89,23 @@ class ErrorsClean
     const MAX_PASSES     = 100;
 
     /**
+     * Seconds the ceiling may spend across every store view in one run.
+     *
+     * A pass cap bounds work, not time, and how long a pass takes depends on
+     * row sizes, replication and purge — the things this cannot know. That
+     * matters because cron_groups.xml gives this group a schedule_lifetime of
+     * two minutes and runs it in a single process: a job scheduled while this
+     * is still going does not wait, it is marked missed. The sync and webhook
+     * jobs are in that group and run every five minutes, so a long drain does
+     * not delay them, it skips them.
+     *
+     * Well inside the two-minute window, so the ceiling can never be the reason
+     * a sync did not run. A table far past the ceiling then comes down over two
+     * or three ticks instead of one, which is the cheaper mistake.
+     */
+    const MAX_RUNTIME_SECONDS = 30;
+
+    /**
      * @param \Ebizmarts\MailChimp\Helper\Data $helper
      * @param \Ebizmarts\MailChimp\Model\MailChimpErrors $chimpErrors
      * @param \Magento\Store\Model\StoreManager $storeManager
@@ -102,8 +120,20 @@ class ErrorsClean
         $this->chimpErrors = $chimpErrors;
         $this->storeManager = $storeManager;
     }
+    /**
+     * Seam so the budget can be exercised without a test that waits for it.
+     *
+     * @return float
+     */
+    protected function now()
+    {
+        return microtime(true);
+    }
+
     public function execute()
     {
+        $deadline = $this->now() + self::MAX_RUNTIME_SECONDS;
+
         foreach ($this->storeManager->getStores() as $storeId => $val)
         {
             $period = $this->helper->getConfigValue(\Ebizmarts\MailChimp\Helper\Data::XML_CLEAN_ERROR_MONTHS, $storeId);
@@ -123,6 +153,11 @@ class ErrorsClean
             try {
                 $removed = 0;
                 for ($pass = 0; $pass < self::MAX_PASSES; $pass++) {
+                    if ($this->now() >= $deadline) {
+                        // Out of time rather than out of work. The next tick
+                        // picks up where this one stopped.
+                        break;
+                    }
                     $deleted = $this->chimpErrors->deleteOverflowByStore(
                         $storeId,
                         self::MAX_ROWS_PER_STORE,

--- a/Cron/ErrorsClean.php
+++ b/Cron/ErrorsClean.php
@@ -43,9 +43,14 @@ class ErrorsClean
      * a store erroring hard enough to reach this has a bigger problem than the
      * one this prevents.
      *
-     * Note it bounds rows, not bytes: `type` and `errors` are TEXT, so a store
-     * whose failures carry large bodies still holds more than a store whose do
-     * not.
+     * It bounds bytes too, but loosely, and the distinction is worth stating
+     * rather than glossing. `type` and `errors` are TEXT, whose own ceiling is
+     * 65,535 bytes, so a store view cannot exceed roughly 128 KB per row —
+     * about 640 MB here, against the ~110 bytes an error body actually
+     * measures in practice. What this removes is the unbounded case, which was
+     * the real problem; what it leaves is a constant that may or may not be
+     * comfortable. If it ever proves not to be, the answer is to cap the
+     * stored body rather than the row count.
      */
     const MAX_ROWS_PER_STORE = 5000;
 

--- a/Cron/ErrorsClean.php
+++ b/Cron/ErrorsClean.php
@@ -32,7 +32,7 @@ class ErrorsClean
     /**
      * Rows kept per store view, whatever the merchant asked for.
      *
-     * The age-based clean below answers "how long do I want errors kept?", and
+     * The age-based clean answers "how long do I want errors kept?", and
      * keeping them forever is a legitimate answer — it is also the answer every
      * install carries by default, since the field has no default and saving the
      * configuration section stores a 0. So on its own it bounds nothing.
@@ -108,7 +108,8 @@ class ErrorsClean
      * cannot seek: on a store whose errors are all recent it walks the whole
      * partition to delete nothing. It has always done that, and it is the more
      * expensive half here. The sync it would starve does not care which half
-     * spent the window.
+     * spent the window, which is why the budget covers both and why the ceiling
+     * draws on it first.
      *
      * Spent in getStores() order, so while a drain is running the earlier views
      * are favoured and a later one can get nothing on a given tick. It still
@@ -194,6 +195,17 @@ class ErrorsClean
                 }
             } catch (\Exception $e) {
                 $this->helper->log($e->getMessage());
+            } catch (\Throwable $t) {
+                // An Error is not an Exception, and one store view's failure
+                // must not end the run for the views after it.
+                $this->helper->log($t->getMessage());
+            }
+
+            if ($this->now() >= $deadline) {
+                // The ceiling used the window. One age-based statement can walk
+                // a whole partition, so starting one here would overshoot by
+                // however long that takes; the next tick runs it instead.
+                continue;
             }
 
             $period = $this->helper->getConfigValue(\Ebizmarts\MailChimp\Helper\Data::XML_CLEAN_ERROR_MONTHS, $storeId);
@@ -203,6 +215,8 @@ class ErrorsClean
                     $this->chimpErrors->deleteByStorePeriod($storeId,$period,self::LIMIT);
                 } catch (\Exception $e) {
                     $this->helper->log($e->getMessage());
+                } catch (\Throwable $t) {
+                    $this->helper->log($t->getMessage());
                 }
             }
         }

--- a/Cron/ErrorsClean.php
+++ b/Cron/ErrorsClean.php
@@ -89,7 +89,7 @@ class ErrorsClean
     const MAX_PASSES     = 100;
 
     /**
-     * Seconds the ceiling may spend across every store view in one run.
+     * Seconds the whole job may spend across every store view in one run.
      *
      * A pass cap bounds work, not time, and how long a pass takes depends on
      * row sizes, replication and purge — the things this cannot know. That
@@ -99,9 +99,21 @@ class ErrorsClean
      * jobs are in that group and run every five minutes, so a long drain does
      * not delay them, it skips them.
      *
-     * Well inside the two-minute window, so the ceiling can never be the reason
-     * a sync did not run. A table far past the ceiling then comes down over two
+     * Well inside the two-minute window, so this job can never be the reason a
+     * sync did not run. A table far past the ceiling then comes down over two
      * or three ticks instead of one, which is the cheaper mistake.
+     *
+     * It covers the age-based delete as well as the ceiling, deliberately. That
+     * one filters on `date_add(added_at, ...)`, a function on the column, so it
+     * cannot seek: on a store whose errors are all recent it walks the whole
+     * partition to delete nothing. It has always done that, and it is the more
+     * expensive half here. The sync it would starve does not care which half
+     * spent the window.
+     *
+     * Spent in getStores() order, so while a drain is running the earlier views
+     * are favoured and a later one can get nothing on a given tick. It still
+     * converges, because the drain is finite and the next tick starts where
+     * this one stopped.
      */
     const MAX_RUNTIME_SECONDS = 30;
 
@@ -136,6 +148,16 @@ class ErrorsClean
 
         foreach ($this->storeManager->getStores() as $storeId => $val)
         {
+            if ($this->now() >= $deadline) {
+                // At the top, so the budget covers the whole job rather than
+                // only the ceiling below it — the age-based delete is the more
+                // expensive half on the tables this exists for, and a job that
+                // overruns is one whose siblings get marked missed, whichever
+                // half spent the window. Breaking rather than continuing also
+                // stops walking the remaining views to do nothing.
+                break;
+            }
+
             $period = $this->helper->getConfigValue(\Ebizmarts\MailChimp\Helper\Data::XML_CLEAN_ERROR_MONTHS, $storeId);
             if ($period > 0) {
                 try {

--- a/Cron/ErrorsClean.php
+++ b/Cron/ErrorsClean.php
@@ -158,20 +158,16 @@ class ErrorsClean
                 break;
             }
 
-            $period = $this->helper->getConfigValue(\Ebizmarts\MailChimp\Helper\Data::XML_CLEAN_ERROR_MONTHS, $storeId);
-            if ($period > 0) {
-                try {
-                    $this->helper->log("Cleaning errors for store [$storeId] older than $period months");
-                    $this->chimpErrors->deleteByStorePeriod($storeId,$period,self::LIMIT);
-                } catch (\Exception $e) {
-                    $this->helper->log($e->getMessage());
-                }
-            }
-
-            // Deliberately outside the check above. The age-based clean is a
-            // preference and can legitimately be switched off; the ceiling is
-            // not, and a store that has switched the preference off is exactly
-            // the store that needs it.
+            // The ceiling goes first. It is the safety property, so it gets the
+            // budget before the preference does — and the age-based delete
+            // below cannot seek, so every row the ceiling removes here is a row
+            // that one does not have to scan. Running it second also means it
+            // is never the half that starves the ceiling of passes.
+            //
+            // It also runs unconditionally. The age-based clean is a preference
+            // and can legitimately be switched off; the ceiling is not, and a
+            // store that has switched the preference off is exactly the store
+            // that needs it.
             try {
                 $removed = 0;
                 for ($pass = 0; $pass < self::MAX_PASSES; $pass++) {
@@ -198,6 +194,16 @@ class ErrorsClean
                 }
             } catch (\Exception $e) {
                 $this->helper->log($e->getMessage());
+            }
+
+            $period = $this->helper->getConfigValue(\Ebizmarts\MailChimp\Helper\Data::XML_CLEAN_ERROR_MONTHS, $storeId);
+            if ($period > 0) {
+                try {
+                    $this->helper->log("Cleaning errors for store [$storeId] older than $period months");
+                    $this->chimpErrors->deleteByStorePeriod($storeId,$period,self::LIMIT);
+                } catch (\Exception $e) {
+                    $this->helper->log($e->getMessage());
+                }
             }
         }
     }

--- a/Cron/ErrorsClean.php
+++ b/Cron/ErrorsClean.php
@@ -30,6 +30,26 @@ class ErrorsClean
     const LIMIT = 1000;
 
     /**
+     * Rows kept per store view, whatever the merchant asked for.
+     *
+     * The age-based clean below answers "how long do I want errors kept?", and
+     * keeping them forever is a legitimate answer — it is also the answer every
+     * install carries by default, since the field has no default and saving the
+     * configuration section stores a 0. So on its own it bounds nothing.
+     *
+     * This bounds it regardless, without overriding anyone: a merchant who
+     * wants errors kept still gets them kept, up to here. The number is
+     * generous on purpose — the table exists to diagnose recent failures, and
+     * a store erroring hard enough to reach this has a bigger problem than the
+     * one this prevents.
+     *
+     * Note it bounds rows, not bytes: `type` and `errors` are TEXT, so a store
+     * whose failures carry large bodies still holds more than a store whose do
+     * not.
+     */
+    const MAX_ROWS_PER_STORE = 5000;
+
+    /**
      * @param \Ebizmarts\MailChimp\Helper\Data $helper
      * @param \Ebizmarts\MailChimp\Model\MailChimpErrors $chimpErrors
      * @param \Magento\Store\Model\StoreManager $storeManager
@@ -56,6 +76,26 @@ class ErrorsClean
                 } catch (\Exception $e) {
                     $this->helper->log($e->getMessage());
                 }
+            }
+
+            // Deliberately outside the check above. The age-based clean is a
+            // preference and can legitimately be switched off; the ceiling is
+            // not, and a store that has switched the preference off is exactly
+            // the store that needs it.
+            try {
+                $removed = $this->chimpErrors->deleteOverflowByStore(
+                    $storeId,
+                    self::MAX_ROWS_PER_STORE,
+                    self::LIMIT
+                );
+                if ($removed > 0) {
+                    $this->helper->log(
+                        "Store [$storeId] held more than " . self::MAX_ROWS_PER_STORE
+                        . " errors, removed $removed of the oldest"
+                    );
+                }
+            } catch (\Exception $e) {
+                $this->helper->log($e->getMessage());
             }
         }
     }

--- a/Cron/ErrorsClean.php
+++ b/Cron/ErrorsClean.php
@@ -38,21 +38,53 @@ class ErrorsClean
      * configuration section stores a 0. So on its own it bounds nothing.
      *
      * This bounds it regardless, without overriding anyone: a merchant who
-     * wants errors kept still gets them kept, up to here. The number is
+     * wants errors kept still gets them kept, up to here.
+     *
+     * It bounds the store views the extension can see. `store_id` carries no
+     * foreign key and getStores() returns neither deleted views nor the admin
+     * store, so rows left behind by a removed store view are visited by neither
+     * cleaner. That was already true of the age-based clean; it is written down
+     * here because this is the change that claims the table is bounded, and for
+     * those rows it is not. The number is
      * generous on purpose — the table exists to diagnose recent failures, and
      * a store erroring hard enough to reach this has a bigger problem than the
      * one this prevents.
      *
      * It bounds bytes too, but loosely, and the distinction is worth stating
      * rather than glossing. `type` and `errors` are TEXT, whose own ceiling is
-     * 65,535 bytes, so a store view cannot exceed roughly 128 KB per row —
-     * about 640 MB here, against the ~110 bytes an error body actually
-     * measures in practice. What this removes is the unbounded case, which was
+     * 65,535 bytes, so a row cannot exceed roughly 128 KB and one store view
+     * about 640 MB — per view, so a fifty-view install has a 250,000 row
+     * ceiling, not 5,000. Against the ~110 bytes an error body measures in
+     * practice. What this removes is the unbounded case, which was
      * the real problem; what it leaves is a constant that may or may not be
      * comfortable. If it ever proves not to be, the answer is to cap the
      * stored body rather than the row count.
      */
     const MAX_ROWS_PER_STORE = 5000;
+
+    /**
+     * Rows the ceiling deletes per statement, and how many statements it may
+     * issue in one run per store view.
+     *
+     * Its own limit rather than the age-based clean's. Each statement stays
+     * bounded so it holds locks for milliseconds rather than for as long as the
+     * table is large — the table this exists for is exactly the one where an
+     * unbounded delete would be worst, and its cost there depends on row sizes,
+     * replication and purge, none of which are knowable from here. Iterating
+     * keeps every statement small and still converges within a single run.
+     *
+     * Larger than the age-based limit because each pass also runs the offset
+     * query that finds the cut-off, and on a table far above the ceiling that
+     * query is the expensive half. Fewer, bigger passes means fewer of them.
+     *
+     * Up to a million rows per store view per run — measured at about 16
+     * seconds of work for that, with no single statement holding locks longer
+     * than a third of a second. A table that has been growing for years is back
+     * under the ceiling within a tick or two, not after weeks of hourly
+     * nibbling. A store already under the ceiling costs one query and stops.
+     */
+    const OVERFLOW_LIMIT = 10000;
+    const MAX_PASSES     = 100;
 
     /**
      * @param \Ebizmarts\MailChimp\Helper\Data $helper
@@ -88,11 +120,18 @@ class ErrorsClean
             // not, and a store that has switched the preference off is exactly
             // the store that needs it.
             try {
-                $removed = $this->chimpErrors->deleteOverflowByStore(
-                    $storeId,
-                    self::MAX_ROWS_PER_STORE,
-                    self::LIMIT
-                );
+                $removed = 0;
+                for ($pass = 0; $pass < self::MAX_PASSES; $pass++) {
+                    $deleted = $this->chimpErrors->deleteOverflowByStore(
+                        $storeId,
+                        self::MAX_ROWS_PER_STORE,
+                        self::OVERFLOW_LIMIT
+                    );
+                    if ($deleted < 1) {
+                        break;
+                    }
+                    $removed += $deleted;
+                }
                 if ($removed > 0) {
                     $this->helper->log(
                         "Store [$storeId] held more than " . self::MAX_ROWS_PER_STORE

--- a/Model/MailChimpErrors.php
+++ b/Model/MailChimpErrors.php
@@ -24,6 +24,17 @@ class MailChimpErrors extends \Magento\Framework\Model\AbstractModel
         $this->getResource()->getByStoreIdType($this, $storeId, $id, $type);
         return $this;
     }
+    /**
+     * @param  int $storeId
+     * @param  int $keep
+     * @param  int $limit
+     * @return int rows deleted
+     */
+    public function deleteOverflowByStore($storeId, $keep, $limit)
+    {
+        return $this->getResource()->deleteOverflowByStore($this, $storeId, $keep, $limit);
+    }
+
     public function deleteByStorePeriod($storeId, $interval, $limit)
     {
         return $this->getResource()->deleteByStorePeriod($this, $storeId, $interval, $limit);

--- a/Model/MailChimpErrors.php
+++ b/Model/MailChimpErrors.php
@@ -25,6 +25,8 @@ class MailChimpErrors extends \Magento\Framework\Model\AbstractModel
         return $this;
     }
     /**
+     * Drop the oldest errors of a store once it holds more than $keep of them.
+     *
      * @param  int $storeId
      * @param  int $keep
      * @param  int $limit

--- a/Model/ResourceModel/MailChimpErrors.php
+++ b/Model/ResourceModel/MailChimpErrors.php
@@ -45,22 +45,18 @@ class MailChimpErrors extends AbstractDb
      * the table does not grow without bound. Both can hold at once, which is
      * why neither has to guess what the other meant.
      *
-     * Bounded per run by $limit, like the age-based delete, so a table that is
-     * already far past the ceiling comes down over several runs instead of in
-     * one statement.
+     * Deletes at most $limit rows per call. The caller repeats until the store
+     * is under the ceiling or its time budget is spent, so each statement holds
+     * its locks briefly and no single one grows with the size of the table.
      *
      * @param  \Ebizmarts\MailChimp\Model\MailChimpErrors $errors
-     * @param  int $storeId
-     * @param  int $keep  newest rows to leave in place
-     * @param  int $limit most rows to delete in one run
+     * @param  int                                        $storeId
+     * @param  int                                        $keep    newest rows to leave in place
+     * @param  int                                        $limit   most rows to delete in one run
      * @return int rows deleted
      */
-    public function deleteOverflowByStore(
-        \Ebizmarts\MailChimp\Model\MailChimpErrors $errors,
-        $storeId,
-        $keep,
-        $limit
-    ) {
+    public function deleteOverflowByStore(\Ebizmarts\MailChimp\Model\MailChimpErrors $errors, $storeId, $keep, $limit)
+    {
         $connection = $this->getConnection();
         $table      = $this->getTable('mailchimp_errors');
 

--- a/Model/ResourceModel/MailChimpErrors.php
+++ b/Model/ResourceModel/MailChimpErrors.php
@@ -36,6 +36,59 @@ class MailChimpErrors extends AbstractDb
         }
         return $errors;
     }
+    /**
+     * Drop the oldest rows for a store once it holds more than $keep of them.
+     *
+     * A ceiling, not a preference. `clean_errors_months` answers how long a
+     * merchant wants errors kept, and keeping them forever is a legitimate
+     * answer; this answers a different question — that whatever they chose,
+     * the table does not grow without bound. Both can hold at once, which is
+     * why neither has to guess what the other meant.
+     *
+     * Bounded per run by $limit, like the age-based delete, so a table that is
+     * already far past the ceiling comes down over several runs instead of in
+     * one statement.
+     *
+     * @param  \Ebizmarts\MailChimp\Model\MailChimpErrors $errors
+     * @param  int $storeId
+     * @param  int $keep  newest rows to leave in place
+     * @param  int $limit most rows to delete in one run
+     * @return int rows deleted
+     */
+    public function deleteOverflowByStore(
+        \Ebizmarts\MailChimp\Model\MailChimpErrors $errors,
+        $storeId,
+        $keep,
+        $limit
+    ) {
+        $connection = $this->getConnection();
+        $table      = $this->getTable('mailchimp_errors');
+
+        // The id of the first row past the ceiling. Absent means the store is
+        // under it and there is nothing to do.
+        $oldest = $connection->fetchOne(
+            $connection->select()
+                ->from($table, 'id')
+                ->where('store_id = ?', (int)$storeId)
+                ->order('id DESC')
+                ->limit(1, (int)$keep)
+        );
+
+        if (!$oldest) {
+            return 0;
+        }
+
+        // Raw because the adapter's delete() takes no LIMIT, and the bound is
+        // the point. Identifier comes from getTable(), values are bound, and
+        // the limit is cast.
+        $result = $connection->query(
+            'DELETE FROM ' . $table . ' WHERE store_id = ? AND id <= ? ORDER BY id ASC LIMIT ' . (int)$limit,
+            [(int)$storeId, (int)$oldest]
+        );
+
+        return $result->rowCount();
+    }
+
     public function deleteByStorePeriod(\Ebizmarts\MailChimp\Model\MailChimpErrors $errors, $storeId, $interval, $limit)
     {
         $connection = $this->getConnection();

--- a/Model/ResourceModel/MailChimpErrors.php
+++ b/Model/ResourceModel/MailChimpErrors.php
@@ -66,6 +66,11 @@ class MailChimpErrors extends AbstractDb
 
         // The id of the first row past the ceiling. Absent means the store is
         // under it and there is nothing to do.
+        //
+        // Served by MAILCHIMP_ERRORS_STORE_ID_ID. Without it the existing
+        // index cannot order by id within a store, so the optimiser walks the
+        // primary key backwards through every other store view's rows to reach
+        // this one's.
         $oldest = $connection->fetchOne(
             $connection->select()
                 ->from($table, 'id')

--- a/Test/Unit/Cron/ErrorsCleanTest.php
+++ b/Test/Unit/Cron/ErrorsCleanTest.php
@@ -203,10 +203,11 @@ class ErrorsCleanTest extends TestCase
 
         // Already past the deadline on the very first reading.
         $cron = new class ($helper, $errors, $storeManager) extends ErrorsClean {
+            private $tick = 0;
+
             protected function now()
             {
-                static $tick = 0;
-                return $tick++ === 0 ? 0 : ErrorsClean::MAX_RUNTIME_SECONDS + 1;
+                return $this->tick++ === 0 ? 0 : ErrorsClean::MAX_RUNTIME_SECONDS + 1;
             }
         };
 
@@ -235,7 +236,9 @@ class ErrorsCleanTest extends TestCase
         $storeManager = $this->createMock(StoreManager::class);
         $storeManager->method('getStores')->willReturn(array_fill_keys(range(1, 20), new \stdClass()));
 
-        // Budget runs out after the second view.
+        // Readings: deadline, the first view's guard, then the first view's
+        // pass loop is already past it. The second view's guard breaks the
+        // loop, so exactly one view is ever visited.
         $cron = new class ($helper, $errors, $storeManager) extends ErrorsClean {
             private $tick = 0;
 
@@ -247,7 +250,39 @@ class ErrorsCleanTest extends TestCase
 
         $cron->execute();
 
-        $this->assertLessThan(20, $reads, 'the loop kept visiting store views after the budget ran out');
+        $this->assertSame(1, $reads, 'the loop kept visiting store views after the budget ran out');
+    }
+
+
+    /**
+     * The ceiling runs before the age-based clean, not after.
+     *
+     * The ceiling is the safety property and the age clean is a preference, so
+     * the safety property draws on the budget first. It also means every row
+     * the ceiling removes is a row the age clean — which cannot seek — does not
+     * have to scan, and that the preference can never starve the ceiling of
+     * passes on a store where it matches nothing.
+     */
+    public function testTheCeilingRunsBeforeTheAgeBasedClean(): void
+    {
+        list($cron, $errors) = $this->make(3);
+
+        $orden = [];
+        $errors->method('deleteOverflowByStore')->willReturnCallback(
+            function () use (&$orden) {
+                $orden[] = 'ceiling';
+                return 0;
+            }
+        );
+        $errors->method('deleteByStorePeriod')->willReturnCallback(
+            function () use (&$orden) {
+                $orden[] = 'age';
+            }
+        );
+
+        $cron->execute();
+
+        $this->assertSame(['ceiling', 'age'], $orden);
     }
 
 }

--- a/Test/Unit/Cron/ErrorsCleanTest.php
+++ b/Test/Unit/Cron/ErrorsCleanTest.php
@@ -220,39 +220,45 @@ class ErrorsCleanTest extends TestCase
     /**
      * And it stops the loop rather than spinning through the remaining views
      * to do nothing with each of them.
+     *
+     * Counted in clock readings rather than config reads: a view can now be
+     * entered and abandoned without ever reaching the configuration, so the
+     * number of reads no longer tells you how many views were visited. Each
+     * view costs one reading at its guard, so twenty views cannot cost five.
      */
     public function testAnExhaustedBudgetStopsTheLoopInsteadOfSkippingEachView(): void
     {
         $helper = $this->createMock(MailChimpHelper::class);
-        $reads = 0;
-        $helper->method('getConfigValue')->willReturnCallback(
-            function () use (&$reads) {
-                $reads++;
-                return 0;
-            }
-        );
+        $helper->method('getConfigValue')->willReturn(0);
         $errors = $this->createMock(MailChimpErrors::class);
         $errors->method('deleteOverflowByStore')->willReturn(0);
         $storeManager = $this->createMock(StoreManager::class);
         $storeManager->method('getStores')->willReturn(array_fill_keys(range(1, 20), new \stdClass()));
 
-        // Readings: deadline, the first view's guard, then the first view's
-        // pass loop is already past it. The second view's guard breaks the
-        // loop, so exactly one view is ever visited.
         $cron = new class ($helper, $errors, $storeManager) extends ErrorsClean {
+            public $readings = 0;
             private $tick = 0;
 
             protected function now()
             {
+                $this->readings++;
                 return $this->tick++ < 2 ? 0 : ErrorsClean::MAX_RUNTIME_SECONDS + 1;
             }
         };
 
         $cron->execute();
 
-        $this->assertSame(1, $reads, 'the loop kept visiting store views after the budget ran out');
+        // One to set the deadline, then the first view is entered and
+        // abandoned, and the second view's guard breaks the loop.
+        // Five: the deadline, the first view's guard, its pass loop, its
+        // age-clean guard, and the second view's guard, which breaks. Twenty
+        // views would be at least twenty-one.
+        $this->assertSame(
+            5,
+            $cron->readings,
+            'the loop kept visiting store views after the budget ran out'
+        );
     }
-
 
     /**
      * The ceiling runs before the age-based clean, not after.

--- a/Test/Unit/Cron/ErrorsCleanTest.php
+++ b/Test/Unit/Cron/ErrorsCleanTest.php
@@ -158,9 +158,10 @@ class ErrorsCleanTest extends TestCase
         $storeManager = $this->createMock(StoreManager::class);
         $storeManager->method('getStores')->willReturn([1 => new \stdClass()]);
 
-        // A clock that jumps a third of the budget per reading, so the third
-        // pass is past the deadline. Anything counting passes alone runs 100.
-        $step = ErrorsClean::MAX_RUNTIME_SECONDS / 3;
+        // A clock that jumps a quarter of the budget per reading. One reading
+        // sets the deadline, one guards the store loop, then the third pass
+        // lands on it. Anything counting passes alone would run 100.
+        $step = ErrorsClean::MAX_RUNTIME_SECONDS / 4;
         $cron = new class ($helper, $errors, $storeManager, $step) extends ErrorsClean {
             private $tick = 0;
             private $step;
@@ -182,6 +183,71 @@ class ErrorsCleanTest extends TestCase
             ->willReturn(ErrorsClean::OVERFLOW_LIMIT);
 
         $cron->execute();
+    }
+
+
+    /**
+     * The budget has to cover the whole job, not the ceiling alone. The
+     * age-based delete runs first for each store view and is the more
+     * expensive half — it filters on a function of the column, so it cannot
+     * seek and walks the partition even when it deletes nothing. A sync marked
+     * missed does not care which half spent the window.
+     */
+    public function testTheBudgetCoversTheAgeBasedCleanToo(): void
+    {
+        $helper = $this->createMock(MailChimpHelper::class);
+        $helper->method('getConfigValue')->willReturn(3);
+        $errors = $this->createMock(MailChimpErrors::class);
+        $storeManager = $this->createMock(StoreManager::class);
+        $storeManager->method('getStores')->willReturn(array_fill_keys([1, 2, 3, 4, 5], new \stdClass()));
+
+        // Already past the deadline on the very first reading.
+        $cron = new class ($helper, $errors, $storeManager) extends ErrorsClean {
+            protected function now()
+            {
+                static $tick = 0;
+                return $tick++ === 0 ? 0 : ErrorsClean::MAX_RUNTIME_SECONDS + 1;
+            }
+        };
+
+        $errors->expects($this->never())->method('deleteByStorePeriod');
+        $errors->expects($this->never())->method('deleteOverflowByStore');
+
+        $cron->execute();
+    }
+
+    /**
+     * And it stops the loop rather than spinning through the remaining views
+     * to do nothing with each of them.
+     */
+    public function testAnExhaustedBudgetStopsTheLoopInsteadOfSkippingEachView(): void
+    {
+        $helper = $this->createMock(MailChimpHelper::class);
+        $reads = 0;
+        $helper->method('getConfigValue')->willReturnCallback(
+            function () use (&$reads) {
+                $reads++;
+                return 0;
+            }
+        );
+        $errors = $this->createMock(MailChimpErrors::class);
+        $errors->method('deleteOverflowByStore')->willReturn(0);
+        $storeManager = $this->createMock(StoreManager::class);
+        $storeManager->method('getStores')->willReturn(array_fill_keys(range(1, 20), new \stdClass()));
+
+        // Budget runs out after the second view.
+        $cron = new class ($helper, $errors, $storeManager) extends ErrorsClean {
+            private $tick = 0;
+
+            protected function now()
+            {
+                return $this->tick++ < 2 ? 0 : ErrorsClean::MAX_RUNTIME_SECONDS + 1;
+            }
+        };
+
+        $cron->execute();
+
+        $this->assertLessThan(20, $reads, 'the loop kept visiting store views after the budget ran out');
     }
 
 }

--- a/Test/Unit/Cron/ErrorsCleanTest.php
+++ b/Test/Unit/Cron/ErrorsCleanTest.php
@@ -119,7 +119,12 @@ class ErrorsCleanTest extends TestCase
             ->method('deleteOverflowByStore')
             ->willReturnCallback(
                 function () use (&$remaining) {
-                    return $remaining-- > 0 ? ErrorsClean::OVERFLOW_LIMIT : 0;
+                    if ($remaining < 1) {
+                        return 0;
+                    }
+                    $remaining--;
+
+                    return ErrorsClean::OVERFLOW_LIMIT;
                 }
             );
 
@@ -142,7 +147,6 @@ class ErrorsCleanTest extends TestCase
         $cron->execute();
     }
 
-
     /**
      * A pass caps work, not time, and how long a pass takes depends on things
      * this cannot know. The cron group gives this job a two-minute window and
@@ -163,7 +167,10 @@ class ErrorsCleanTest extends TestCase
         // lands on it. Anything counting passes alone would run 100.
         $step = ErrorsClean::MAX_RUNTIME_SECONDS / 4;
         $cron = new class ($helper, $errors, $storeManager, $step) extends ErrorsClean {
+            /** @var int */
             private $tick = 0;
+
+            /** @var float */
             private $step;
 
             public function __construct($helper, $errors, $storeManager, $step)
@@ -174,7 +181,10 @@ class ErrorsCleanTest extends TestCase
 
             protected function now()
             {
-                return $this->tick++ * $this->step;
+                $reading = $this->tick * $this->step;
+                $this->tick++;
+
+                return $reading;
             }
         };
 
@@ -184,7 +194,6 @@ class ErrorsCleanTest extends TestCase
 
         $cron->execute();
     }
-
 
     /**
      * The budget has to cover the whole job, not the ceiling alone. The
@@ -203,6 +212,7 @@ class ErrorsCleanTest extends TestCase
 
         // Already past the deadline on the very first reading.
         $cron = new class ($helper, $errors, $storeManager) extends ErrorsClean {
+            /** @var int */
             private $tick = 0;
 
             protected function now()
@@ -236,7 +246,10 @@ class ErrorsCleanTest extends TestCase
         $storeManager->method('getStores')->willReturn(array_fill_keys(range(1, 20), new \stdClass()));
 
         $cron = new class ($helper, $errors, $storeManager) extends ErrorsClean {
+            /** @var int */
             public $readings = 0;
+
+            /** @var int */
             private $tick = 0;
 
             protected function now()
@@ -290,5 +303,4 @@ class ErrorsCleanTest extends TestCase
 
         $this->assertSame(['ceiling', 'age'], $orden);
     }
-
 }

--- a/Test/Unit/Cron/ErrorsCleanTest.php
+++ b/Test/Unit/Cron/ErrorsCleanTest.php
@@ -142,4 +142,46 @@ class ErrorsCleanTest extends TestCase
         $cron->execute();
     }
 
+
+    /**
+     * A pass caps work, not time, and how long a pass takes depends on things
+     * this cannot know. The cron group gives this job a two-minute window and
+     * runs it in one process alongside the sync jobs, so a drain that overruns
+     * does not delay them — Magento marks them missed. The ceiling stops on the
+     * clock, and the next tick continues.
+     */
+    public function testTheCeilingStopsOnTheClockNotOnlyOnThePassCap(): void
+    {
+        $helper = $this->createMock(MailChimpHelper::class);
+        $helper->method('getConfigValue')->willReturn(0);
+        $errors = $this->createMock(MailChimpErrors::class);
+        $storeManager = $this->createMock(StoreManager::class);
+        $storeManager->method('getStores')->willReturn([1 => new \stdClass()]);
+
+        // A clock that jumps a third of the budget per reading, so the third
+        // pass is past the deadline. Anything counting passes alone runs 100.
+        $step = ErrorsClean::MAX_RUNTIME_SECONDS / 3;
+        $cron = new class ($helper, $errors, $storeManager, $step) extends ErrorsClean {
+            private $tick = 0;
+            private $step;
+
+            public function __construct($helper, $errors, $storeManager, $step)
+            {
+                parent::__construct($helper, $errors, $storeManager);
+                $this->step = $step;
+            }
+
+            protected function now()
+            {
+                return $this->tick++ * $this->step;
+            }
+        };
+
+        $errors->expects($this->exactly(2))
+            ->method('deleteOverflowByStore')
+            ->willReturn(ErrorsClean::OVERFLOW_LIMIT);
+
+        $cron->execute();
+    }
+
 }

--- a/Test/Unit/Cron/ErrorsCleanTest.php
+++ b/Test/Unit/Cron/ErrorsCleanTest.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Ebizmarts_MailChimp Magento Component
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Test\Unit\Cron;
+
+use Ebizmarts\MailChimp\Cron\ErrorsClean;
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Ebizmarts\MailChimp\Model\MailChimpErrors;
+use Magento\Store\Model\StoreManager;
+use PHPUnit\Framework\TestCase;
+
+class ErrorsCleanTest extends TestCase
+{
+    /**
+     * @param  mixed $period value of clean_errors_months
+     * @return array [$cron, $errors]
+     */
+    private function make($period, array $storeIds = [1])
+    {
+        $helper = $this->createMock(MailChimpHelper::class);
+        $helper->method('getConfigValue')->willReturn($period);
+
+        $errors = $this->createMock(MailChimpErrors::class);
+
+        $storeManager = $this->createMock(StoreManager::class);
+        // getStores() is keyed by store id, and the cron reads the key.
+        $storeManager->method('getStores')->willReturn(array_fill_keys($storeIds, new \stdClass()));
+
+        return [new ErrorsClean($helper, $errors, $storeManager), $errors];
+    }
+
+    /**
+     * The ceiling is a safety property, not a preference. A store that has the
+     * age-based clean switched off — which is every store by default, since
+     * the field has no default and saving the section stores a 0 — is exactly
+     * the store that needs the table bounded.
+     */
+    public function testTheCeilingIsAppliedEvenWithTheAgeCleanSwitchedOff(): void
+    {
+        list($cron, $errors) = $this->make(0);
+
+        $errors->expects($this->never())->method('deleteByStorePeriod');
+        $errors->expects($this->once())
+            ->method('deleteOverflowByStore')
+            ->with(1, ErrorsClean::MAX_ROWS_PER_STORE, ErrorsClean::LIMIT)
+            ->willReturn(0);
+
+        $cron->execute();
+    }
+
+    public function testBothRunWhenTheMerchantAsksForAnAgeBasedClean(): void
+    {
+        list($cron, $errors) = $this->make(3);
+
+        $errors->expects($this->once())->method('deleteByStorePeriod')->with(1, 3, ErrorsClean::LIMIT);
+        $errors->expects($this->once())->method('deleteOverflowByStore')->willReturn(0);
+
+        $cron->execute();
+    }
+
+    /**
+     * The two are independent: a failing age-based clean must not take the
+     * ceiling with it, or the table stops being bounded for the store whose
+     * cleanup is broken.
+     */
+    public function testAFailingAgeCleanDoesNotSkipTheCeiling(): void
+    {
+        list($cron, $errors) = $this->make(3);
+
+        $errors->method('deleteByStorePeriod')->willThrowException(new \Exception('table is locked'));
+        $errors->expects($this->once())->method('deleteOverflowByStore')->willReturn(0);
+
+        $cron->execute();
+    }
+
+    /**
+     * The ceiling is per store view, so every view has to be offered it — one
+     * view failing must not stop the rest.
+     */
+    public function testEveryStoreViewIsBounded(): void
+    {
+        list($cron, $errors) = $this->make(0, [1, 2, 3]);
+
+        $seen = [];
+        $errors->method('deleteOverflowByStore')->willReturnCallback(
+            function ($storeId) use (&$seen) {
+                $seen[] = $storeId;
+                if ($storeId === 2) {
+                    throw new \Exception('deadlock');
+                }
+                return 0;
+            }
+        );
+
+        $cron->execute();
+
+        $this->assertSame([1, 2, 3], $seen);
+    }
+}

--- a/Test/Unit/Cron/ErrorsCleanTest.php
+++ b/Test/Unit/Cron/ErrorsCleanTest.php
@@ -50,7 +50,7 @@ class ErrorsCleanTest extends TestCase
         $errors->expects($this->never())->method('deleteByStorePeriod');
         $errors->expects($this->once())
             ->method('deleteOverflowByStore')
-            ->with(1, ErrorsClean::MAX_ROWS_PER_STORE, ErrorsClean::LIMIT)
+            ->with(1, ErrorsClean::MAX_ROWS_PER_STORE, ErrorsClean::OVERFLOW_LIMIT)
             ->willReturn(0);
 
         $cron->execute();
@@ -104,4 +104,42 @@ class ErrorsCleanTest extends TestCase
 
         $this->assertSame([1, 2, 3], $seen);
     }
+
+    /**
+     * A run keeps going until the store is under the ceiling. Deleting a fixed
+     * slice per run and stopping would leave a table that has been growing for
+     * years to come down over weeks, which is the case the ceiling exists for.
+     */
+    public function testTheCeilingKeepsGoingUntilThereIsNothingLeftToDelete(): void
+    {
+        list($cron, $errors) = $this->make(0);
+
+        $remaining = 3;
+        $errors->expects($this->exactly(4))
+            ->method('deleteOverflowByStore')
+            ->willReturnCallback(
+                function () use (&$remaining) {
+                    return $remaining-- > 0 ? ErrorsClean::OVERFLOW_LIMIT : 0;
+                }
+            );
+
+        $cron->execute();
+    }
+
+    /**
+     * But one run is still bounded. Without a cap a store far enough past the
+     * ceiling would hold the cron for as long as it took, and the whole reason
+     * the delete is chunked is to keep any single run predictable.
+     */
+    public function testOneRunIsBoundedEvenIfTheStoreNeverComesDown(): void
+    {
+        list($cron, $errors) = $this->make(0);
+
+        $errors->expects($this->exactly(ErrorsClean::MAX_PASSES))
+            ->method('deleteOverflowByStore')
+            ->willReturn(ErrorsClean::OVERFLOW_LIMIT);
+
+        $cron->execute();
+    }
+
 }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -282,7 +282,7 @@
                 <field id="clean_errors_months" translate="label comment" type="select" sortOrder="175" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Months to clear the error table</label>
                     <source_model>Ebizmarts\MailChimp\Model\Config\Source\Months</source_model>
-                    <comment><![CDATA[How many month before clean the error from the error table automatically and not retry]]></comment>
+                    <comment><![CDATA[How many month before clean the error from the error table automatically and not retry. Whatever you choose here, the oldest errors of a store view are removed once it holds more than 5,000 of them, so the table cannot grow without limit. Errors are what the Mailchimp columns on the product, customer and order grids show, so removing them removes those explanations.]]></comment>
                     <depends>
                         <field id="*/*/active">1</field>
                     </depends>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -282,7 +282,7 @@
                 <field id="clean_errors_months" translate="label comment" type="select" sortOrder="175" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Months to clear the error table</label>
                     <source_model>Ebizmarts\MailChimp\Model\Config\Source\Months</source_model>
-                    <comment><![CDATA[How many month before clean the error from the error table automatically and not retry. Whatever you choose here, the oldest errors of a store view are removed once it holds more than 5,000 of them, so the table cannot grow without limit. Errors are what the Mailchimp columns on the product, customer and order grids show, so removing them removes those explanations.]]></comment>
+                    <comment><![CDATA[How many month before clean the error from the error table automatically and not retry. Whatever you choose here, the oldest errors of a store view are removed once it holds more than a few thousand of them, so the table cannot grow without limit. Errors are what the Mailchimp columns on the product, customer and order grids show, so removing them removes those explanations.]]></comment>
                     <depends>
                         <field id="*/*/active">1</field>
                     </depends>

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -35,6 +35,10 @@
             <column name="regtype"/>
             <column name="original_id"/>
         </index>
+        <index referenceId="MAILCHIMP_ERRORS_STORE_ID_ID" indexType="btree">
+            <column name="store_id"/>
+            <column name="id"/>
+        </index>
     </table>
     <table name="mailchimp_interest_group">
         <column xsi:type="int" name="id" padding="10" nullable="false" identity="true" comment="Table Id"/>

--- a/etc/db_schema_whitelist.json
+++ b/etc/db_schema_whitelist.json
@@ -38,7 +38,8 @@
       "added_at": true
     },
     "index": {
-      "MAILCHIMP_ERRORS_STORE_ID_REGTYPE_ORIGINAL_ID": true
+      "MAILCHIMP_ERRORS_STORE_ID_REGTYPE_ORIGINAL_ID": true,
+      "MAILCHIMP_ERRORS_STORE_ID_ID": true
     },
     "constraint": {
       "PRIMARY": true


### PR DESCRIPTION
`mailchimp_errors` grows without a ceiling on a default install. This bounds it, inside the window the cron group allows.

## Why the cleaner that already exists does not

`Cron/ErrorsClean.php` runs hourly and deletes rows older than `clean_errors_months`, but it is gated on `$period > 0`, and that path has **no default in `config.xml`**. So the job runs every hour and deletes nothing.

A `config.xml` default would not fix it. A stored `0` is **explicit, not absent** — it is written in the same timestamp as fourteen other rows of the same group, because saving the section persists every field in it. And that inverts who a default reaches: for the table to grow, ecommerce has to be active; for that, someone saved the group; saving it wrote the `0`. **The population at risk is by construction the one a default would not help.**

Rewriting those zeroes would reach them, but a stored `0` is genuinely ambiguous between "never thought about it" and "keep my errors", and guessing wrong there is invisible.

## What this does instead

Bounds the table rather than arguing about the preference. They answer different questions and both hold:

- `clean_errors_months` — *how long do I want errors kept?* A preference, and forever is a legitimate answer.
- the ceiling — *whatever was chosen, one store view never holds more than `MAX_ROWS_PER_STORE`.* A safety property.

Nobody is overridden, and nothing has to decide what a `0` meant. It runs **unconditionally**, because a store with the age clean switched off is exactly the store that needs bounding.

## Converging without starving the sync

The ceiling has its own delete limit and repeats within a run, so a table far past the ceiling comes down in a tick or two rather than the six weeks a fixed 1,000-rows-an-hour slice would take. Measured: **1,000,000 rows per store view in ~16 s**, no single statement holding locks longer than **265 ms**.

That created a second problem, and it is why the budget exists. `etc/cron_groups.xml` gives this group a `schedule_lifetime` of two minutes and `use_separate_process`, and `ebizmarts_ecommerce` and `ebizmarts_webhooks` are `*/5` jobs in it. A job that overruns does not delay its siblings — Magento marks them **missed**. So the whole job now stops on a wall-clock budget well inside that window, and the next tick continues.

The budget covers **both halves deliberately**. The age-based delete filters on `date_add(added_at, ...)` — a function on the column, so it cannot seek: on a store whose errors are all recent it walks the partition to delete nothing, measured in review at ~1.55 µs per row scanned. The sync it would starve does not care which half spent the window.

And the **ceiling runs first**: the safety property draws on the budget before the preference does, and every row it removes is a row the non-seeking scan does not have to walk.

## The index

`(store_id, id)`, declared in `db_schema.xml` and registered in the whitelist.

An earlier revision argued it could wait. That argument was measured wrong and is retracted in the thread. What it actually buys, stated narrowly:

| | without | with |
|---|---|---|
| skewed, pre-drain (100k old rows under 400k newer) | 19.3 ms | 0.7 ms |
| this PR's offset query, bounded state, MariaDB 10.6 | 0.77 ms | 0.71 ms |
| `ORDER BY id DESC LIMIT 1`, bounded state, 10.6 | 52.49 ms | 0.04 ms |

So in **this** PR it buys a transient win while a table drains. The permanent win is on the `LIMIT 1` shape, which arrives with the beacon. On MariaDB 11.4 the optimiser does not take the backward walk in the bounded state at all — so this is insurance against plan choice that varies by engine version, at a measured **6 µs** per error insert. Single-store-view installs are unaffected either way: the walk only crosses rows belonging to *other* views.

## What it does not cover

Rows left by a **deleted** store view. `store_id` carries no foreign key and `getStores()` returns neither deleted views nor the admin store, so neither cleaner ever visits them. Already true of the age-based clean; stated here because this is the change that claims the table is bounded.

Bytes are bounded only loosely: two `TEXT` columns at 65,535 each put a row under ~128 KB and one store view under ~640 MB — **per view**, so a fifty-view install has a 250,000-row ceiling. Against ~110 bytes an error body measures in practice. If that constant ever bites, the answer is to cap the stored body, not the row count.

The non-seeking scan itself is untouched. Rewriting the predicate to seek needs an index on `added_at` to pay, which is a second index and a second write per insert — a separate change.

## Merchant-facing

The admin field said only that errors are removed after N months. It now also says the ceiling applies whatever is chosen, and that removing errors removes what the Mailchimp columns on the product, customer and order grids show — which is where a merchant meets them.

## Tests

**Ten** in `ErrorsCleanTest`, and the module suite is **136 tests, 245 assertions** green. Each new one was checked failing against the revision before it: the ceiling applies with the age clean off, both run when it is on, a failing age clean does not skip the ceiling, every view is offered it even when one throws, the ceiling keeps going until a pass deletes nothing, one run is bounded by the pass cap, it stops on the clock, the budget covers the age clean too, an exhausted budget stops the loop rather than visiting every view, and the ceiling runs before the age clean.