### PR TITLE
Pin the interest reset to sendSubscribers, not to the test helper

### DIFF
--- a/Test/Unit/Model/Api/SubscriberInterestTest.php
+++ b/Test/Unit/Model/Api/SubscriberInterestTest.php
@@ -44,31 +44,58 @@ class SubscriberInterestTest extends TestCase
             }
         );
 
+        $helper->method('getTableName')->willReturn('mailchimp_sync_ecommerce');
+        $helper->method('getDateMicrotime')->willReturn('1757000000');
+
+        // Enough of a collection for sendSubscribers() to walk it and find
+        // nothing. An empty view is the case that matters here: it must still
+        // reset, and it must still cost no fetch.
+        $select = new class {
+            public function joinLeft() { return $this; }
+            public function where() { return $this; }
+            public function limit() { return $this; }
+        };
+        $collection = new class($select) implements \IteratorAggregate {
+            private $select;
+            public function __construct($select) { $this->select = $select; }
+            public function addFieldToFilter() { return $this; }
+            public function getSelect() { return $this->select; }
+            public function getIterator(): \Traversable { return new \ArrayIterator([]); }
+        };
+        $collectionFactory = $this->getMockBuilder(\stdClass::class)
+            ->addMethods(['create'])
+            ->getMock();
+        $collectionFactory->method('create')->willReturn($collection);
+
         $api = $this->getMockBuilder(Subscriber::class)
             ->disableOriginalConstructor()
             ->onlyMethods([])
             ->getMock();
 
-        $prop = new \ReflectionProperty(Subscriber::class, '_helper');
-        $prop->setAccessible(true);
-        $prop->setValue($api, $helper);
+        foreach (['_helper' => $helper, '_subscriberCollection' => $collectionFactory] as $name => $value) {
+            $prop = new \ReflectionProperty(Subscriber::class, $name);
+            $prop->setAccessible(true);
+            $prop->setValue($api, $value);
+        }
 
         return [$api, $helper];
     }
 
     /**
+     * Begins a store view the way the cron does — by calling
+     * sendSubscribers() — rather than by resetting the two fields directly.
+     *
+     * That distinction is the whole point: resetting them here would make the
+     * cross-view test pass even if the reset were deleted from the module, so
+     * it would be pinning the test helper rather than the code.
+     *
      * @param  Subscriber $api
      * @param  int        $storeId
      * @return void
      */
     private function beginStore(Subscriber $api, $storeId)
     {
-        $p1 = new \ReflectionProperty(Subscriber::class, '_interest');
-        $p1->setAccessible(true);
-        $p1->setValue($api, null);
-        $p2 = new \ReflectionProperty(Subscriber::class, '_interestLoaded');
-        $p2->setAccessible(true);
-        $p2->setValue($api, false);
+        $api->sendSubscribers($storeId, 'list-' . $storeId);
     }
 
     /**


### PR DESCRIPTION
Follow-up to PR 2355, raised in review there and worth fixing rather than leaving.

## The test proved less than it claimed

`SubscriberInterestTest` began a store view like this:

```php
private function beginStore(Subscriber $api, $storeId)
{
    // reset both fields directly, by reflection
}
```

So `testOneStoreViewDoesNotInheritAnothersGroups` — the one named after the singleton trap — **passed whether or not the module reset anything**. Deleting both reset lines from `sendSubscribers()` left it green. It was pinning the test helper.

That matters more than usual here, because the row in 2355's table reading *"view 2 inherits view 1's groups → each fetches its own"* was, as written, guaranteed by the fixture rather than by the code.

## What it does now

A view begins the way the cron begins one: by calling `sendSubscribers()`, with a collection double that yields nothing. An empty view is the right case to drive it with — it must still reset, and it must still cost no fetch.

## Verified by breaking it

With the two reset lines removed from `Model/Api/Subscriber.php`:

```
1) SubscriberInterestTest::testOneStoreViewDoesNotInheritAnothersGroups
Failed asserting that two arrays are identical.
Tests: 4, Assertions: 4, Failures: 1.
```

Restored, green. That failure is the whole point of the change — before it, the same deletion was silent.

Full module unit suite: 173 tests, 320 assertions, green.

## Scope

Test only. No production file is touched.