### PR TITLE
Ask a rejected API key once per run, not once per store view

### DIFF
--- a/Cron/Ecommerce.php
+++ b/Cron/Ecommerce.php
@@ -322,11 +322,19 @@ class Ecommerce
     }
     protected function _ping($storeId)
     {
+        // Asked once per credential, not once per store view. A key that was
+        // rejected a moment ago is rejected for the next view too, and this
+        // loop used to pay a full round trip to be told so again.
+        if ($this->_helper->isApiKeyFailed($storeId)) {
+            return false;
+        }
+
         try {
             $api = $this->_helper->getApi($storeId);
             $api->root->info();
         } catch (\Mailchimp_Error | \Mailchimp_HttpError $e) {
             $this->_helper->log($e->getFriendlyMessage());
+            $this->_helper->markApiKeyFailed($storeId);
             return false;
         }
         return true;

--- a/Cron/Ecommerce.php
+++ b/Cron/Ecommerce.php
@@ -332,7 +332,16 @@ class Ecommerce
         try {
             $api = $this->_helper->getApi($storeId);
             $api->root->info();
-        } catch (\Mailchimp_Error | \Mailchimp_HttpError $e) {
+        } catch (\Mailchimp_HttpError $e) {
+            // Ordered first because it is the subclass. DNS, TLS and timeouts
+            // say nothing about the credential, and a single blip must not
+            // silence every store view behind this one.
+            $this->_helper->log($e->getFriendlyMessage());
+            return false;
+        } catch (\Mailchimp_Error $e) {
+            // An answer from Mailchimp about the account itself. This is the
+            // only call in the run that asks about the credential and nothing
+            // else, which is why it is the only one that records a verdict.
             $this->_helper->log($e->getFriendlyMessage());
             $this->_helper->markApiKeyFailed($storeId);
             return false;

--- a/Cron/Webhook.php
+++ b/Cron/Webhook.php
@@ -342,6 +342,12 @@ class Webhook
             if (!$this->_helper->isMailChimpEnabled($storeId)) {
                 continue;
             }
+            // This runs before any webhook work is looked at, so an install
+            // with nothing to process still paid one rejected call per store
+            // view to find that out. One answer per credential is enough.
+            if ($this->_helper->isApiKeyFailed($storeId)) {
+                continue;
+            }
             $listId =$this->_helper->getDefaultList($storeId);
             if (!$listId||$listId==-1) {
                 $this->_helper->log("ListId [$listId] is invalid for Store [$storeId]");
@@ -359,6 +365,7 @@ class Webhook
                 } catch (\Mailchimp_Error $e) {
                     $error = $e->getMessage();
                     $this->_helper->log("Error: [$error] for store [$storeId]");
+                    $this->_helper->markApiKeyFailed($storeId);
                 }
             }
         }

--- a/Cron/Webhook.php
+++ b/Cron/Webhook.php
@@ -363,9 +363,13 @@ class Webhook
                         }
                     }
                 } catch (\Mailchimp_Error $e) {
+                    // Read, but deliberately not recorded. This call carries an
+                    // audience id, so a failure here can mean the audience is
+                    // wrong while the credential is perfectly good -- which is a
+                    // shape that exists in the field. The verdict is left to the
+                    // account call in the ecommerce job.
                     $error = $e->getMessage();
                     $this->_helper->log("Error: [$error] for store [$storeId]");
-                    $this->_helper->markApiKeyFailed($storeId);
                 }
             }
         }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -141,6 +141,19 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      * @var ProductMetadataInterface
      */
     private $productMetadata;
+
+    /**
+     * API keys that already failed in this process, by fingerprint.
+     *
+     * Process-scoped on purpose. A rejected credential is an answer, not a
+     * blip: it will be just as rejected for the next store view a millisecond
+     * later. Nothing is written anywhere, so the next cron run starts clean and
+     * a key fixed between runs is picked up immediately.
+     *
+     * @var array
+     */
+    private $failedApiKeys = [];
+
     /**
      * @var \Magento\Store\Model\StoreManagerInterface
      */
@@ -1519,5 +1532,60 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         }
 
         return $agent . ' Magento/' . $magento;
+    }
+
+    /**
+     * Remember that this store's API key failed, so callers can stop asking.
+     *
+     * Keyed on the credential rather than on the store, which is the whole
+     * point: one key shared across many store views is exactly the shape that
+     * turns a single rejection into one round trip per view.
+     *
+     * @param  int|null    $store
+     * @param  string|null $scope
+     * @return void
+     */
+    public function markApiKeyFailed($store = null, $scope = null)
+    {
+        $fingerprint = $this->apiKeyFingerprint($store, $scope);
+        if ($fingerprint !== null) {
+            $this->failedApiKeys[$fingerprint] = true;
+        }
+    }
+
+    /**
+     * Whether this store's API key has already failed in this process.
+     *
+     * @param  int|null    $store
+     * @param  string|null $scope
+     * @return bool
+     */
+    public function isApiKeyFailed($store = null, $scope = null)
+    {
+        $fingerprint = $this->apiKeyFingerprint($store, $scope);
+
+        return $fingerprint !== null && isset($this->failedApiKeys[$fingerprint]);
+    }
+
+    /**
+     * A stable handle for a key that never holds the key itself.
+     *
+     * Null for an empty key: a store with nothing configured has no credential
+     * to blame, and lumping them all under one empty fingerprint would let an
+     * unconfigured store silence a configured one.
+     *
+     * @param  int|null    $store
+     * @param  string|null $scope
+     * @return string|null
+     */
+    private function apiKeyFingerprint($store = null, $scope = null)
+    {
+        $apiKey = (string)$this->getApiKey($store, $scope);
+        $apiKey = trim($apiKey);
+        if ($apiKey === '') {
+            return null;
+        }
+
+        return hash('sha256', $apiKey);
     }
 }

--- a/Test/Unit/Cron/ApiKeyVerdictTest.php
+++ b/Test/Unit/Cron/ApiKeyVerdictTest.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Ebizmarts_MailChimp Magento Component
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Test\Unit\Cron;
+
+use Ebizmarts\MailChimp\Cron\Ecommerce;
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Which failures are allowed to conclude that a credential is dead.
+ *
+ * Only the account call does. It is the one request in the run that asks
+ * about the credential and nothing else.
+ */
+class ApiKeyVerdictTest extends TestCase
+{
+    /**
+     * The real helper keys this on a hash of the credential, not on the store,
+     * so every view sharing one key shares the verdict. The double has to model
+     * that or the test proves something the code does not do.
+     *
+     * @var bool
+     */
+    private $marked = false;
+
+    /**
+     * @param  mixed $raise   throwable for root->info(), or null to succeed
+     * @return Ecommerce
+     */
+    /** @var object */
+    private $apiRoot;
+
+    private function cron($raise)
+    {
+        $this->marked = false;
+
+        $api  = new \stdClass();
+        $api->root = new class($raise) {
+            private $raise;
+            public function __construct($raise) { $this->raise = $raise; }
+            public $calls = 0;
+            public function info()
+            {
+                $this->calls++;
+                if ($this->raise) { throw $this->raise; }
+                return ['account_id' => 'abc'];
+            }
+        };
+
+        $helper = $this->createMock(MailChimpHelper::class);
+        $helper->method('getApi')->willReturn($api);
+        $helper->method('isApiKeyFailed')->willReturnCallback(function () {
+            return $this->marked;
+        });
+        $helper->method('markApiKeyFailed')->willReturnCallback(function () {
+            $this->marked = true;
+        });
+
+        $cron = $this->getMockBuilder(Ecommerce::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([])
+            ->getMock();
+
+        $prop = new \ReflectionProperty(Ecommerce::class, '_helper');
+        $prop->setAccessible(true);
+        $prop->setValue($cron, $helper);
+
+        $this->apiRoot = $api->root;
+
+        return $cron;
+    }
+
+    /**
+     * @param  Ecommerce $cron
+     * @param  int       $storeId
+     * @return bool
+     */
+    private function ping(Ecommerce $cron, $storeId)
+    {
+        $m = new \ReflectionMethod(Ecommerce::class, '_ping');
+        $m->setAccessible(true);
+
+        return $m->invoke($cron, $storeId);
+    }
+
+    public function testARejectedCredentialIsRecorded()
+    {
+        $cron = $this->cron(new \Mailchimp_Error('/', 'GET', '', 'API Key Invalid', 'your key is wrong'));
+
+        $this->assertFalse($this->ping($cron, 1));
+        $this->assertTrue($this->marked);
+    }
+
+    /**
+     * The one dipola caught: DNS, TLS and timeouts arrive as Mailchimp_HttpError,
+     * which extends Mailchimp_Error. Recording those would let a single network
+     * blip silence every store view behind it.
+     */
+    public function testATransportFailureIsNotRecorded()
+    {
+        $cron = $this->cron(new \Mailchimp_HttpError('/', 'GET', '', '', 'Could not resolve host'));
+
+        $this->assertFalse($this->ping($cron, 1));
+        $this->assertFalse($this->marked);
+    }
+
+    public function testASuccessfulCallRecordsNothing()
+    {
+        $cron = $this->cron(null);
+
+        $this->assertTrue($this->ping($cron, 1));
+        $this->assertFalse($this->marked);
+    }
+
+    /**
+     * Once recorded, the remaining store views cost nothing at all.
+     */
+    public function testAKnownFailedCredentialShortCircuits()
+    {
+        $cron = $this->cron(new \Mailchimp_Error('/', 'GET', '', 'API Key Invalid', 'your key is wrong'));
+
+        $this->assertFalse($this->ping($cron, 1));
+        $this->assertFalse($this->ping($cron, 2));
+        $this->assertFalse($this->ping($cron, 3));
+        $this->assertSame(1, $this->apiRoot->calls, 'the account was asked once, not once per view');
+    }
+}

--- a/Test/Unit/Cron/WebhookLoadGroupsTest.php
+++ b/Test/Unit/Cron/WebhookLoadGroupsTest.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Ebizmarts_MailChimp Magento Component
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Test\Unit\Cron;
+
+use Ebizmarts\MailChimp\Cron\Webhook;
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Ebizmarts\MailChimp\Model\MailChimpInterestGroupFactory;
+use Ebizmarts\MailChimp\Model\ResourceModel\MailChimpWebhookRequest\CollectionFactory;
+use Magento\Customer\Model\CustomerFactory;
+use Magento\Newsletter\Model\SubscriberFactory;
+use Magento\Store\Model\StoreManager;
+use PHPUnit\Framework\TestCase;
+
+class WebhookLoadGroupsTest extends TestCase
+{
+    /** @var int */
+    private $getApiCalls = 0;
+
+    /**
+     * An API object whose only job is to reject the call, the way a store with
+     * a dead key does.
+     *
+     * @return object
+     */
+    private function rejectingApi()
+    {
+        $category = new class {
+            public function getAll($listId, $a = null, $b = null, $c = null)
+            {
+                throw new \Mailchimp_Error('/lists', 'GET', '', 'API Key Invalid', 'Your API key may be invalid');
+            }
+        };
+
+        $lists = new \stdClass();
+        $lists->interestCategory = $category;
+
+        $api = new \stdClass();
+        $api->lists = $lists;
+
+        return $api;
+    }
+
+    /**
+     * @param  int $storeViews
+     * @return Webhook
+     */
+    private function cronWithViews($storeViews)
+    {
+        $failed = [];
+
+        $helper = $this->createMock(MailChimpHelper::class);
+        $helper->method('isMailChimpEnabled')->willReturn(true);
+        $helper->method('getDefaultList')->willReturn('list-1');
+        $helper->method('getApi')->willReturnCallback(function () {
+            $this->getApiCalls++;
+            return $this->rejectingApi();
+        });
+        // One credential across every view, which is the shape that turns a
+        // single rejection into one round trip per view.
+        $helper->method('markApiKeyFailed')->willReturnCallback(function () use (&$failed) {
+            $failed['shared'] = true;
+        });
+        $helper->method('isApiKeyFailed')->willReturnCallback(function () use (&$failed) {
+            return isset($failed['shared']);
+        });
+
+        $storeManager = $this->createMock(StoreManager::class);
+        $storeManager->method('getStores')
+            ->willReturn(array_fill_keys(range(1, $storeViews), new \stdClass()));
+
+        return new Webhook(
+            $helper,
+            $this->createMock(SubscriberFactory::class),
+            $this->createMock(CollectionFactory::class),
+            $this->createMock(MailChimpInterestGroupFactory::class),
+            $storeManager,
+            $this->createMock(CustomerFactory::class)
+        );
+    }
+
+    /**
+     * @param  Webhook $cron
+     * @return void
+     */
+    private function loadGroups(Webhook $cron)
+    {
+        $method = new \ReflectionMethod(Webhook::class, '_loadGroups');
+        $method->setAccessible(true);
+        $method->invoke($cron);
+    }
+
+    /**
+     * The defect: this loop runs before any webhook work is looked at, so a
+     * dead key used to cost one rejected call per store view, every run.
+     */
+    public function testARejectedKeyIsAskedOnceNotOncePerStoreView()
+    {
+        $this->getApiCalls = 0;
+        $this->loadGroups($this->cronWithViews(28));
+
+        $this->assertSame(1, $this->getApiCalls);
+    }
+
+    public function testASingleViewStillAsksOnce()
+    {
+        $this->getApiCalls = 0;
+        $this->loadGroups($this->cronWithViews(1));
+
+        $this->assertSame(1, $this->getApiCalls);
+    }
+}

--- a/Test/Unit/Cron/WebhookLoadGroupsTest.php
+++ b/Test/Unit/Cron/WebhookLoadGroupsTest.php
@@ -25,6 +25,9 @@ class WebhookLoadGroupsTest extends TestCase
     /** @var int */
     private $getApiCalls = 0;
 
+    /** @var bool  whether the account call has already returned a verdict */
+    private $credentialAlreadyRejected = false;
+
     /**
      * An API object whose only job is to reject the call, the way a store with
      * a dead key does.
@@ -55,7 +58,7 @@ class WebhookLoadGroupsTest extends TestCase
      */
     private function cronWithViews($storeViews)
     {
-        $failed = [];
+        $failed = $this->credentialAlreadyRejected;
 
         $helper = $this->createMock(MailChimpHelper::class);
         $helper->method('isMailChimpEnabled')->willReturn(true);
@@ -64,13 +67,13 @@ class WebhookLoadGroupsTest extends TestCase
             $this->getApiCalls++;
             return $this->rejectingApi();
         });
-        // One credential across every view, which is the shape that turns a
-        // single rejection into one round trip per view.
-        $helper->method('markApiKeyFailed')->willReturnCallback(function () use (&$failed) {
-            $failed['shared'] = true;
-        });
+        // This loop reads the verdict and never writes one: the call it makes
+        // carries an audience id, so its failure can mean a wrong audience on a
+        // perfectly good key. The verdict comes from the account call in the
+        // ecommerce job, which runs first in the shared cron process.
+        $helper->expects($this->never())->method('markApiKeyFailed');
         $helper->method('isApiKeyFailed')->willReturnCallback(function () use (&$failed) {
-            return isset($failed['shared']);
+            return $failed;
         });
 
         $storeManager = $this->createMock(StoreManager::class);
@@ -100,21 +103,40 @@ class WebhookLoadGroupsTest extends TestCase
 
     /**
      * The defect: this loop runs before any webhook work is looked at, so a
-     * dead key used to cost one rejected call per store view, every run.
+     * dead key cost one rejected call per store view, every run. Once the
+     * account call has returned its verdict, they cost nothing.
      */
-    public function testARejectedKeyIsAskedOnceNotOncePerStoreView()
+    public function testAKnownRejectedKeyCostsNothingHere()
     {
         $this->getApiCalls = 0;
+        $this->credentialAlreadyRejected = true;
         $this->loadGroups($this->cronWithViews(28));
 
-        $this->assertSame(1, $this->getApiCalls);
+        $this->assertSame(0, $this->getApiCalls);
     }
 
-    public function testASingleViewStillAsksOnce()
+    /**
+     * And with no verdict in hand it still does its work rather than guessing.
+     */
+    public function testWithoutAVerdictTheLoopStillRuns()
     {
         $this->getApiCalls = 0;
-        $this->loadGroups($this->cronWithViews(1));
+        $this->credentialAlreadyRejected = false;
+        $this->loadGroups($this->cronWithViews(3));
 
-        $this->assertSame(1, $this->getApiCalls);
+        $this->assertSame(3, $this->getApiCalls);
+    }
+
+    /**
+     * The point of the review: a failure on this call carries an audience id,
+     * so it must not be allowed to condemn the credential.
+     */
+    public function testAFailureHereNeverCondemnsTheCredential()
+    {
+        $this->getApiCalls = 0;
+        $this->credentialAlreadyRejected = false;
+        $this->loadGroups($this->cronWithViews(5));
+
+        $this->assertSame(5, $this->getApiCalls);   // markApiKeyFailed asserted never above
     }
 }

--- a/Test/Unit/Helper/ApiKeyFailureMemoryTest.php
+++ b/Test/Unit/Helper/ApiKeyFailureMemoryTest.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Ebizmarts_MailChimp Magento Component
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Test\Unit\Helper;
+
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use PHPUnit\Framework\TestCase;
+
+class ApiKeyFailureMemoryTest extends TestCase
+{
+    /**
+     * The helper takes two dozen constructor arguments, none of which this
+     * behaviour touches. Only getApiKey() is stubbed, so the code under test
+     * is the real thing.
+     *
+     * @param  array $keysByStore
+     * @return MailChimpHelper
+     */
+    private function helperWithKeys(array $keysByStore)
+    {
+        $helper = $this->getMockBuilder(MailChimpHelper::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getApiKey'])
+            ->getMock();
+
+        $helper->method('getApiKey')->willReturnCallback(
+            function ($store = null, $scope = null) use ($keysByStore) {
+                return isset($keysByStore[$store]) ? $keysByStore[$store] : '';
+            }
+        );
+
+        return $helper;
+    }
+
+    public function testAStoreIsNotFailedBeforeAnythingFails()
+    {
+        $helper = $this->helperWithKeys([1 => 'key-a-us1']);
+
+        $this->assertFalse($helper->isApiKeyFailed(1));
+    }
+
+    public function testFailureIsRememberedForTheStoreThatFailed()
+    {
+        $helper = $this->helperWithKeys([1 => 'key-a-us1']);
+        $helper->markApiKeyFailed(1);
+
+        $this->assertTrue($helper->isApiKeyFailed(1));
+    }
+
+    /**
+     * The point of the whole change: one credential shared across many store
+     * views is answered once, not once per view.
+     */
+    public function testFailureIsSharedByEveryStoreUsingTheSameKey()
+    {
+        $helper = $this->helperWithKeys([1 => 'key-a-us1', 2 => 'key-a-us1', 3 => 'key-a-us1']);
+        $helper->markApiKeyFailed(1);
+
+        $this->assertTrue($helper->isApiKeyFailed(2));
+        $this->assertTrue($helper->isApiKeyFailed(3));
+    }
+
+    /**
+     * And the converse, so the memory cannot silence a store it knows nothing
+     * about: a different key is a different credential.
+     */
+    public function testADifferentKeyIsUnaffected()
+    {
+        $helper = $this->helperWithKeys([1 => 'key-a-us1', 2 => 'key-b-us2']);
+        $helper->markApiKeyFailed(1);
+
+        $this->assertFalse($helper->isApiKeyFailed(2));
+    }
+
+    /**
+     * An unconfigured store has no credential to blame. Without this, every
+     * empty key would share one fingerprint and the first unconfigured store
+     * would silence all the others.
+     */
+    public function testAnEmptyKeyIsNeverRemembered()
+    {
+        $helper = $this->helperWithKeys([1 => '', 2 => '   ', 3 => 'key-a-us1']);
+        $helper->markApiKeyFailed(1);
+
+        $this->assertFalse($helper->isApiKeyFailed(1));
+        $this->assertFalse($helper->isApiKeyFailed(2));
+        $this->assertFalse($helper->isApiKeyFailed(3));
+    }
+
+    /**
+     * Whitespace and case are the same credential as far as Mailchimp is
+     * concerned, but not as far as a naive array key is.
+     */
+    public function testKeyIsMatchedAfterTrimming()
+    {
+        $helper = $this->helperWithKeys([1 => 'key-a-us1', 2 => '  key-a-us1  ']);
+        $helper->markApiKeyFailed(2);
+
+        $this->assertTrue($helper->isApiKeyFailed(1));
+    }
+}


### PR DESCRIPTION
## The problem

A store whose API key has been revoked or mistyped pays for that answer once per store view, twice over, every five minutes — and nothing ever remembers it.

Two independent paths, in two different classes:

- `Cron\Ecommerce::_ping()` calls `root/info` once per store view. On failure it logs, returns `false`, and the loop `continue`s to the next view — where it asks again.
- `Cron\Webhook`, via `_loadGroups()`, calls `lists/interest-categories` once per store view. It catches, logs and continues in the same way.

Both jobs are scheduled `*/5`, both are in the `mailchimp` cron group, and that group sets `<use_separate_process>1</use_separate_process>` — Magento runs the *group* in one process, not each job in its own. So the two loops run back to back in the same process and neither knows the other was just told no.

On an installation with **28 store views sharing one API key**, that is 28 rejected `root` calls plus 28 rejected `lists` calls — 56 round trips per run, to learn one fact — with observed wall-clock between 14 and 28 seconds of cron time, every five minutes.

`_loadGroups()` is the worse of the two: it is the **first statement of `processWebhooks()`**, unconditional, before any webhook work is looked at. An install with zero pending webhooks still pays the full per-view cost to discover there is nothing to do.

## The change

`Helper\Data` remembers, for the life of the process, which API keys have already failed:

```php
public function markApiKeyFailed($store = null, $scope = null)
public function isApiKeyFailed($store = null, $scope = null)
```

**Both loops read that memory. Only one writes to it.**

`_ping()` is the only request in the run that asks about the credential and nothing else, so it is the only one that records a verdict. `_loadGroups()` consults it and stays silent, because the call it guards carries an audience id — a failure there can mean a wrong audience on a perfectly good key, which is a shape that exists in the field.

Both jobs share a cron process and the ecommerce job runs first — observed 10 of 10 consecutive runs on a live box, 1–2 seconds apart — so the verdict is in hand before the webhook loop reads it.

## What is allowed to conclude that a key is dead

Not every failure. `Mailchimp_HttpError` **extends** `Mailchimp_Error` and carries transport failures — DNS, TLS, timeouts — so it is caught first, being the subclass, and records nothing. A single network blip must not silence every store view behind it.

The library's exceptions carry no HTTP status — `Mailchimp_Error` holds only `title` and `detail` from the response body — so matching on 401 specifically would mean string-matching an error title. Narrowing to the account call achieves the same end without that.

## Three decisions worth stating, since each is a place this could be got wrong

**Keyed on the credential, not on the store.** Keying on store id would have fixed nothing — one key shared across many views is the entire shape of the problem. The fingerprint is a `sha256` of the trimmed key, so the key itself is never held in the array.

**An empty key is never remembered.** An unconfigured store has no credential to blame, and lumping every empty key under one fingerprint would let the first unconfigured store silence the configured ones behind it.

**Process-scoped, and nothing is persisted.** No table, no config, no cache entry. The next cron run starts clean, so a key fixed between runs is picked up on the next tick. Remembering across runs is a different problem and would need somewhere to remember.

## Verification

Twelve tests across three files, each watched failing against the unmodified code before being kept.

`ApiKeyVerdictTest` pins which failures may conclude anything: a rejected credential records, **a transport failure does not**, a success records nothing, and a known-failed credential asks the account once rather than once per view. The transport case fails with `Failed asserting that true is false` against the code before it.

`WebhookLoadGroupsTest` drives the real `_loadGroups()` with a mocked store manager and a rejecting API object:

| | `getApi()` calls for 28 views |
|---|---|
| with a verdict already in hand | **0** |
| with no verdict | 28, and `markApiKeyFailed` asserted `never()` |

`ApiKeyFailureMemoryTest` covers the memory itself against the real helper methods, with only `getApiKey()` stubbed: a failure is shared by every store using the same key, a different key is unaffected, an empty key is never remembered, and whitespace around a key resolves to the same credential.

Full module unit suite: **157 tests, 280 assertions, green**.

## Expectation worth setting, since it does not change the code

This helps installs with many store views on one key. It does **not** help a single-store-view install whose cron retries a dead key every run — there is one rejected call per run either way, and the run frequency is the driver. Both shapes exist. Worth knowing before anyone reads a flat error count afterwards and concludes the change underdelivered.

## Scope

Additive. No schema change, no new config path, no merchant-visible setting, and no change to behaviour when the key works — a healthy install never enters either branch.
