### PR TITLE
Tell the library which Mailchimp store this store view syncs into

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -368,6 +368,20 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         $this->_api->setApiKey($apiKey);
         $this->_api->setHelper($this);
         $this->_api->setStoreURL($this->_storeManager->getStore($store)->getBaseUrl());
+        // The library cannot observe this one. It is visible in a path only
+        // when a caller addresses a store directly, and the ecommerce sync
+        // posts all of its per-store work to `batches` with the store id in
+        // the body — which the library deliberately never reads.
+        //
+        // Guarded because composer.json is not always what decides which
+        // library is present. An app/code install puts this extension on disk
+        // by clone and the library comes from a separate composer require, so
+        // the `>=3.0.47` constraint below is inert there and the two can be
+        // updated independently. Without this check that pairing is a fatal on
+        // every call into the API, which is most of the extension.
+        if (method_exists($this->_api, 'setMailchimpStoreId')) {
+            $this->_api->setMailchimpStoreId($this->getConfigValue(self::XML_MAILCHIMP_STORE, $store, $scope));
+        }
         $this->_api->setUserAgent('Mailchimp4Magento' . (string)$this->getModuleVersion());
         if ($timeOut) {
             $this->_api->setTimeOut($timeOut);
@@ -504,6 +518,9 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         $this->_api->setUserAgent('Mailchimp4Magento' . (string)$this->getModuleVersion());
         $this->_api->setHelper($this);
         $this->_api->setStoreURL($this->_storeManager->getStore()->getBaseUrl());
+        if (method_exists($this->_api, 'setMailchimpStoreId')) {
+            $this->_api->setMailchimpStoreId($this->getConfigValue(self::XML_MAILCHIMP_STORE));
+        }
 
         return $this->_api;
     }

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   },
   "description": "Connect MailChimp with Magento",
   "type": "magento2-module",
-  "version": "103.4.81",
+  "version": "103.4.82",
   "authors": [
     {
       "name": "Ebizmarts Corp",
@@ -25,7 +25,7 @@
   },
   "require" : {
     "magento/framework": "103.0.*",
-    "ebizmarts/mailchimp-lib": ">=3.0.44",
+    "ebizmarts/mailchimp-lib": ">=3.0.47",
     "ext-json": "*"
   }
 }

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -11,7 +11,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Ebizmarts_MailChimp" setup_version="103.4.81">
+    <module name="Ebizmarts_MailChimp" setup_version="103.4.82">
         <sequence>
             <module name="Magento_Newsletter"/>
             <module name="Magento_Sales"/>


### PR DESCRIPTION
Extension half of a change whose other half is in the library (mailchimp-lib, PR 76). Three files, twenty lines.

## Why

The QoS beacon could only observe `mc_store_id` when a caller addressed a store by path — `ecommerce/stores/<id>`. The ecommerce sync never does: it submits all of its per-store work as **one POST to `batches`**, with the store id inside each operation in the body, which the library deliberately never reads.

So a perfectly healthy cron doing a full sync reported no store id, and a null in that field came to mean two unrelated things: *this install has no Mailchimp store*, and *this process never addressed one by path*. Nothing was lost — the receiving side keeps the first value it sees — but the per-beacon rows are what anyone would count, and they would answer "how many installs have no ecommerce store" wrongly.

Reading it out of the request body would have fixed it and cost the library's promise that it records no part of a request's contents. This extension already knows the value, and already hands the library several facts it cannot observe: the helper, the store URL, the user agent. The store id joins them.

Both places that configure the API are covered — `getApi()` and `getApiByApiKey()`.

## The constraint, and why the call is guarded anyway

`>=3.0.44` becomes `>=3.0.47`, which is where the setter exists. That also matters independently of this change: `share_contact` has been read by the library since 3.0.47, so until it is installed the opt-out in this extension's admin governs nothing.

**But the constraint is not always what decides which library is present.** An `app/code` install puts this extension on disk by clone and takes the library from a separate `composer require`, so `composer.json` is inert there and the two can be updated independently.

Verified that pairing without a guard:

```
Error: Call to undefined method Mailchimp::setMailchimpStoreId()
```

raised from `getApi()` — which is reached by most of the extension, so the failure is "unusable", not "degraded". With the guard the same pairing works and simply does not report the store id.

## Version

103.4.81 → **103.4.82**. Two builds that require different library versions must not both call themselves 103.4.81: the beacon reports `module_version`, and that is the field that would have to tell them apart when someone asks why an install is fataling.

## Verification

Against a live install, with the library from PR 76:

```
after getApi(), before any call : mc_store_id='342f07f6…'
after a POST to 'batches'       : families=batches  mc_store_id='342f07f6…'
in the envelope                 : 342f07f6…
```

That is exactly the case that motivated it — a process whose only recorded call is the batch submission now carries the store id, where before it carried nothing.

Also verified the reverse pairing is safe now, and that an older extension against the new library is unaffected: the library degrades rather than requiring anything new of its host.

**138 tests, 249 assertions.**