### PR TITLE
Remember a failed connected-site lookup instead of repeating it every render

### DIFF
--- a/Controller/Adminhtml/Ecommerce/FixMailchimpJS.php
+++ b/Controller/Adminhtml/Ecommerce/FixMailchimpJS.php
@@ -72,6 +72,11 @@ class FixMailchimpJS extends \Magento\Backend\App\Action
         $resultJson = $this->resultJsonFactory->create();
         try {
             $this->config->deleteConfig(\Ebizmarts\MailChimp\Helper\Data::XML_MAILCHIMP_JS_URL, $scope, $scopeId);
+            // This button exists to make the next render look the URL up
+            // again. Dropping the config value alone would not do that for a
+            // store view that had been failing: it would still be holding a
+            // marker telling the helper not to ask.
+            $this->helper->clearJsUrlFailures();
         } catch(ValidatorException $e) {
             $valid = 0;
             $message = $e->getMessage();

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -92,6 +92,28 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     const XML_PIXEL_SCRIPT_URL        = 'mailchimp/pixel/script_url';
     const XML_PIXEL_SCRIPT_FRAGMENT   = 'mailchimp/pixel/script_fragment';
 
+    /**
+     * How long a failed connected-site lookup is remembered for.
+     *
+     * Fifteen minutes is the balance between the two ways this can be wrong.
+     * Too short and a Mailchimp outage is still paid for by visitors, since
+     * the whole point is that a store view attempts once per window instead of
+     * once per render. Too long and a merchant who fixes the cause outside
+     * Magento -- reconnecting the site, restoring a revoked key -- waits for
+     * the window to run out, because nothing inside Magento changes to say so.
+     *
+     * The admin's own fixes do not wait: choosing a different Mailchimp store
+     * and the "Fix Mailchimp JS" button both drop the markers outright, so the
+     * TTL only ever governs repairs made on Mailchimp's side.
+     */
+    const JS_URL_FAILURE_TTL         = 900;
+
+    /**
+     * Tagged so those two admin paths can drop every marker in one call,
+     * without having to work out which store views hold one.
+     */
+    const JS_URL_FAILURE_CACHE_TAG   = 'MAILCHIMP_JS_URL_FAILURE';
+
     const ORDER_STATE_OK             = 'complete';
 
     const GUEST_GROUP                = 'NOT LOGGED IN';
@@ -216,6 +238,10 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      */
     private $_cacheTypeList;
     /**
+     * @var \Magento\Framework\App\CacheInterface|null
+     */
+    private $_cache;
+    /**
      * @var \Magento\Customer\Model\ResourceModel\Attribute\CollectionFactory
      */
     private $_attCollection;
@@ -311,7 +337,8 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         \Magento\Directory\Model\CountryFactory $countryFactory,
         \Magento\Framework\Locale\Resolver $resolver,
         MailchimpNotificationFactory $mailchimpNotificationFactory,
-        ProductMetadataInterface $productMetadata
+        ProductMetadataInterface $productMetadata,
+        ?\Magento\Framework\App\CacheInterface $cache = null
     ) {
 
         $this->_storeManager  = $storeManager;
@@ -340,6 +367,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         $this->resolver                 = $resolver;
         $this->mailchimpNotificationFactory = $mailchimpNotificationFactory;
         $this->productMetadata          = $productMetadata;
+        $this->_cache                   = $cache;
         parent::__construct($context);
     }
 
@@ -1134,6 +1162,23 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
                 return $url;
             }
 
+            // A store id that is real but does not resolve passes the guard
+            // above and fails below, writing nothing -- so without a marker
+            // the next render repeats it, and so does the one after that. It
+            // gets there by being deleted on Mailchimp's side, by arriving in
+            // a restored database that points at another account, by having no
+            // connected site, or by its key being revoked.
+            //
+            // The widest case is not merchant error at all. While Mailchimp is
+            // down or slow, every uncached render of every store using the
+            // pixel blocks on curl until the library's timeout before the page
+            // is served, cart and checkout included. That is what this bounds:
+            // one attempt per store view per window, rather than one per
+            // visitor.
+            if ($this->jsUrlLookupFailedRecently($storeId)) {
+                return $url;
+            }
+
             try {
                 $api = $this->getApi($storeId);
                 $storeData = $api->ecommerce->stores->get($mailChimpStoreId);
@@ -1145,12 +1190,93 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
                     // and called again -- a successful lookup that never
                     // stopped asking, and left no error behind to notice.
                     $this->saveConfigValue(self::XML_MAILCHIMP_JS_URL, $url, $storeId);
+                } else {
+                    // A 200 carrying no URL -- the store exists but has no
+                    // connected site. The quietest of the failures: nothing
+                    // throws, nothing is logged and nothing is written, so it
+                    // needs the marker at least as much as the loud ones.
+                    $this->rememberJsUrlLookupFailed($storeId);
                 }
             } catch (\Mailchimp_Error | \Mailchimp_HttpError $e) {
+                // Mailchimp_HttpError is what the library throws on a curl
+                // failure as well as on an HTTP one, so marking here is what
+                // covers the outage, not just the 404 and the 401.
+                $this->rememberJsUrlLookupFailed($storeId);
                 $this->log($e->getFriendlyMessage());
             }
         }
         return $url;
+    }
+
+    /**
+     * Whether this store view's lookup failed recently enough not to retry.
+     *
+     * The cache is optional so that a helper built without it -- an older
+     * di.xml, a unit test constructing it by hand -- keeps the behaviour it had
+     * before this existed rather than fataling.
+     *
+     * @param  int|string $storeId
+     * @return bool
+     */
+    private function jsUrlLookupFailedRecently($storeId)
+    {
+        if ($this->_cache === null) {
+            return false;
+        }
+
+        return (bool)$this->_cache->load($this->jsUrlFailureCacheId($storeId));
+    }
+
+    /**
+     * Remember that this store view's lookup failed, for JS_URL_FAILURE_TTL.
+     *
+     * @param  int|string $storeId
+     * @return void
+     */
+    private function rememberJsUrlLookupFailed($storeId)
+    {
+        if ($this->_cache === null) {
+            return;
+        }
+
+        $this->_cache->save(
+            '1',
+            $this->jsUrlFailureCacheId($storeId),
+            [self::JS_URL_FAILURE_CACHE_TAG],
+            self::JS_URL_FAILURE_TTL
+        );
+    }
+
+    /**
+     * Drop every remembered failure, so the next render asks again.
+     *
+     * Called from the two admin paths that change what the lookup would
+     * answer: saving a different Mailchimp store, and the "Fix Mailchimp JS"
+     * button. Both are rare and deliberate, so dropping all of the markers
+     * instead of working out which store views the change reaches costs at
+     * most one call per store view on the next render -- which is exactly what
+     * those store views paid on every render before this existed.
+     *
+     * @return void
+     */
+    public function clearJsUrlFailures()
+    {
+        if ($this->_cache === null) {
+            return;
+        }
+
+        $this->_cache->clean([self::JS_URL_FAILURE_CACHE_TAG]);
+    }
+
+    /**
+     * Cache id of the failure marker for one store view.
+     *
+     * @param  int|string $storeId
+     * @return string
+     */
+    private function jsUrlFailureCacheId($storeId)
+    {
+        return 'mailchimp_js_url_failed_' . (int)$storeId;
     }
 
     public function getWebhooksKey()

--- a/Model/Config/Backend/MonkeyStore.php
+++ b/Model/Config/Backend/MonkeyStore.php
@@ -122,6 +122,12 @@ class MonkeyStore extends Value
                     $createWebhook = false;
                 }
             }
+            // The URLs above are gone, but a store view whose lookup had been
+            // failing also holds a marker saying not to ask again for a while.
+            // Leaving it would make this save appear not to have worked until
+            // the marker expired, which is the one thing an admin changing the
+            // store is entitled to see take effect now.
+            $this->_helper->clearJsUrlFailures();
             if ($found==1) {
                 $this->_helper->cancelAllPendingBatches($mailchimpStore);
                 $this->syncHelper->resetErrors($mailchimpStore, $this->getScopeId(), true);

--- a/Test/Unit/Helper/JsUrlTest.php
+++ b/Test/Unit/Helper/JsUrlTest.php
@@ -30,9 +30,10 @@ class JsUrlTest extends TestCase
      * @param  mixed $storeId   value of mailchimp/general/monkeystore
      * @param  mixed $savedUrl  value already in config, or ''
      * @param  mixed $answer    API answer, or a throwable
+     * @param  mixed $cache     cache double, or null for a helper built without one
      * @return MailChimpHelper
      */
-    private function helper($storeId, $savedUrl, $answer = null)
+    private function helper($storeId, $savedUrl, $answer = null, $cache = null)
     {
         $this->apiCalls = 0;
         $this->saved    = [];
@@ -69,7 +70,74 @@ class JsUrlTest extends TestCase
             $this->saved[$path] = $value;
         });
 
+        // The constructor is disabled, so the cache has to go in by hand. A
+        // helper left without one is the pre-upgrade object: it is what proves
+        // the new argument stayed optional.
+        if ($cache !== null) {
+            $property = new \ReflectionProperty(MailChimpHelper::class, '_cache');
+            $property->setAccessible(true);
+            $property->setValue($helper, $cache);
+        }
+
         return $helper;
+    }
+
+    /**
+     * An in-memory CacheInterface.
+     *
+     * clean() honours tags rather than emptying itself, so a production call
+     * that cleaned the wrong tag would fail here instead of passing on a double
+     * that forgives it.
+     *
+     * @return object
+     */
+    private function cache()
+    {
+        return new class implements \Magento\Framework\App\CacheInterface {
+            /** @var array */
+            public $data = [];
+            /** @var array */
+            public $saves = [];
+            /** @var array */
+            public $cleans = [];
+
+            public function getFrontend()
+            {
+                return null;
+            }
+
+            public function load($identifier)
+            {
+                return array_key_exists($identifier, $this->data) ? $this->data[$identifier] : false;
+            }
+
+            public function save($data, $identifier, $tags = [], $lifeTime = null)
+            {
+                $this->data[$identifier] = (string)$data;
+                $this->saves[] = ['id' => $identifier, 'tags' => $tags, 'lifetime' => $lifeTime];
+
+                return true;
+            }
+
+            public function remove($identifier)
+            {
+                unset($this->data[$identifier]);
+
+                return true;
+            }
+
+            public function clean($tags = [])
+            {
+                $this->cleans[] = $tags;
+                foreach ($this->saves as $save) {
+                    if (array_intersect((array)$tags, $save['tags'])) {
+                        unset($this->data[$save['id']]);
+                    }
+                }
+
+                return true;
+            }
+        };
     }
 
     public function countApiCall()
@@ -152,8 +220,8 @@ class JsUrlTest extends TestCase
     }
 
     /**
-     * A real store id that fails is still one call. Not remembering that is a
-     * separate problem and deliberately not fixed here.
+     * A real store id that fails writes nothing and returns empty. What it must
+     * not do is keep asking -- see the negative-cache tests below.
      */
     public function testARealStoreThatFailsIsLoggedAndReturnsEmpty()
     {
@@ -162,5 +230,189 @@ class JsUrlTest extends TestCase
         $this->assertSame('', $helper->getJsUrl(1));
         $this->assertSame(1, $this->apiCalls);
         $this->assertSame([], $this->saved);
+    }
+
+    /**
+     * Bug 3: a store id that is real but does not resolve passes the guards and
+     * fails, saving nothing, so every uncached render asked again.
+     *
+     * These four are the ways to get there. The first three are merchant state;
+     * the fourth is not, and is the reason the others are worth fixing with it.
+     *
+     * @return array
+     */
+    public static function unresolvableStoreProvider()
+    {
+        return [
+            'deleted on Mailchimp\'s side, or a database restored against another account' => [
+                new \Mailchimp_Error('/ecommerce/stores/abc123', 'GET', '', 'Resource Not Found', 'nope'),
+            ],
+            'the key was revoked' => [
+                new \Mailchimp_Error('/ecommerce/stores/abc123', 'GET', '', 'API Key Invalid', 'nope'),
+            ],
+            'Mailchimp is down or slow: curl gives up, and the visitor waited for it' => [
+                new \Mailchimp_HttpError(
+                    '/ecommerce/stores/abc123',
+                    'GET',
+                    '',
+                    '',
+                    'Operation timed out after 10001 milliseconds'
+                ),
+            ],
+            'the store exists but has no connected site: a 200 carrying no URL' => [
+                ['id' => 'abc123', 'name' => 'Store', 'connected_site' => []],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider unresolvableStoreProvider
+     * @param mixed $answer
+     */
+    public function testAnUnresolvableStoreIsAskedOnceNotOncePerRender($answer)
+    {
+        $cache  = $this->cache();
+        $helper = $this->helper('abc123', '', $answer, $cache);
+
+        $this->assertSame('', $helper->getJsUrl(1));
+        $this->assertSame('', $helper->getJsUrl(1));
+        $this->assertSame('', $helper->getJsUrl(1));
+
+        $this->assertSame(1, $this->apiCalls);
+        $this->assertSame([], $this->saved);
+    }
+
+    /**
+     * The marker carries the documented lifetime and the tag the admin paths
+     * clean by. Neither is decoration: a missing lifetime would remember the
+     * failure until the cache was flushed, and a missing tag would leave
+     * clearJsUrlFailures() nothing to find.
+     */
+    public function testTheMarkerCarriesTheLifetimeAndTheTag()
+    {
+        $cache  = $this->cache();
+        $helper = $this->helper('abc123', '', new \Mailchimp_Error('/', 'GET', '', 'Not Found', 'nope'), $cache);
+
+        $helper->getJsUrl(1);
+
+        $this->assertCount(1, $cache->saves);
+        $this->assertSame(MailChimpHelper::JS_URL_FAILURE_TTL, $cache->saves[0]['lifetime']);
+        $this->assertSame([MailChimpHelper::JS_URL_FAILURE_CACHE_TAG], $cache->saves[0]['tags']);
+    }
+
+    /**
+     * Store views resolve to different Mailchimp stores, so one failing view
+     * must not silence a working one.
+     */
+    public function testTheMarkerIsPerStoreView()
+    {
+        $cache  = $this->cache();
+        $helper = $this->helper('abc123', '', new \Mailchimp_Error('/', 'GET', '', 'Not Found', 'nope'), $cache);
+
+        $helper->getJsUrl(1);
+        $helper->getJsUrl(2);
+
+        $this->assertSame(2, $this->apiCalls);
+
+        $helper->getJsUrl(1);
+        $helper->getJsUrl(2);
+
+        $this->assertSame(2, $this->apiCalls);
+    }
+
+    public function testASuccessfulLookupLeavesNoMarker()
+    {
+        $cache  = $this->cache();
+        $helper = $this->helper(
+            'abc123',
+            '',
+            ['connected_site' => ['site_script' => ['url' => 'https://chimpstatic.com/mcjs/x.js']]],
+            $cache
+        );
+
+        $this->assertSame('https://chimpstatic.com/mcjs/x.js', $helper->getJsUrl(1));
+        $this->assertSame([], $cache->saves);
+    }
+
+    /**
+     * What the "Fix Mailchimp JS" button and a change of Mailchimp store call.
+     * Without it those two would clear the config value and appear not to have
+     * worked, because the marker would still be telling the helper not to ask.
+     */
+    public function testClearingTheMarkersMakesTheNextRenderAskAgain()
+    {
+        $cache  = $this->cache();
+        $helper = $this->helper('abc123', '', new \Mailchimp_Error('/', 'GET', '', 'Not Found', 'nope'), $cache);
+
+        $helper->getJsUrl(1);
+        $helper->getJsUrl(1);
+        $this->assertSame(1, $this->apiCalls);
+
+        $helper->clearJsUrlFailures();
+
+        $this->assertSame([[MailChimpHelper::JS_URL_FAILURE_CACHE_TAG]], $cache->cleans);
+
+        $helper->getJsUrl(1);
+        $this->assertSame(2, $this->apiCalls);
+    }
+
+    /**
+     * The cache is a new, optional, trailing constructor argument. A helper
+     * built without one -- a stale generated factory, an override that still
+     * lists the old arguments -- has to keep working, calling every render as
+     * it did before, rather than fatal on a null.
+     */
+    public function testAHelperBuiltWithoutACacheStillWorks()
+    {
+        $helper = $this->helper('abc123', '', new \Mailchimp_Error('/', 'GET', '', 'Not Found', 'nope'));
+
+        $this->assertSame('', $helper->getJsUrl(1));
+        $this->assertSame('', $helper->getJsUrl(1));
+
+        $this->assertSame(2, $this->apiCalls);
+
+        $helper->clearJsUrlFailures();
+    }
+
+    /**
+     * The two halves of how the cache reaches the helper, pinned together
+     * because either one alone is a helper that never caches anything.
+     *
+     * The argument has a default so the constructor stays backwards compatible.
+     * The price of that default is that the ObjectManager will not resolve it:
+     * ClassReader records a parameter with a default value as not required
+     * (Code/Reader/ClassReader.php), and AbstractFactory::getResolvedArgument()
+     * hands a not-required parameter its default instead of instantiating its
+     * type. So di.xml has to name it, and every test above would still pass if
+     * nobody did -- they inject the cache themselves.
+     */
+    public function testTheCacheIsOptionalInTheConstructorAndThereforeWiredInDi()
+    {
+        $cache = null;
+        foreach ((new \ReflectionClass(MailChimpHelper::class))->getConstructor()->getParameters() as $parameter) {
+            if ($parameter->getName() === 'cache') {
+                $cache = $parameter;
+            }
+        }
+
+        $this->assertNotNull($cache, 'The helper no longer takes a $cache argument.');
+        $this->assertTrue(
+            $cache->isDefaultValueAvailable(),
+            'Dropping the default makes the argument required, which breaks anything still '
+            . 'calling the constructor with the old argument list.'
+        );
+
+        $di = simplexml_load_file(__DIR__ . '/../../../etc/di.xml');
+        $argument = $di->xpath(
+            '//type[@name="Ebizmarts\MailChimp\Helper\Data"]/arguments/argument[@name="cache"]'
+        );
+
+        $this->assertCount(
+            1,
+            $argument,
+            'di.xml does not name the $cache argument, so it arrives null and getJsUrl() calls '
+            . 'the API on every render again.'
+        );
+        $this->assertSame('Magento\Framework\App\CacheInterface', trim((string)$argument[0]));
     }
 }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -11,6 +11,20 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <!--
+        The helper's $cache argument is optional so that anything still building
+        it with the old argument list keeps working. That optionality is exactly
+        why it has to be named here: ClassReader marks a parameter with a default
+        value as not required, and the ObjectManager hands such a parameter its
+        default rather than resolving its type. Without this line the argument
+        would arrive null on every instantiation, and the negative cache in
+        getJsUrl() would silently do nothing.
+    -->
+    <type name="Ebizmarts\MailChimp\Helper\Data">
+        <arguments>
+            <argument name="cache" xsi:type="object">Magento\Framework\App\CacheInterface</argument>
+        </arguments>
+    </type>
     <type name="Ebizmarts\MailChimp\Block\Mailchimpjs">
         <arguments>
             <argument name="helper" xsi:type="object">Ebizmarts\MailChimp\Helper\Data\Proxy</argument>


### PR DESCRIPTION
Follow-up to the connected-site work in PR 2354, covering what that one deliberately left out.

## The problem

2354 returns early for `-1`, `''`, `null`, `0` and `'0'`, so the misconfigured loop is closed. What still runs on **every uncached page render** is a store id that is real but does not resolve: it passes the guard, `stores->get()` throws or answers without `connected_site.site_script.url`, the catch logs (a no-op unless logging is on), `$url` stays empty, nothing is written, and the next render repeats it.

Four ways to get there:

- the Mailchimp store was **deleted** on Mailchimp's side
- a **restored database** carries a store id belonging to another account
- the store exists but has **no connected site** — which the dropdown itself offers as *"(Warning: not connected)"*
- the **key was revoked**, so the call 401s

And the one that is not merchant error at all: while **Mailchimp is down or slow**, every uncached render of every store using the pixel blocks on curl until the library's timeout before the page is served — cart and checkout included, since the extension marks those uncacheable itself. That case is bounded by nothing we control, which is why the other three are worth fixing alongside it.

## The change

A failure is remembered for fifteen minutes, so an unresolved store is asked about once per window instead of once per visitor.

The marker is written in **two** places, not one:

- in the `catch` — which is what covers the outage, because the library raises `Mailchimp_HttpError` on a curl failure as well as on an HTTP one (`if(curl_error($ch)) throw new Mailchimp_HttpError`), so the timeout lands in the same handler as the 404 and the 401;
- in a new `else` for the **200 that carries no URL** — the quietest failure of the set, where nothing throws, nothing is logged and nothing is written, so it would otherwise keep asking forever with no error to notice it by.

`MonkeyStore::beforeSave()` and the "Fix Mailchimp JS" button both drop the markers, so an admin fix takes effect on the next render rather than after the window. The TTL therefore only governs repairs made on Mailchimp's side — a site reconnected, a key restored — which is what fifteen minutes is chosen for.

`clearJsUrlFailures()` cleans by tag rather than per store view on purpose: in `beforeSave` the scope id can be a website or `0`, while the marker is keyed by store view id, so being surgical there would simply be wrong. Both call sites are rare, deliberate admin actions, and the cost of dropping all the markers is at most one call per store view on the next render — which is what those store views paid on *every* render before this.

## Why the cache argument is in di.xml

The argument is optional so the constructor stays backwards compatible, and that optionality is exactly why it has to be named in `di.xml`: `ClassReader` records a parameter with a default value as **not required**, and `AbstractFactory::getResolvedArgument()` hands a not-required parameter its default instead of resolving its type. Without that line the argument arrives `null` on every instantiation and this change does nothing at all — silently, with the unit tests still green, because they inject the double themselves. There is a test pinning both halves.

## Verified

Unit suite: 183 tests, 357 assertions. The new tests were each checked against a mutant — removing the read guard, the marker in the `catch`, the marker in the 200-without-URL branch, the lifetime, or the tag all produce failures.

Also measured on a 2.4.8 install with `monkeystore` set to a 32-hex id that 404s, no saved URL, and genuinely uncached renders (unique query string past Varnish), counting calls by entries added to `var/log/MailChimp.log`:

| 4 uncached renders | API calls | render times |
|---|---|---|
| before | **4** | 1.87 / 1.14 / 1.24 / 1.31 s |
| after | **1** | 1.16 / 0.39 / 0.41 / 0.35 s |

At helper level across separate processes, which is what shows the marker surviving a request: first call 0.788s, second and third 0.000s; after `clearJsUrlFailures()`, 0.642s again and back to 0.000s.

Note for testing: the di.xml change needs a `cache:flush` before it takes effect, since the merged DI config lives in the `config` cache type even in developer mode. A version bump's `setup:upgrade` covers that for merchants.
