### PR TITLE
Require performance claims to be measured after ANALYZE TABLE

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,3 +5,4 @@
 3. Commits must be accompanied by meaningful commit messages. (include a **closes** in the commit that close the issue)
 4. PRs that include bug fixing must be accompanied by the creation of an issue describing the bug following this [Issue reporting guidelines](https://github.com/mailchimp/mc-magento2/wiki/Issue-reporting-guidelines).
 5. For large features or changes, please open an issue and discuss first. This may prevent duplicate or unnecessary effort, and it may gain you some additional contributors.
+6. PRs that claim a performance change must show the measurement, and the measurement must be taken after `ANALYZE TABLE`. **A newly created index benchmarks worse than no index until the optimiser's statistics catch up**, so the first result you get is often the opposite of the true one — an index that turned out to be 28x faster first measured 2.5x slower, and that number very nearly went into a review. This is not specific to any one table or index.


### PR DESCRIPTION
Split out of the `mailchimp_errors` ceiling PR, where it was riding as a repo-wide policy change inside a bugfix. Easier to find, and to disagree with, on its own.

One line added to `CONTRIBUTING.md`:

> PRs that claim a performance change must show the measurement, and the measurement must be taken after `ANALYZE TABLE`. **A newly created index benchmarks worse than no index until the optimiser's statistics catch up**, so the first result you get is often the opposite of the true one — an index that turned out to be 28x faster first measured 2.5x slower, and that number very nearly went into a review. This is not specific to any one table or index.

## Where it comes from

Measuring a candidate index on `mailchimp_errors`:

| | |
|---|---|
| first run, no `ANALYZE TABLE` | 7.9 ms without the index, **19.6 ms with it** — the index looked 2.5x *slower* |
| after `ANALYZE TABLE` | 19.3 ms without, **0.7 ms with** — 28x faster |

The first number was about to be posted as evidence that the index was not worth adding. It was an artefact: MariaDB has no statistics for a brand-new index and picks badly until they refresh.

Nothing about that is specific to that table. Anyone benchmarking an index change in this repository will hit it, and the failure mode is the dangerous kind — a confident number pointing the wrong way, produced by a procedure that looks correct.

It cost three measurements on that one question before a result held, so the rule is written where someone opening a PR will see it rather than in a review thread.