### PR TITLE
Fetch interest groups once per store view, and only when they can be used

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1296,9 +1296,27 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         } else {
             $interest = [];
         }
+
+        // Nothing below can use the answer when no groups are selected: the
+        // first loop matches against an empty list and the second iterates
+        // one, so $rc comes back empty however the call goes. This is the
+        // quiet majority -- an audience configured and no groups chosen is
+        // the default state of an install that never used them.
+        if (!$interest) {
+            return $rc;
+        }
+
+        // And the audience id has the same placeholder problem as the store
+        // id: -1 is the dropdown's, and an empty value builds
+        // `lists//interest-categories`. Cron/Webhook guards this exact call
+        // the same way.
+        $listId = $this->getConfigValue(self::XML_PATH_LIST, $storeId);
+        if (!$listId || $listId == -1) {
+            return $rc;
+        }
+
         try {
             $api = $this->getApi($storeId);
-            $listId = $this->getConfigValue(self::XML_PATH_LIST, $storeId);
             $allInterest = $api->lists->interestCategory->getAll($listId, null, null, 200);
             if (is_array($allInterest) &&
                 array_key_exists('categories', $allInterest) &&
@@ -1327,7 +1345,12 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     }
     public function getSubscriberInterest($subscriberId, $storeId, $interest = null)
     {
-        if (!$interest) {
+        // Strictly null, because [] is an answer and not an absence. Read as
+        // falsy it meant "the caller supplied nothing", so a store with no
+        // groups configured -- where this legitimately returns [] -- re-asked
+        // Mailchimp once per subscriber, on a successful call, with nothing to
+        // show for it and no error to notice it by.
+        if ($interest === null) {
             $interest = $this->getInterest($storeId);
         }
         /**

--- a/Model/Api/Subscriber.php
+++ b/Model/Api/Subscriber.php
@@ -40,6 +40,15 @@ class Subscriber
     protected $_interest=null;
 
     /**
+     * Whether the interest groups for the store view being synced have been
+     * fetched. Separate from $_interest because [] is a real answer: without
+     * it, a store with no groups configured looks unfetched forever.
+     *
+     * @var bool
+     */
+    protected $_interestLoaded = false;
+
+    /**
      * @param \Ebizmarts\MailChimp\Helper\Data $helper
      * @param SyncHelper $syncHelper
      * @param \Magento\Newsletter\Model\ResourceModel\Subscriber\CollectionFactory $subscriberCollection
@@ -65,7 +74,16 @@ class Subscriber
     {
         //get subscribers
 //        $listId = $this->_helper->getGeneralList($storeId);
-        $this->_interest = $this->_helper->getInterest($storeId);
+        // Reset rather than fetch. This object has no shared="false" in
+        // di.xml, so it is one instance reused for every store view in a cron
+        // run -- carrying one view's groups into the next would sync the wrong
+        // groups, with no error and no log line to show for it.
+        //
+        // And fetching here cost a call on every view of every run, before
+        // anything established there was a subscriber to sync at all.
+        $this->_interest       = null;
+        $this->_interestLoaded = false;
+
         $collection = $this->_subscriberCollection->create();
         $collection->addFieldToFilter('subscriber_status', ['eq' => 1])
             ->addFieldToFilter('store_id', ['eq' => $storeId]);
@@ -140,6 +158,12 @@ class Subscriber
     protected function _getInterest(\Magento\Newsletter\Model\Subscriber $subscriber)
     {
         $rc = [];
+
+        if (!$this->_interestLoaded) {
+            $this->_interest       = $this->_helper->getInterest($subscriber->getStoreId());
+            $this->_interestLoaded = true;
+        }
+
         $interest = $this->_helper->getSubscriberInterest(
             $subscriber->getSubscriberId(),
             $subscriber->getStoreId(),

--- a/Test/Unit/Helper/InterestGroupsTest.php
+++ b/Test/Unit/Helper/InterestGroupsTest.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * Ebizmarts_MailChimp Magento Component
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Test\Unit\Helper;
+
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Ebizmarts\MailChimp\Model\MailChimpInterestGroupFactory;
+use PHPUnit\Framework\TestCase;
+
+class InterestGroupsTest extends TestCase
+{
+    /** @var int */
+    private $apiCalls = 0;
+
+    /**
+     * @param  string $groups  value of mailchimp/general/interest
+     * @param  mixed  $listId  value of mailchimp/general/monkeylist
+     * @return MailChimpHelper
+     */
+    private function helper($groups, $listId)
+    {
+        $this->apiCalls = 0;
+
+        // The real call is two deep: the categories, then one request per
+        // configured group id.
+        $interests = new class($this) {
+            private $test;
+            public function __construct($test) { $this->test = $test; }
+            public function getAll($listId, $catId, $a = null, $b = null, $c = null)
+            {
+                $this->test->countCall();
+                return ['interests' => []];
+            }
+        };
+        $category = new class($this, $interests) {
+            private $test;
+            public $interests;
+            public function __construct($test, $interests) { $this->test = $test; $this->interests = $interests; }
+            public function getAll($listId, $a = null, $b = null, $c = null)
+            {
+                $this->test->countCall();
+                return ['categories' => []];
+            }
+        };
+        $lists = new \stdClass();
+        $lists->interestCategory = $category;
+        $api = new \stdClass();
+        $api->lists = $lists;
+
+        $helper = $this->getMockBuilder(MailChimpHelper::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getConfigValue', 'getApi', 'log'])
+            ->getMock();
+        $helper->method('getConfigValue')->willReturnCallback(
+            function ($path) use ($groups, $listId) {
+                if ($path === MailChimpHelper::XML_INTEREST)   { return $groups; }
+                if ($path === MailChimpHelper::XML_PATH_LIST)  { return $listId; }
+                return null;
+            }
+        );
+        $helper->method('getApi')->willReturn($api);
+
+        return $helper;
+    }
+
+    public function countCall()
+    {
+        $this->apiCalls++;
+    }
+
+    /**
+     * getSubscriberInterest() reaches for the stored group data after the
+     * sentinel, so the factory has to exist for the sentinel to be reachable
+     * at all.
+     *
+     * @param  MailChimpHelper $helper
+     * @return void
+     */
+    private function giveItAGroupStore(MailChimpHelper $helper)
+    {
+        // getGroupdata() is a magic getter on the Magento model rather than a
+        // declared method, so it cannot be configured on a mock.
+        $group = new class {
+            public function getBySubscriberIdStoreId($subscriberId, $storeId) { return $this; }
+            public function getGroupdata() { return null; }
+        };
+
+        $factory = $this->createMock(MailChimpInterestGroupFactory::class);
+        $factory->method('create')->willReturn($group);
+
+        $prop = new \ReflectionProperty(MailChimpHelper::class, '_interestGroupFactory');
+        $prop->setAccessible(true);
+        $prop->setValue($helper, $factory);
+    }
+
+    /**
+     * The silent majority: an audience configured and no groups chosen. The
+     * answer cannot be used either way -- the first loop matches against an
+     * empty list and the second iterates one -- so the call was pure waste,
+     * on a 200, with no error to notice it by.
+     */
+    public function testNoGroupsConfiguredAsksNothing()
+    {
+        $helper = $this->helper('', 'list-1');
+
+        $this->assertSame([], $helper->getInterest(1));
+        $this->assertSame(0, $this->apiCalls);
+    }
+
+    public function testAnUnsetAudienceAsksNothing()
+    {
+        foreach (['', null, 0, '0', -1, '-1'] as $noAudience) {
+            $helper = $this->helper('cat-1', $noAudience);
+            $this->assertSame([], $helper->getInterest(1));
+            $this->assertSame(0, $this->apiCalls, var_export($noAudience, true));
+        }
+    }
+
+    public function testAConfiguredStoreStillAsks()
+    {
+        $helper = $this->helper('cat-1', 'list-1');
+
+        // One for the categories, one per configured group id.
+        $helper->getInterest(1);
+        $this->assertSame(2, $this->apiCalls);
+    }
+
+    /**
+     * [] is an answer. Read as falsy it meant "nothing was supplied", so the
+     * helper re-asked Mailchimp once per subscriber for a store that simply
+     * has no groups.
+     */
+    public function testAnEmptyResultSuppliedByTheCallerIsNotRefetched()
+    {
+        $helper = $this->helper('cat-1', 'list-1');
+        $this->giveItAGroupStore($helper);
+
+        $helper->getSubscriberInterest(1, 1, []);
+        $this->assertSame(0, $this->apiCalls);
+    }
+
+    public function testNothingSuppliedIsStillFetched()
+    {
+        $helper = $this->getMockBuilder(MailChimpHelper::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getInterest'])
+            ->getMock();
+        $helper->expects($this->once())->method('getInterest')->willReturn([]);
+        $this->giveItAGroupStore($helper);
+
+        $helper->getSubscriberInterest(1, 1, null);
+    }
+}

--- a/Test/Unit/Model/Api/SubscriberInterestTest.php
+++ b/Test/Unit/Model/Api/SubscriberInterestTest.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Ebizmarts_MailChimp Magento Component
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Test\Unit\Model\Api;
+
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Ebizmarts\MailChimp\Model\Api\Subscriber;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * This object has no shared="false" in di.xml, so one instance serves every
+ * store view in a cron run. Anything remembered on it has to be scoped to the
+ * view being synced or it bleeds into the next one.
+ */
+class SubscriberInterestTest extends TestCase
+{
+    /** @var array  store ids passed to getInterest(), in order */
+    private $fetchedFor = [];
+
+    /**
+     * @param  array $byStore  store id => interest groups to answer with
+     * @return array [$api, $helper]
+     */
+    private function make(array $byStore)
+    {
+        $this->fetchedFor = [];
+
+        $helper = $this->createMock(MailChimpHelper::class);
+        $helper->method('getInterest')->willReturnCallback(function ($storeId) use ($byStore) {
+            $this->fetchedFor[] = $storeId;
+            return isset($byStore[$storeId]) ? $byStore[$storeId] : [];
+        });
+        $helper->method('getSubscriberInterest')->willReturnCallback(
+            function ($subscriberId, $storeId, $interest = null) {
+                return is_array($interest) ? $interest : [];
+            }
+        );
+
+        $api = $this->getMockBuilder(Subscriber::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([])
+            ->getMock();
+
+        $prop = new \ReflectionProperty(Subscriber::class, '_helper');
+        $prop->setAccessible(true);
+        $prop->setValue($api, $helper);
+
+        return [$api, $helper];
+    }
+
+    /**
+     * @param  Subscriber $api
+     * @param  int        $storeId
+     * @return void
+     */
+    private function beginStore(Subscriber $api, $storeId)
+    {
+        $p1 = new \ReflectionProperty(Subscriber::class, '_interest');
+        $p1->setAccessible(true);
+        $p1->setValue($api, null);
+        $p2 = new \ReflectionProperty(Subscriber::class, '_interestLoaded');
+        $p2->setAccessible(true);
+        $p2->setValue($api, false);
+    }
+
+    /**
+     * @param  Subscriber $api
+     * @param  int        $storeId
+     * @return void
+     */
+    private function syncSubscriber(Subscriber $api, $storeId)
+    {
+        // addMethods, not onlyMethods: these are magic getters on the Magento
+        // model rather than declared methods.
+        $subscriber = $this->getMockBuilder(\Magento\Newsletter\Model\Subscriber::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['getSubscriberId', 'getStoreId'])
+            ->getMock();
+        $subscriber->method('getSubscriberId')->willReturn(7);
+        $subscriber->method('getStoreId')->willReturn($storeId);
+
+        $m = new \ReflectionMethod(Subscriber::class, '_getInterest');
+        $m->setAccessible(true);
+        $m->invoke($api, $subscriber);
+    }
+
+    /**
+     * The whole point: one fetch for a store view however many subscribers it
+     * has, instead of one per subscriber.
+     */
+    public function testTheGroupsAreFetchedOncePerStoreViewNotPerSubscriber()
+    {
+        list($api) = $this->make([1 => []]);
+
+        $this->beginStore($api, 1);
+        for ($i = 0; $i < 5; $i++) {
+            $this->syncSubscriber($api, 1);
+        }
+
+        $this->assertSame([1], $this->fetchedFor);
+    }
+
+    /**
+     * A store view with nothing to sync never reaches _getInterest, so it now
+     * costs nothing at all. Before, the fetch happened before the collection
+     * was even built.
+     */
+    public function testAStoreViewWithNoSubscribersFetchesNothing()
+    {
+        list($api) = $this->make([1 => []]);
+
+        $this->beginStore($api, 1);
+
+        $this->assertSame([], $this->fetchedFor);
+    }
+
+    /**
+     * The trap: this object is a DI singleton reused across store views. A
+     * loaded-flag that is not reset would serve view 1's groups to view 2 --
+     * wrong groups synced, no error, no log line.
+     */
+    public function testOneStoreViewDoesNotInheritAnothersGroups()
+    {
+        list($api) = $this->make([
+            1 => ['cat-a' => ['category' => []]],
+            2 => ['cat-b' => ['category' => []]],
+        ]);
+
+        $this->beginStore($api, 1);
+        $this->syncSubscriber($api, 1);
+
+        $this->beginStore($api, 2);
+        $this->syncSubscriber($api, 2);
+
+        $this->assertSame([1, 2], $this->fetchedFor);
+
+        $prop = new \ReflectionProperty(Subscriber::class, '_interest');
+        $prop->setAccessible(true);
+        $this->assertSame(['cat-b' => ['category' => []]], $prop->getValue($api));
+    }
+
+    /**
+     * An empty result is a result. Without the separate flag, a store with no
+     * groups configured would look unfetched on every subscriber.
+     */
+    public function testAnEmptyResultIsNotRefetched()
+    {
+        list($api) = $this->make([1 => []]);
+
+        $this->beginStore($api, 1);
+        $this->syncSubscriber($api, 1);
+        $this->syncSubscriber($api, 1);
+        $this->syncSubscriber($api, 1);
+
+        $this->assertSame([1], $this->fetchedFor);
+    }
+}


### PR DESCRIPTION
Three ways the same interest groups were fetched over and over. None of them leaves an error behind, which is why none had been noticed.

## 1. An empty result was read as "nothing was supplied"

`getSubscriberInterest()` takes the groups as an optional third argument and used `!$interest` to decide whether the caller had passed them:

```php
public function getSubscriberInterest($subscriberId, $storeId, $interest = null)
{
    if (!$interest) {
        $interest = $this->getInterest($storeId);
    }
```

`[]` is falsy. And `[]` is exactly what `getInterest()` returns for a store with no groups configured — **on a completely successful call**. So the supplied value was treated as a cache miss and the fetch re-issued, once per subscriber, forever, with no error and no log line.

`Model/Api/Subscriber.php` is where that multiplies: it primes the groups, then passes them back in for every subscriber row.

Now `$interest === null`, matching the parameter's own default. The three callers that genuinely supply nothing pass `null` and are unaffected.

## 2. The call was made when its answer could not be used

With no groups selected, `getInterest()` still asked Mailchimp — then discarded the answer, because the first loop matches category ids against an empty list and the second iterates that same empty list. The result is `[]` however the call goes.

That is the quiet majority rather than an edge case: an audience configured and no groups chosen is the default state of any install that never used them.

The audience id had the same placeholder problem the store id did, too — `-1` from the dropdown, or an empty value building `lists//interest-categories`. `Cron/Webhook.php:351` already guards this exact call that way; this path did not.

## 3. The groups were fetched before there was anything to sync

`sendSubscribers()` fetched them as its first statement, before the subscriber collection was even built, and `_processStore()` calls it unconditionally. So every store view of every run paid for the groups whether or not a single subscriber was waiting.

They are now loaded on first use, with a flag of their own — `[]` has to be distinguishable from "not fetched yet", which is the same distinction defect 1 got wrong.

## The trap that shaped the fix

`Model\Api\Subscriber` has **no `shared="false"` in `etc/di.xml`**, so one instance serves every store view in a cron run — confirmed against the object manager, including that `Cron\Ecommerce` holds that same instance.

A loaded-flag living on the instance would therefore have served store view 1's groups to store view 2: wrong groups synced, no error, no log line. Exactly the class of defect this PR is about.

Both the groups and the flag are reset at the top of `sendSubscribers()`, so the memory is scoped to the view being synced.

## Verification

Nine tests across two files, all watched failing against the unmodified code first:

| | before | after |
|---|---|---|
| no groups configured | 1 call | **0** |
| audience id `''`, `null`, `0`, `'0'`, `-1`, `'-1'` | 2 calls | **0** |
| `[]` supplied by the caller | 2 calls | **0** |
| five subscribers in one view | 5 fetches | **1** |
| a view with no subscribers | 1 fetch | **0** |
| two views in one run | view 2 inherits view 1's groups | each fetches its own |

Full module unit suite: 173 tests, 320 assertions, green.

## Not changed

`Model/Config/Source/MonkeyList` still cannot enumerate the account's audiences, so the dropdown offers only what is already saved. That is a behaviour change and belongs in its own PR — and it is why `required-entry` must not be added to that field, which would make the section unsavable.