### PR TITLE
Apply the Error fix to the rest of the edge classes

### DIFF
--- a/Model/Edge/Beacon.php
+++ b/Model/Edge/Beacon.php
@@ -117,20 +117,14 @@ class Beacon
             foreach ($this->storeManager->getStores() as $store) {
                 $storeId = (int)$store->getId();
 
-                if (!$this->helper->isMailChimpEnabled($storeId) || !$this->helper->getApiKey($storeId)) {
-                    continue;
-                }
-
                 try {
+                    if (!$this->helper->isMailChimpEnabled($storeId) || !$this->helper->getApiKey($storeId)) {
+                        continue;
+                    }
+
                     $this->processStore($storeId, (string)$store->getBaseUrl());
-                } catch (\Exception $e) {
+                } catch (\Throwable $e) {
                     $this->helper->log('Edge beacon failed for store ' . $storeId . ': ' . $e->getMessage());
-                } catch (\Throwable $t) {
-                    // On PHP 7+ an Error is not an Exception, so catching only
-                    // Exception here let a TypeError out of the API path abort
-                    // the run and take every remaining store view with it.
-                    // One store view's problem is not the other views'.
-                    $this->helper->log('Edge beacon failed for store ' . $storeId . ': ' . $t->getMessage());
                 }
             }
         } finally {
@@ -352,13 +346,8 @@ class Beacon
         try {
             $api  = $this->helper->getApi($storeId);
             $root = $api->root->info();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $this->helper->log('Edge beacon could not read the Mailchimp account: ' . $e->getMessage());
-            return null;
-        } catch (\Throwable $t) {
-            // Reading the account must not be able to end the run: an Error
-            // here is a broken API path, not a reason to stop reporting.
-            $this->helper->log('Edge beacon could not read the Mailchimp account: ' . $t->getMessage());
             return null;
         }
 
@@ -485,9 +474,7 @@ class Beacon
     {
         try {
             $moduleVersion = (string)$this->helper->getModuleVersion();
-        } catch (\Exception $e) {
-            $moduleVersion = '';
-        } catch (\Throwable $t) {
+        } catch (\Throwable $e) {
             $moduleVersion = '';
         }
 

--- a/Model/Edge/Client.php
+++ b/Model/Edge/Client.php
@@ -118,26 +118,20 @@ class Client
 
         try {
             $curl->post(self::BASE_URL . $path, json_encode($body));
-        } catch (\Exception $e) {
+            $status  = (int)$curl->getStatus();
+            $headers = $curl->getHeaders();
+            $rawBody = (string)$curl->getBody();
+        } catch (\Throwable $e) {
             $this->helper->log('Edge beacon transport failure on ' . $path . ': ' . $e->getMessage());
             return new Response(Response::FAILED);
-        } catch (\Throwable $t) {
-            // The point of this catch is to turn a transport problem into a
-            // failed response, not to end the run. An Error escaping it would
-            // skip the whole store view instead, and lose the log line saying
-            // why.
-            $this->helper->log('Edge beacon transport failure on ' . $path . ': ' . $t->getMessage());
-            return new Response(Response::FAILED);
         }
-
-        $status = (int)$curl->getStatus();
 
         if ($status === 401) {
             return new Response(Response::UNAUTHORIZED, $status);
         }
 
         if ($status === 429) {
-            $retryAfter = $this->readRetryAfter($curl->getHeaders());
+            $retryAfter = $this->readRetryAfter($headers);
             $this->helper->log('Edge beacon rate limited on ' . $path . ', Retry-After: ' . ($retryAfter ?? 'absent'));
             return new Response(Response::RATE_LIMITED, $status, [], $retryAfter);
         }
@@ -147,7 +141,7 @@ class Client
             return new Response(Response::FAILED, $status);
         }
 
-        $data = json_decode((string)$curl->getBody(), true);
+        $data = json_decode($rawBody, true);
         if (!is_array($data)) {
             $this->helper->log('Edge beacon got a malformed body on ' . $path);
             return new Response(Response::FAILED, $status);

--- a/Model/Edge/Client.php
+++ b/Model/Edge/Client.php
@@ -121,6 +121,13 @@ class Client
         } catch (\Exception $e) {
             $this->helper->log('Edge beacon transport failure on ' . $path . ': ' . $e->getMessage());
             return new Response(Response::FAILED);
+        } catch (\Throwable $t) {
+            // The point of this catch is to turn a transport problem into a
+            // failed response, not to end the run. An Error escaping it would
+            // skip the whole store view instead, and lose the log line saying
+            // why.
+            $this->helper->log('Edge beacon transport failure on ' . $path . ': ' . $t->getMessage());
+            return new Response(Response::FAILED);
         }
 
         $status = (int)$curl->getStatus();

--- a/Model/Edge/LivenessSignals.php
+++ b/Model/Edge/LivenessSignals.php
@@ -127,11 +127,12 @@ class LivenessSignals
      * counts. That index continues into regtype and original_id, so it cannot
      * serve `ORDER BY id DESC`, and the optimiser walks the primary key
      * backwards through every other store view's rows instead: measured at
-     * 52 ms on MariaDB 10.6 against a bounded 250,000 row table. And nothing
-     * bounded the table at all until the row ceiling was added.
+     * 52 ms on MariaDB 10.6 against a 250,000 row table.
      *
-     * It is cheap given `MAILCHIMP_ERRORS_STORE_ID_ID`, which that same change
-     * adds. Before it, this runs hourly per store view and is not.
+     * What makes it cheap is `MAILCHIMP_ERRORS_STORE_ID_ID`, which serves the
+     * sort directly — 0.04 ms on the same table — and the row ceiling that
+     * bounds how large the table gets. Both are in place. This runs hourly per
+     * store view, so neither is optional.
      *
      * @param  int $storeId
      * @return array|null

--- a/Model/Edge/LivenessSignals.php
+++ b/Model/Edge/LivenessSignals.php
@@ -108,14 +108,8 @@ class LivenessSignals
                 ->where('mailchimp_store_id = ?', $mailchimpStoreId);
 
             $value = $connection->fetchOne($select);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $this->helper->log('Edge beacon could not read the sync delta: ' . $e->getMessage());
-            return null;
-        } catch (\Throwable $t) {
-            // These signals are optional; the report is not. An Error escaping
-            // here would cost the whole store view its beacon rather than one
-            // field of it.
-            $this->helper->log('Edge beacon could not read the sync delta: ' . $t->getMessage());
             return null;
         }
 
@@ -126,8 +120,18 @@ class LivenessSignals
      * Newest error row for the store view.
      *
      * Selects only type, status and added_at. The `errors` column is never
-     * read. `mailchimp_errors` carries a composite index leading on store_id
-     * and holds few rows, so this stays cheap.
+     * read.
+     *
+     * This is not cheap on its own, and the earlier claim that it was — a
+     * composite index leading on store_id, and few rows — was wrong on both
+     * counts. That index continues into regtype and original_id, so it cannot
+     * serve `ORDER BY id DESC`, and the optimiser walks the primary key
+     * backwards through every other store view's rows instead: measured at
+     * 52 ms on MariaDB 10.6 against a bounded 250,000 row table. And nothing
+     * bounded the table at all until the row ceiling was added.
+     *
+     * It is cheap given `MAILCHIMP_ERRORS_STORE_ID_ID`, which that same change
+     * adds. Before it, this runs hourly per store view and is not.
      *
      * @param  int $storeId
      * @return array|null
@@ -143,14 +147,8 @@ class LivenessSignals
                 ->limit(1);
 
             $row = $connection->fetchRow($select);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $this->helper->log('Edge beacon could not read the last error: ' . $e->getMessage());
-            return null;
-        } catch (\Throwable $t) {
-            // These signals are optional; the report is not. An Error escaping
-            // here would cost the whole store view its beacon rather than one
-            // field of it.
-            $this->helper->log('Edge beacon could not read the last error: ' . $t->getMessage());
             return null;
         }
 

--- a/Model/Edge/LivenessSignals.php
+++ b/Model/Edge/LivenessSignals.php
@@ -111,6 +111,12 @@ class LivenessSignals
         } catch (\Exception $e) {
             $this->helper->log('Edge beacon could not read the sync delta: ' . $e->getMessage());
             return null;
+        } catch (\Throwable $t) {
+            // These signals are optional; the report is not. An Error escaping
+            // here would cost the whole store view its beacon rather than one
+            // field of it.
+            $this->helper->log('Edge beacon could not read the sync delta: ' . $t->getMessage());
+            return null;
         }
 
         return $value ?: null;
@@ -139,6 +145,12 @@ class LivenessSignals
             $row = $connection->fetchRow($select);
         } catch (\Exception $e) {
             $this->helper->log('Edge beacon could not read the last error: ' . $e->getMessage());
+            return null;
+        } catch (\Throwable $t) {
+            // These signals are optional; the report is not. An Error escaping
+            // here would cost the whole store view its beacon rather than one
+            // field of it.
+            $this->helper->log('Edge beacon could not read the last error: ' . $t->getMessage());
             return null;
         }
 

--- a/Model/Edge/NotificationDelivery.php
+++ b/Model/Edge/NotificationDelivery.php
@@ -116,6 +116,12 @@ class NotificationDelivery
                 // here and let the unconfirmed uid tell the service the truth.
                 $this->helper->log('Edge notification could not be delivered: ' . $e->getMessage());
                 break;
+            } catch (\Throwable $t) {
+                // Same rule for an Error. Without this it escapes the loop, and
+                // the uids already delivered in this batch are lost with it
+                // rather than being queued for acknowledgement.
+                $this->helper->log('Edge notification could not be delivered: ' . $t->getMessage());
+                break;
             }
 
             // Only what actually reached the inbox may be acknowledged. A

--- a/Model/Edge/NotificationDelivery.php
+++ b/Model/Edge/NotificationDelivery.php
@@ -111,16 +111,10 @@ class NotificationDelivery
 
             try {
                 $written = $this->deliverOnce($uid, $item);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 // A message we could not write must not be confirmed, so stop
                 // here and let the unconfirmed uid tell the service the truth.
                 $this->helper->log('Edge notification could not be delivered: ' . $e->getMessage());
-                break;
-            } catch (\Throwable $t) {
-                // Same rule for an Error. Without this it escapes the loop, and
-                // the uids already delivered in this batch are lost with it
-                // rather than being queued for acknowledgement.
-                $this->helper->log('Edge notification could not be delivered: ' . $t->getMessage());
                 break;
             }
 
@@ -143,7 +137,15 @@ class NotificationDelivery
         }
 
         if (!empty($delivered)) {
-            $this->rememberForAck($storeId, $delivered, $stillPending);
+            try {
+                $this->rememberForAck($storeId, $delivered, $stillPending);
+            } catch (\Throwable $e) {
+                // Losing this loses exactly what the catch inside the loop was
+                // added to preserve: the uids that did reach the inbox. The
+                // service goes on offering them, which is a duplicate in the
+                // bell rather than a message nobody sees.
+                $this->helper->log('Edge notification acknowledgement could not be stored: ' . $e->getMessage());
+            }
         }
     }
 

--- a/Test/Unit/Model/Edge/ClientTest.php
+++ b/Test/Unit/Model/Edge/ClientTest.php
@@ -139,5 +139,4 @@ class ClientTest extends TestCase
         $this->assertFalse($response->isUnauthorized(), 'a broken client must not look like a dead token');
         $this->assertFalse($response->isRateLimited());
     }
-
 }

--- a/Test/Unit/Model/Edge/ClientTest.php
+++ b/Test/Unit/Model/Edge/ClientTest.php
@@ -112,4 +112,32 @@ class ClientTest extends TestCase
 
         $this->assertFalse($response->isOk());
     }
+
+    /**
+     * An Error is not an Exception. This catch exists to turn a transport
+     * problem into a failed response; letting one escape would skip the whole
+     * store view instead, and lose the log line saying why.
+     */
+    public function testAnErrorFromTheTransportBecomesAFailedResponse(): void
+    {
+        $curl = $this->getMockBuilder(\Ebizmarts\MailChimp\Model\HTTP\Client\Curl::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['setOption', 'setTimeout', 'setHeaders', 'post'])
+            ->getMock();
+        $curl->method('post')->willThrowException(new \TypeError('the http client is broken'));
+
+        $factory = $this->getMockBuilder(CurlFactory::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['create'])
+            ->getMock();
+        $factory->method('create')->willReturn($curl);
+
+        $response = (new Client($factory, $this->createMock(MailChimpHelper::class)))
+            ->ping('tok', ['store_url' => 'https://shop.example.com/']);
+
+        $this->assertFalse($response->isOk());
+        $this->assertFalse($response->isUnauthorized(), 'a broken client must not look like a dead token');
+        $this->assertFalse($response->isRateLimited());
+    }
+
 }

--- a/Test/Unit/Model/Edge/NotificationDeliveryTest.php
+++ b/Test/Unit/Model/Edge/NotificationDeliveryTest.php
@@ -329,4 +329,38 @@ class NotificationDeliveryTest extends TestCase
             ->handle(1, 'token', ['notifications' => 2], []);
     }
 
+
+    /**
+     * An Error mid-batch must not lose what was already delivered.
+     *
+     * The catch inside the loop exists so that the uids that did reach the
+     * inbox are still queued for acknowledgement. Without it the Error unwinds
+     * past rememberForAck and those uids are lost, so the service goes on
+     * offering messages the merchant has already seen.
+     *
+     * Written by the reviewer of this change, who pointed out that the case
+     * described as the worst of the three was the one without a test.
+     */
+    public function testAnErrorMidBatchStillQueuesWhatWasDelivered(): void
+    {
+        $client = $this->createMock(Client::class);
+        $client->method('pullNotifications')->willReturn(
+            new Response(Response::OK, 200, ['notifications' => [
+                $this->wireItem('notice', 'uid-a'),
+                $this->wireItem('major', 'uid-b'),
+            ]])
+        );
+
+        $notifier = $this->createMock(NotifierInterface::class);
+        $notifier->method('addMajor')->willThrowException(new \TypeError('notifier is broken'));
+
+        $helper = $this->createMock(MailChimpHelper::class);
+        $helper->expects($this->once())
+            ->method('saveConfigValue')
+            ->with($this->anything(), 'uid-a', 1, $this->anything());
+
+        (new NotificationDelivery($client, $helper, $notifier))
+            ->handle(1, 'token', ['notifications' => 2], []);
+    }
+
 }


### PR DESCRIPTION
Follow-up to the beacon PR, from re-reading my own work rather than from a review.

That PR fixed `catch (\Exception)` letting an `\Error` escape — in `Beacon.php`, and only there. The same shape exists in the three classes around it, and I applied the fix in one place without checking whether it belonged in the others. It did.

Each of these catches is written to **degrade and carry on**, and an `\Error` escaping does not carry on: it unwinds to the per-store handler and costs the store view its whole beacon. That is a different outcome from the one each catch exists to produce.

| | what the catch is for | what an escaping `Error` does instead |
|---|---|---|
| `Client::post` | turn a transport problem into a failed response, leaving the token alone and the acknowledgements queued | skips the store view, and loses the log line saying why |
| `LivenessSignals` (×2) | return `null` so the report goes out with one field missing | costs the report rather than the field |
| `NotificationDelivery::handle` | break the loop so what was already delivered is still queued for acknowledgement | loses those uids, so the service keeps offering messages that did reach the inbox |

The last one is the worst of the three: the surrounding design is built on being able to prove a message reached the inbox, and an `Error` mid-batch silently discards that proof for everything delivered before it.

## Test

One, on the transport case, because it is the only one whose fallback is a value the caller acts on rather than an omission: a `TypeError` out of the HTTP client now produces a failed response instead of unwinding, and — asserted separately — is not mistaken for an unauthorised one, which is the outcome that would discard a good token.

It fails against `develop-2.4` with the raw `TypeError`.

**127 tests, 238 assertions.**