### PR TITLE
Load the interest-group tree only when a webhook row needs it

### DIFF
--- a/Cron/Webhook.php
+++ b/Cron/Webhook.php
@@ -57,6 +57,18 @@ class Webhook
     protected $groups = [];
 
     /**
+     * Whether _loadGroups() has already run in this process.
+     *
+     * A flag rather than `if (!$this->groups)`: an audience that defines no
+     * interest categories legitimately loads as [], and a falsy check would
+     * read that as "not loaded yet" and re-fetch the whole tree for every
+     * webhook row that asked.
+     *
+     * @var bool
+     */
+    private $groupsLoaded = false;
+
+    /**
      * Webhook constructor.
      * @param \Ebizmarts\MailChimp\Helper\Data $helper
      * @param \Magento\Newsletter\Model\SubscriberFactory $subscriberFactory
@@ -87,7 +99,6 @@ class Webhook
     }
     public function processWebhooks()
     {
-        $this->_loadGroups();
         /**
          * @var $collection \Ebizmarts\MailChimp\Model\ResourceModel\MailChimpWebhookRequest\Collection
          */
@@ -336,15 +347,35 @@ class Webhook
         $subscriber->setIsStatusChanged(true);
         $subscriber->getResource()->save($subscriber);
     }
+    /**
+     * Fetch every enabled store view's interest-group tree, once per process.
+     *
+     * This used to be the first statement of processWebhooks(), which read the
+     * queue two lines later: an install with nothing to process paid the whole
+     * tree -- one `interest-categories` call per store view plus one
+     * `interests` call per category -- every five minutes, and discarded it.
+     * The single consumer is _getGroups(), reached only from a `profile`
+     * webhook carrying a GROUPINGS merge field, so it is now called from there.
+     *
+     * The flag is set before the work rather than after, so a run that throws
+     * does not re-enter this once per row.
+     *
+     * @return void
+     */
     protected function _loadGroups()
     {
+        if ($this->groupsLoaded) {
+            return;
+        }
+        $this->groupsLoaded = true;
+
         foreach ($this->storeManager->getStores() as $storeId => $val) {
             if (!$this->_helper->isMailChimpEnabled($storeId)) {
                 continue;
             }
-            // This runs before any webhook work is looked at, so an install
-            // with nothing to process still paid one rejected call per store
-            // view to find that out. One answer per credential is enough.
+            // One answer per credential is enough. This loop no longer runs
+            // unless a row actually needs the groups, but when it does run a
+            // dead key would still cost one rejected call per store view.
             if ($this->_helper->isApiKeyFailed($storeId)) {
                 continue;
             }
@@ -376,6 +407,8 @@ class Webhook
     }
     protected function _getGroups($groups, $cat)
     {
+        $this->_loadGroups();
+
         $rc = [];
         $gr = explode(",",$groups);
         foreach ($gr as $g) {

--- a/Test/Unit/Cron/WebhookLazyGroupsTest.php
+++ b/Test/Unit/Cron/WebhookLazyGroupsTest.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ * Ebizmarts_MailChimp Magento Component
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Test\Unit\Cron;
+
+use Ebizmarts\MailChimp\Cron\Webhook;
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Ebizmarts\MailChimp\Model\MailChimpInterestGroupFactory;
+use Ebizmarts\MailChimp\Model\ResourceModel\MailChimpWebhookRequest\CollectionFactory;
+use Magento\Customer\Model\CustomerFactory;
+use Magento\Newsletter\Model\SubscriberFactory;
+use Magento\Store\Model\StoreManager;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The interest-group tree was fetched at the top of processWebhooks(), which
+ * reads its queue two lines later. On a five-minute cron that is the whole tree
+ * per store view per run whether or not anything consumes it.
+ *
+ * Its one consumer is _getGroups(), reached only from a `profile` webhook row
+ * carrying a GROUPINGS merge field, so these pin that the work now happens
+ * there and happens once.
+ */
+class WebhookLazyGroupsTest extends TestCase
+{
+    /** @var int  one per interest-categories or interests GET */
+    private $apiCalls = 0;
+
+    /**
+     * @param  array $categories  what the audience defines
+     * @return object
+     */
+    private function api(array $categories)
+    {
+        $test = $this;
+
+        $interests = new class($test) {
+            private $test;
+            public function __construct($test)
+            {
+                $this->test = $test;
+            }
+            public function getAll($listId, $catId, $a = null, $b = null, $c = null)
+            {
+                $this->test->countApiCall();
+
+                return ['interests' => [
+                    ['id' => 'i-' . $catId, 'name' => 'Group', 'category_id' => $catId],
+                ]];
+            }
+        };
+
+        $category = new class($test, $categories, $interests) {
+            private $test;
+            private $categories;
+            public $interests;
+            public function __construct($test, $categories, $interests)
+            {
+                $this->test = $test;
+                $this->categories = $categories;
+                $this->interests = $interests;
+            }
+            public function getAll($listId, $a = null, $b = null, $c = null)
+            {
+                $this->test->countApiCall();
+
+                return ['categories' => $this->categories];
+            }
+        };
+
+        $lists = new \stdClass();
+        $lists->interestCategory = $category;
+
+        $api = new \stdClass();
+        $api->lists = $lists;
+
+        return $api;
+    }
+
+    public function countApiCall()
+    {
+        $this->apiCalls++;
+    }
+
+    /**
+     * @param  int   $storeViews
+     * @param  array $categories
+     * @return Webhook
+     */
+    private function cron($storeViews, array $categories)
+    {
+        $this->apiCalls = 0;
+
+        $helper = $this->createMock(MailChimpHelper::class);
+        $helper->method('isMailChimpEnabled')->willReturn(true);
+        $helper->method('isApiKeyFailed')->willReturn(false);
+        $helper->method('getDefaultList')->willReturn('list-1');
+        $helper->method('getApi')->willReturnCallback(function () use ($categories) {
+            return $this->api($categories);
+        });
+
+        $storeManager = $this->createMock(StoreManager::class);
+        $storeManager->method('getStores')
+            ->willReturn(array_fill_keys(range(1, $storeViews), new \stdClass()));
+
+        // An empty queue, built the way processWebhooks() uses it: filtered,
+        // limited, then walked.
+        $collection = new class implements \IteratorAggregate {
+            public function addFieldToFilter($field, $condition)
+            {
+                return $this;
+            }
+            public function getSelect()
+            {
+                return new class {
+                    public function limit($n)
+                    {
+                        return $this;
+                    }
+                };
+            }
+            public function getIterator(): \Traversable
+            {
+                return new \ArrayIterator([]);
+            }
+        };
+
+        $collectionFactory = $this->createMock(CollectionFactory::class);
+        $collectionFactory->method('create')->willReturn($collection);
+
+        return new Webhook(
+            $helper,
+            $this->createMock(SubscriberFactory::class),
+            $collectionFactory,
+            $this->createMock(MailChimpInterestGroupFactory::class),
+            $storeManager,
+            $this->createMock(CustomerFactory::class)
+        );
+    }
+
+    /**
+     * @param  Webhook $cron
+     * @return array
+     */
+    private function getGroups(Webhook $cron)
+    {
+        $method = new \ReflectionMethod(Webhook::class, '_getGroups');
+        $method->setAccessible(true);
+
+        return $method->invoke($cron, 'Group', 'cat-1');
+    }
+
+    /**
+     * The measurement this comes from: five identical cron beacons, 21 `lists`
+     * calls each, nothing written and nothing changing. With no row to serve,
+     * the run must now cost nothing at all.
+     */
+    public function testAnEmptyQueueMakesNoApiCalls()
+    {
+        $cron = $this->cron(4, [['id' => 'cat-1'], ['id' => 'cat-2']]);
+
+        $cron->processWebhooks();
+
+        $this->assertSame(0, $this->apiCalls);
+    }
+
+    /**
+     * And the consumer still gets its tree, so the laziness did not simply
+     * remove the feature.
+     */
+    public function testTheConsumerStillLoadsTheTree()
+    {
+        $cron = $this->cron(1, [['id' => 'cat-1']]);
+
+        $groups = $this->getGroups($cron);
+
+        $this->assertSame(2, $this->apiCalls);            // 1 categories + 1 interests
+        $this->assertSame(['i-cat-1' => 'i-cat-1'], $groups);
+    }
+
+    /**
+     * Once per process, not once per row. A hundred profile rows in one queue
+     * must not be a hundred trees.
+     */
+    public function testRepeatedRowsLoadTheTreeOnce()
+    {
+        $cron = $this->cron(1, [['id' => 'cat-1']]);
+
+        $this->getGroups($cron);
+        $this->getGroups($cron);
+        $this->getGroups($cron);
+
+        $this->assertSame(2, $this->apiCalls);
+    }
+
+    /**
+     * The #1450 lesson, one file over: an audience that defines no interest
+     * categories legitimately loads as []. A `if (!$this->groups)` guard would
+     * read that as "not loaded" and re-fetch for every row that asked, which is
+     * the amplification this change exists to remove.
+     */
+    public function testAnAudienceWithNoCategoriesIsNotRefetchedPerRow()
+    {
+        $cron = $this->cron(1, []);
+
+        $this->getGroups($cron);
+        $this->getGroups($cron);
+        $this->getGroups($cron);
+
+        $this->assertSame(1, $this->apiCalls);            // the categories call, once
+    }
+}


### PR DESCRIPTION
Found by reading telemetry from a live merchant, not from a bug report.

## The problem

`_loadGroups()` is the first statement of `processWebhooks()`, and the queue it exists to serve is read two lines later:

```php
public function processWebhooks()
{
    $this->_loadGroups();                                   // API work
    $collection = $this->_webhookCollection->create();
    $collection->addFieldToFilter('processed', ['eq' => self::NOT_PROCESSED]);
```

It walks every Mailchimp-enabled store view and issues **one `interest-categories` call plus one `interests` call per category**. On a `*/5` cron that is the whole tree, per store view, 288 times a day, whether or not anything will consume it.

The tree has exactly one consumer:

```
written   Cron/Webhook.php:361
read      Cron/Webhook.php:376   inside _getGroups()
          _getGroups()      <- _processMerges() :283
          _processMerges()  <- _profile() :239
          _profile()        <- case TYPE_PROFILE :119
```

So it is fetched to serve `profile`-type rows carrying a GROUPINGS merge field, and nothing else. `protected $groups = []` is a plain instance property — no cache, nothing survives the process.

On the merchant this was found on: 21 `lists` calls and 232 KB downloaded every five minutes, `bytes_up` 0, five consecutive beacons byte-identical. 40.1 of a 41.1-second cron run.

## The change

The load moves to `_getGroups()`, its only reader. A run with nothing to serve costs nothing; a run processing a hundred subscribe or unsubscribe rows also costs nothing, because those never reach the consumer.

**The guard is an explicit loaded-flag, not a check on the array.** An audience that defines no interest categories legitimately loads as `[]`, and `if (!$this->groups)` would read that as "not loaded yet" and re-fetch the whole tree for every row that asked — reintroducing the amplification, inside the guard meant to prevent it. The flag is set *before* the work rather than after, so a run that throws does not re-enter once per row.

The `isApiKeyFailed` guard inside the loop keeps its purpose but lost its rationale, which said this ran before any webhook work was looked at. It no longer does, so the comment now says what is true.

## Verified against the live API, not only in tests

2.4.8 install, empty queue, real Mailchimp credentials:

| `processWebhooks()`, empty queue | run 1 | run 2 |
|---|---|---|
| before | 1.576 s | 1.502 s |
| after | **0.005 s** | **0.001 s** |

And the half that matters more — that it did not become cheap by ceasing to work. Driving the consumer on the real cron object:

```
_getGroups() first call:  1.464s   <- loads the tree
_getGroups() second call: 0.000s   <- the flag holds
groups loaded: 6
groupsLoaded: true
```

Six real groups from the install's audience. The work moved to the point of use rather than disappearing.

Unit suite 183 → 187 tests, 362 assertions. The new tests were each checked against a mutant: restoring the eager load fails the empty-queue test; removing the trigger from `_getGroups()` fails three; **swapping the flag for a falsy check fails exactly the no-categories test**; removing the guard entirely fails two.

`phpcs --standard=Magento2`: 0 errors, and `Cron/Webhook.php` goes from 61 warnings to 59.

## Deliberately not changed

`:361` merges every store view's interests into one flat array with `array_merge_recursive`, and `_getGroups()` then matches on `name` + `category_id` across that merged set — so two store views on different audiences can collide on a category id. Making the load lazy neither causes nor worsens it. Keying the cache per store view would change matching behaviour for multi-view installs, which deserves its own change and its own review rather than riding along in this one.

## One thing worth knowing about the measurement it came from

The beacon cannot establish that the queue was empty on those runs. `_subscribe()`, `_unsubscribe()`, `_clean()` and `_updateEmail()` make no API calls at all, and neither does the `_processMerges()` branch of `_profile()` — which is the branch that consumes the tree. The only other call in the file is a `members->get` reached when a profile row matches no local customer *and* no local subscriber. So a run that processed a hundred rows would emit a byte-identical beacon.

That does not weaken the case for this change, since the fetch is unconditional either way. It does mean the saving is "the tree is no longer fetched when nothing needs it" rather than a claim about how many of those fetches were provably wasted.
