### PR TITLE
Name the store when loading Mailchimp stores

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1003,6 +1003,13 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
             $this->_api->setApiKey(trim($apiKey));
             $this->_api->setUserAgent('Mailchimp4Magento' . (string)$this->getModuleVersion());
             $this->_api->setHelper($this);
+            // Must stay after setApiKey. That call is what opens the library's
+            // telemetry bucket, and setStoreURL() writes into an already-open
+            // bucket rather than keeping a copy on the instance -- so moved
+            // above it this line is silently lost and the bucket reports with
+            // no site attached. Verified: before setApiKey the URL comes
+            // through NULL, after it comes through set.
+            $this->_api->setStoreURL($this->_storeManager->getStore()->getBaseUrl());
 
 
             try {


### PR DESCRIPTION
## The problem

`Helper\Data` has three places that hand an API key to the library. Two of them name the store; one does not.

| | `setApiKey` | `setHelper` | `setStoreURL` |
|---|---|---|---|
| `getApi()` | ✅ | ✅ | ✅ |
| `getApiByApiKey()` | ✅ | ✅ | ✅ |
| `loadStores()` | ✅ | ✅ | **missing** |

The asymmetry is visible as a bare count in the file: `setHelper` three times, `setStoreURL` twice.

`setApiKey()` is what opens the library's telemetry bucket, and `setStoreURL()` writes into an already-open bucket rather than keeping a copy on the instance. So a bucket opened without that call can never acquire a URL later — everything reported from that run is unattributable to a site, including the account id and subscriber count that this path is the only one to collect.

`loadStores()` has a single caller, `Controller/Adminhtml/Stores/Index.php:21`.

## The change

One call, after `setApiKey`:

```php
$this->_api->setStoreURL($this->_storeManager->getStore()->getBaseUrl());
```

Copied from the sibling in `getApiByApiKey()`, which is also admin-invoked and has always read the base URL this way — so this is existing shipped behaviour applied to a third site, not a new pattern.

## Verification

**Placement matters, and it was checked rather than assumed.** Driving the real library through each sequence and reading the bucket back:

| sequence | `store_url` in the bucket |
|---|---|
| `loadStores()` as it stands | `NULL` |
| with this call added, after `setApiKey` | `'https://…/'` |
| the same call placed *before* `setApiKey` | `NULL` |

The third row is why the line goes where it does: before `setApiKey` there is no bucket to write into, and the call is silently lost.

**Admin context returns the storefront URL, not the admin URL.** Worth confirming since the only caller is an admin controller — with the area set to `adminhtml`, `getStore()` returns the admin store (id 0) and `getBaseUrl()` still yields the storefront base URL.

Module unit suite: 138 tests, 249 assertions, green.

## Not done here

The four-line prelude now appears three times and has drifted once, so collapsing it into a shared private method is tempting. I left it alone deliberately: the three sites differ in four ways — one decrypts the key, one trims it, one takes a store parameter, one applies a timeout — so a shared helper would need parameters for each, and it would rewrite two working call sites to guard against a hypothetical fourth. Worth doing as its own change, with its own review, rather than riding along with a one-line fix.