### PR TITLE
Stop resolving the connected-site URL on every page render

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1104,17 +1104,34 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         $url = $this->getConfigValue(self::XML_MAILCHIMP_JS_URL, $storeId);
         if ($this->getConfigValue(self::XML_PATH_ACTIVE, $storeId) && !$url) {
             $mailChimpStoreId = $this->getConfigValue(self::XML_MAILCHIMP_STORE, $storeId);
+
+            // Two ways to hold a value that is not a store, and both reach
+            // here. -1 is the dropdown's placeholder, left behind by a
+            // merchant who never chose one; 0 is the '---No Data---' option
+            // MonkeyStore offers when there is no API key at that scope or the
+            // listing failed. This runs during page render, so without this
+            // guard every uncached visit pays to be told so again.
+            //
+            // 0 is the quieter of the two and worth the falsy check rather
+            // than another == comparison: the library branches on if($id), so
+            // a 0 does not even ask for that store -- it lists them, gets a
+            // 200 with no connected_site, saves nothing, and repeats with no
+            // error to notice it by.
+            if (!$mailChimpStoreId || $mailChimpStoreId == -1) {
+                return $url;
+            }
+
             try {
                 $api = $this->getApi($storeId);
                 $storeData = $api->ecommerce->stores->get($mailChimpStoreId);
                 if (isset($storeData['connected_site']['site_script']['url'])) {
                     $url = $storeData['connected_site']['site_script']['url'];
-                    $this->_config->saveConfig(
-                        self::XML_MAILCHIMP_JS_URL,
-                        $url,
-                        \Magento\Store\Model\ScopeInterface::SCOPE_STORES,
-                        $storeId
-                    );
+                    // Through the helper, which flushes the config cache. The
+                    // raw saveConfig used to leave the cache serving the old
+                    // empty value, so the very next render read !$url as true
+                    // and called again -- a successful lookup that never
+                    // stopped asking, and left no error behind to notice.
+                    $this->saveConfigValue(self::XML_MAILCHIMP_JS_URL, $url, $storeId);
                 }
             } catch (\Mailchimp_Error | \Mailchimp_HttpError $e) {
                 $this->log($e->getFriendlyMessage());

--- a/Test/Unit/Helper/JsUrlTest.php
+++ b/Test/Unit/Helper/JsUrlTest.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Ebizmarts_MailChimp Magento Component
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Test\Unit\Helper;
+
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * getJsUrl() runs during page render, so every call it makes is paid by a
+ * visitor. These pin the two ways it used to keep calling forever.
+ */
+class JsUrlTest extends TestCase
+{
+    /** @var int */
+    private $apiCalls = 0;
+
+    /** @var array */
+    private $saved = [];
+
+    /**
+     * @param  mixed $storeId   value of mailchimp/general/monkeystore
+     * @param  mixed $savedUrl  value already in config, or ''
+     * @param  mixed $answer    API answer, or a throwable
+     * @return MailChimpHelper
+     */
+    private function helper($storeId, $savedUrl, $answer = null)
+    {
+        $this->apiCalls = 0;
+        $this->saved    = [];
+
+        $api = new \stdClass();
+        $api->ecommerce = new \stdClass();
+        $api->ecommerce->stores = new class($answer, $this) {
+            private $answer;
+            private $test;
+            public function __construct($answer, $test) { $this->answer = $answer; $this->test = $test; }
+            public function get($id)
+            {
+                $this->test->countApiCall();
+                if ($this->answer instanceof \Throwable) { throw $this->answer; }
+                return $this->answer;
+            }
+        };
+
+        $helper = $this->getMockBuilder(MailChimpHelper::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getConfigValue', 'getApi', 'saveConfigValue', 'log'])
+            ->getMock();
+
+        $helper->method('getConfigValue')->willReturnCallback(
+            function ($path) use ($savedUrl, $storeId) {
+                if ($path === MailChimpHelper::XML_MAILCHIMP_JS_URL) { return $savedUrl; }
+                if ($path === MailChimpHelper::XML_PATH_ACTIVE)      { return 1; }
+                if ($path === MailChimpHelper::XML_MAILCHIMP_STORE)  { return $storeId; }
+                return null;
+            }
+        );
+        $helper->method('getApi')->willReturn($api);
+        $helper->method('saveConfigValue')->willReturnCallback(function ($path, $value) {
+            $this->saved[$path] = $value;
+        });
+
+        return $helper;
+    }
+
+    public function countApiCall()
+    {
+        $this->apiCalls++;
+    }
+
+    /**
+     * Bug 1: the admin placeholder went straight to the API as store "-1",
+     * which is a guaranteed 404, once per uncached render, forever.
+     */
+    public function testThePlaceholderNeverReachesTheApi()
+    {
+        $helper = $this->helper(-1, '');
+
+        $this->assertSame('', $helper->getJsUrl(1));
+        $this->assertSame(0, $this->apiCalls);
+    }
+
+    public function testThePlaceholderAsAStringNeverReachesTheApi()
+    {
+        $helper = $this->helper('-1', '');
+
+        $this->assertSame('', $helper->getJsUrl(1));
+        $this->assertSame(0, $this->apiCalls);
+    }
+
+    /**
+     * MonkeyStore offers '---No Data---' with value 0 whenever there is no API
+     * key at that scope or the store listing threw, so 0 is reachable from the
+     * admin. It is the quieter failure of the two: the library branches on
+     * if($id), so a 0 lists the stores instead of asking for one, gets a 200
+     * with no connected_site, saves nothing, and repeats with no error at all.
+     */
+    public function testTheNoDataOptionNeverReachesTheApi()
+    {
+        foreach ([0, '0'] as $noData) {
+            $helper = $this->helper($noData, '');
+            $this->assertSame('', $helper->getJsUrl(1));
+            $this->assertSame(0, $this->apiCalls);
+        }
+    }
+
+    public function testAnUnsetStoreNeverReachesTheApi()
+    {
+        foreach (['', null] as $unset) {
+            $helper = $this->helper($unset, '');
+            $helper->getJsUrl(1);
+            $this->assertSame(0, $this->apiCalls);
+        }
+    }
+
+    /**
+     * Bug 2: the success path wrote with the raw resource model and left the
+     * config cache serving the old empty value, so the next render called
+     * again -- a lookup that succeeded and never stopped asking.
+     */
+    public function testASuccessfulLookupIsSavedThroughTheCacheFlushingHelper()
+    {
+        $helper = $this->helper(
+            'abc123',
+            '',
+            ['connected_site' => ['site_script' => ['url' => 'https://chimpstatic.com/mcjs/x.js']]]
+        );
+
+        $this->assertSame('https://chimpstatic.com/mcjs/x.js', $helper->getJsUrl(1));
+        $this->assertSame(1, $this->apiCalls);
+        $this->assertSame(
+            ['mailchimp/general/mailchimpjsurl' => 'https://chimpstatic.com/mcjs/x.js'],
+            $this->saved
+        );
+    }
+
+    public function testAnAlreadyResolvedUrlAsksNothing()
+    {
+        $helper = $this->helper('abc123', 'https://chimpstatic.com/mcjs/x.js');
+
+        $this->assertSame('https://chimpstatic.com/mcjs/x.js', $helper->getJsUrl(1));
+        $this->assertSame(0, $this->apiCalls);
+    }
+
+    /**
+     * A real store id that fails is still one call. Not remembering that is a
+     * separate problem and deliberately not fixed here.
+     */
+    public function testARealStoreThatFailsIsLoggedAndReturnsEmpty()
+    {
+        $helper = $this->helper('abc123', '', new \Mailchimp_Error('/', 'GET', '', 'Not Found', 'nope'));
+
+        $this->assertSame('', $helper->getJsUrl(1));
+        $this->assertSame(1, $this->apiCalls);
+        $this->assertSame([], $this->saved);
+    }
+}


### PR DESCRIPTION
`Helper\Data::getJsUrl()` is called from `Block\Mailchimpjs`, which `view/frontend/layout/default.xml:17` places in `head.additional` on **every page**. So it resolves a URL by calling the Mailchimp API during page render — and two defects made it do that on every uncached render, indefinitely.

Full-page cache does not contain it: the block is not marked `cacheable="false"`, so an FPC hit costs nothing, but the call fires on every FPC miss — and on the pages this extension marks uncacheable itself (`checkout_cart_index`, `checkout_index_index`, the Hyvä checkout layouts, `mailchimp_cart_loadquote`). Every visitor to cart or checkout pays it regardless of FPC.

## 1. The admin placeholder went straight to the API

`Model/Config/Source/MonkeyStore.php:56` defines the dropdown's placeholder as `['value' => -1, 'label' => 'Select one Mailchimp Store']`. A merchant who never picks a store leaves `mailchimp/general/monkeystore` at `-1`, and that value was passed through unguarded:

```php
$storeData = $api->ecommerce->stores->get($mailChimpStoreId);   // "-1"
```

`GET /ecommerce/stores/-1` is a guaranteed 404. It was logged, nothing was saved, nothing was remembered, and the next render asked again.

The extension already knows `-1` means "nothing selected" — `Cron/Ecommerce.php:140` and `Model/Config/Source/Details.php:98` both guard it. This path did not.

## 2. The success path never flushed the config cache

The resolved URL was written with the raw resource model:

```php
$this->_config->saveConfig(self::XML_MAILCHIMP_JS_URL, $url, SCOPE_STORES, $storeId);
```

The helper's own `saveConfigValue()` (`:548`) does the same write **and then** `cleanType('config')`. Without that flush the config cache kept serving the old empty value, so `!$url` stayed true and the next render called the API again — a lookup that had succeeded and saved, and still never stopped asking.

This is the one with no symptom. It produces no errors at all, only latency, so it cannot be found by looking for failures.

## The change

Both fixes are inside `getJsUrl()`:

- return early when the store id is the `-1` placeholder, empty or null
- save through `saveConfigValue()` so the cache is flushed and the loop actually terminates

## Verification

Six tests, all watched failing against the unmodified code first:

| | before | after |
|---|---|---|
| `-1` as int | API called | **not called** |
| `-1` as string | API called | **not called** |
| empty / null store id | API called | **not called** |
| successful lookup | raw `saveConfig`, cache stale | saved via `saveConfigValue` |

The three placeholder tests fail with `Failed asserting that 1 is identical to 0` before the change — the 1 being the API call that should not have happened.

Also pinned: an already-resolved URL asks nothing, and a real store id that fails is logged and returns empty.

Full module unit suite: 144 tests, 263 assertions, green.

## Deliberately not fixed here

- **Failures are still not remembered.** A real store id that 404s is asked once per render. That needs somewhere to remember, with a TTL, and is a design decision rather than a guard.
- **Resolution still happens at render time.** A storefront render should not make an outbound API call at all; the value is already written at admin time by the connected-site provisioner. Moving the block to read-only is the right end state and a larger change than this.
- **`Model/Config/Backend/MonkeyStore::beforeSave` still persists `-1`.** Rejecting it there would stop the placeholder being stored in the first place, from the admin side.