### PR TITLE
Do not emit a script tag when the connected-site URL is empty

### DIFF
--- a/view/frontend/templates/mailchimpjs.phtml
+++ b/view/frontend/templates/mailchimpjs.phtml
@@ -6,5 +6,13 @@
 $url = $block->getJsUrl();
 $render = $block->getRender();
 ?>
-<?= /* @noEscape */ $render->renderTag('script',['type'=>'text/javascript','src'=>$escaper->escapeUrl($url),'defer'=>'defer'],"\n",true); ?>
-
+<?php // An unresolved connected site leaves $url empty -- null when nothing is
+      // saved, since the config read returns null rather than ''. Rendering
+      // anyway put <script src=""> on the page: inert per the HTML spec, which
+      // fires an error event and fetches nothing, but it is the one symptom of
+      // that state a merchant sees in their own browser console, and it is not
+      // the reason the connected-site script is missing. No tag says the same
+      // thing without inviting the wrong investigation. ?>
+<?php if ($url): ?>
+    <?= /* @noEscape */ $render->renderTag('script',['type'=>'text/javascript','src'=>$escaper->escapeUrl($url),'defer'=>'defer'],"\n",true); ?>
+<?php endif; ?>


### PR DESCRIPTION
One line of behaviour, filed as cosmetic and promoted by a review note: after the negative-cache work, this empty tag is the **last visible symptom** of that whole family, and the only one a merchant sees in their own browser console.

## What it does

`view/frontend/templates/mailchimpjs.phtml` rendered the script tag unconditionally. An unresolved connected site leaves the URL empty — `null` rather than `''`, since the config read returns null when nothing is saved — so the page carried:

```html
<script type="text/javascript" src="" defer="defer"></script>
```

That is inert: per the HTML spec an empty `src` fires an `error` event and fetches nothing. It is **not** why the connected-site script fails to load — it is a symptom of the URL being empty, which is addressed at the source. But it is the symptom a merchant can see, so it invites an investigation into the wrong thing. Rendering nothing says as much and asks no questions.

## Verified on a running install, both directions

Because the risk in a guard like this is not the empty case, it is silencing the working one.

| store id | before | after |
|---|---|---|
| does not resolve | `<script type="text/javascript" src="" defer="defer">` | **no tag at all** |
| resolves | tag renders | **tag renders, unchanged** |

The "before" row is a real capture from this morning against the untouched template, not a reconstruction. The healthy row was re-checked after a late whitespace fix, so what was measured is what is in the commit.

Unit suite unchanged at 183 tests, 357 assertions. `phpcs --standard=Magento2`: 0 errors and **no new warnings** — the first version of the guard added two, from `if ($url) :` spacing and the unindented body, and both are fixed here.

## Not in scope

The pixel block emits its own `mc-pixel-config` JSON carrying a script URL from a different config path. It is untouched by this and was confirmed present in the same renders, so nothing here changes the pixel.
