### PR TITLE
Report the Magento version in the user agent

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -15,6 +15,7 @@ use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\Exception\ValidatorException;
 use Magento\Store\Model\Store;
 use Ebizmarts\MailChimp\Model\MailchimpNotificationFactory as MailchimpNotificationFactory;
+use Magento\Framework\App\ProductMetadataInterface;
 
 class Data extends \Magento\Framework\App\Helper\AbstractHelper
 {
@@ -135,6 +136,11 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     const MIN_LIB_VERSION = '3.0.45';
 
     protected $counters = [];
+
+    /**
+     * @var ProductMetadataInterface
+     */
+    private $productMetadata;
     /**
      * @var \Magento\Store\Model\StoreManagerInterface
      */
@@ -291,7 +297,8 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         \Magento\Framework\Stdlib\DateTime\DateTime $date,
         \Magento\Directory\Model\CountryFactory $countryFactory,
         \Magento\Framework\Locale\Resolver $resolver,
-        MailchimpNotificationFactory $mailchimpNotificationFactory
+        MailchimpNotificationFactory $mailchimpNotificationFactory,
+        ProductMetadataInterface $productMetadata
     ) {
 
         $this->_storeManager  = $storeManager;
@@ -319,6 +326,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         $this->countryFactory           = $countryFactory;
         $this->resolver                 = $resolver;
         $this->mailchimpNotificationFactory = $mailchimpNotificationFactory;
+        $this->productMetadata          = $productMetadata;
         parent::__construct($context);
     }
 
@@ -382,7 +390,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         if (method_exists($this->_api, 'setMailchimpStoreId')) {
             $this->_api->setMailchimpStoreId($this->getConfigValue(self::XML_MAILCHIMP_STORE, $store, $scope));
         }
-        $this->_api->setUserAgent('Mailchimp4Magento' . (string)$this->getModuleVersion());
+        $this->_api->setUserAgent($this->userAgent());
         if ($timeOut) {
             $this->_api->setTimeOut($timeOut);
         }
@@ -515,7 +523,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
             $this->_api->setApiKey($apiKey);
         }
 
-        $this->_api->setUserAgent('Mailchimp4Magento' . (string)$this->getModuleVersion());
+        $this->_api->setUserAgent($this->userAgent());
         $this->_api->setHelper($this);
         $this->_api->setStoreURL($this->_storeManager->getStore()->getBaseUrl());
         if (method_exists($this->_api, 'setMailchimpStoreId')) {
@@ -1001,7 +1009,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
                 continue;
             }
             $this->_api->setApiKey(trim($apiKey));
-            $this->_api->setUserAgent('Mailchimp4Magento' . (string)$this->getModuleVersion());
+            $this->_api->setUserAgent($this->userAgent());
             $this->_api->setHelper($this);
 
 
@@ -1472,5 +1480,37 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     public function getPixelScriptUrl($storeId)
     {
         return (string)$this->getConfigValue(self::XML_PIXEL_SCRIPT_URL, $storeId);
+    }
+
+    /**
+     * The user agent every call to the Mailchimp API carries.
+     *
+     * `Mailchimp4Magento103.4.82` reads to the eye as though the number were
+     * the Magento version. It is the module's. The platform version is added
+     * with a slash so the two cannot be confused by a reader or by a parser,
+     * and so it stays absent rather than wrong on a host that cannot answer.
+     *
+     * Built in one place because the three callers were byte-identical and a
+     * fourth would have had nothing to copy from but one of them.
+     *
+     * @return string
+     */
+    private function userAgent()
+    {
+        $agent = 'Mailchimp4Magento' . (string)$this->getModuleVersion();
+
+        try {
+            $magento = (string)$this->productMetadata->getVersion();
+        } catch (\Throwable $t) {
+            // One arm covers both: Exception implements Throwable, and this
+            // module's floor is Magento 2.4, so PHP 7 or newer is guaranteed.
+            return $agent;
+        }
+
+        if ($magento === '') {
+            return $agent;
+        }
+
+        return $agent . ' Magento/' . $magento;
     }
 }

--- a/Test/Unit/Helper/UserAgentTest.php
+++ b/Test/Unit/Helper/UserAgentTest.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Ebizmarts_MailChimp Magento Component
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Test\Unit\Helper;
+
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Magento\Framework\App\ProductMetadataInterface;
+use PHPUnit\Framework\TestCase;
+
+class UserAgentTest extends TestCase
+{
+    /**
+     * Only the two inputs are stubbed, so the string under test is built by
+     * the real method.
+     *
+     * @param  string $moduleVersion
+     * @param  mixed  $magentoVersion string, or a throwable to raise
+     * @return string
+     */
+    private function agent($moduleVersion, $magentoVersion)
+    {
+        $metadata = $this->createMock(ProductMetadataInterface::class);
+        if ($magentoVersion instanceof \Throwable) {
+            $metadata->method('getVersion')->willThrowException($magentoVersion);
+        } else {
+            $metadata->method('getVersion')->willReturn($magentoVersion);
+        }
+
+        $helper = $this->getMockBuilder(MailChimpHelper::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getModuleVersion'])
+            ->getMock();
+        $helper->method('getModuleVersion')->willReturn($moduleVersion);
+
+        $prop = new \ReflectionProperty(MailChimpHelper::class, 'productMetadata');
+        $prop->setAccessible(true);
+        $prop->setValue($helper, $metadata);
+
+        $method = new \ReflectionMethod(MailChimpHelper::class, 'userAgent');
+        $method->setAccessible(true);
+
+        return $method->invoke($helper);
+    }
+
+    public function testCarriesBothVersions()
+    {
+        $this->assertSame(
+            'Mailchimp4Magento103.4.82 Magento/2.4.8',
+            $this->agent('103.4.82', '2.4.8')
+        );
+    }
+
+    /**
+     * The reader requires the slash, so `Mailchimp4Magento103.4.82` can never
+     * be misread as a Magento version.
+     */
+    public function testPlatformVersionIsSlashPrefixed()
+    {
+        $this->assertMatchesRegularExpression('~ Magento/2\.4\.8$~', $this->agent('103.4.82', '2.4.8'));
+    }
+
+    public function testStaysWellUnderTheHeaderCap()
+    {
+        $this->assertLessThan(128, strlen($this->agent('103.4.82', '2.4.8')));
+    }
+
+    /**
+     * Absent beats wrong: a host that cannot answer keeps the old agent rather
+     * than reporting an empty or invented platform version.
+     */
+    public function testFallsBackToTheModuleAgentWhenTheVersionIsEmpty()
+    {
+        $this->assertSame('Mailchimp4Magento103.4.82', $this->agent('103.4.82', ''));
+    }
+
+    public function testFallsBackWhenTheVersionLookupRaises()
+    {
+        $this->assertSame(
+            'Mailchimp4Magento103.4.82',
+            $this->agent('103.4.82', new \RuntimeException('no metadata'))
+        );
+    }
+
+    /**
+     * The cross-check looks for the module version inside the agent rather
+     * than comparing the whole string, so a second version must not push the
+     * first out of reach.
+     */
+    public function testModuleVersionIsStillFindableInTheAgent()
+    {
+        $this->assertStringContainsString('103.4.82', $this->agent('103.4.82', '2.4.8'));
+    }
+}


### PR DESCRIPTION
## What it changes

The user agent sent with every Mailchimp API call has always been:

```
Mailchimp4Magento103.4.82
```

which reads as though the number were the Magento version. It is the **module's** `setup_version` — `getModuleVersion()` returns `$modules['Ebizmarts_MailChimp']['setup_version']`. The platform version was not carried anywhere.

It now reads:

```
Mailchimp4Magento103.4.82 Magento/2.4.8
```

39 characters against a 128 cap.

The slash is deliberate rather than cosmetic: it makes the two versions impossible to confuse for a reader, and it lets anything parsing the agent require `Magento/x.y.z` instead of guessing which number is which.

## Absent beats wrong

If `ProductMetadataInterface` cannot be asked, or answers with an empty string, the agent stays exactly as it was. Nothing invented, nothing empty appended — the change can only add a version that is really there.

## Three call sites became one method

`setUserAgent(...)` appeared three times in `Helper\Data`, byte-identical. Collapsing them was safe precisely because they were identical — unlike the surrounding four-line API prelude, which differs between sites and is deliberately left alone. A fourth caller would otherwise have had nothing to copy from but one of the three.

## Cost

`ProductMetadataInterface` was not injected in `Helper\Data`, so this adds a constructor argument — the 25th. Checked before doing it: nothing constructs the helper with `new` anywhere in the module, and all fourteen tests that touch it use `createMock`, so a new argument reaches none of them. Verified afterwards that the object manager still builds the helper.

## Verification

Six new tests, each watched failing against the unmodified helper first — all six error with `Call to undefined method` before the change and pass after.

They cover: both versions present; the slash prefix; the length staying under the cap; the fallback when the platform version is empty; the fallback when the lookup raises; and the module version still being findable inside the agent, since a cross-check that searches for it must not be broken by a second version appearing.

On a real install the method produces `Mailchimp4Magento103.4.82 Magento/2.4.8`.

Full module unit suite: 144 tests, 255 assertions, green.