### PR TITLE
Reject the store dropdown's non-answers, and keep a good list id on a failed lookup

### DIFF
--- a/Model/Config/Backend/MonkeyStore.php
+++ b/Model/Config/Backend/MonkeyStore.php
@@ -21,6 +21,7 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\Config\Value;
 use Magento\Framework\Data\Collection\AbstractDb;
 use Magento\Framework\Model\Context;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Model\ResourceModel\AbstractResource;
 use Magento\Framework\Registry;
 use Magento\Framework\Stdlib\DateTime\DateTime;
@@ -73,6 +74,24 @@ class MonkeyStore extends Value
         } else {
             $active = 0;
         }
+        // The dropdown offers two values that are not stores: -1, its
+        // placeholder (Model/Config/Source/MonkeyStore.php), and 0, the
+        // '---No Data---' option it falls back to when there is no API key at
+        // this scope or the store listing threw. Persisting either leaves a
+        // setting that is not a store, which every later reader has to know to
+        // special-case, and three already do.
+        //
+        // Only while ecommerce is active. With it off, "no store selected" is a
+        // legitimate state, and rejecting it here would stop a merchant saving
+        // any Mailchimp configuration at all -- including the switch that would
+        // turn ecommerce off.
+        if ($active && !$this->isARealStore($this->getValue())) {
+            throw new LocalizedException(
+                __('Select a Mailchimp store, or turn Mailchimp ecommerce off. '
+                    . 'Ecommerce cannot sync without one.')
+            );
+        }
+
         if ($active && $this->isValueChanged()) {
             $mailchimpStore     = $this->getOldValue();
             // charge the $newListId
@@ -85,12 +104,20 @@ class MonkeyStore extends Value
                 $newListId = $data['general']['fields']['monkeylist']['value'];
             } else {
                 $newListId = $this->getStore($apiKey, $this->getValue());
-                $this->_helper->saveConfigValue(
-                    Data::XML_PATH_LIST,
-                    $newListId,
-                    $this->getScopeId(),
-                    $this->getScope()
-                );
+                // getStore() answers null when its own lookup fails -- a 404 on
+                // a store Mailchimp no longer has, a revoked key. Writing that
+                // replaced a working audience id with nothing, so a failed
+                // lookup did not merely fail: it destroyed the answer it could
+                // not confirm. Keep what is there and let the failure be a
+                // failure.
+                if ($newListId) {
+                    $this->_helper->saveConfigValue(
+                        Data::XML_PATH_LIST,
+                        $newListId,
+                        $this->getScopeId(),
+                        $this->getScope()
+                    );
+                }
             }
             $this->oldListId = $this->_helper->getConfigValue(
                 Data::XML_PATH_LIST,
@@ -133,12 +160,30 @@ class MonkeyStore extends Value
                 $this->syncHelper->resetErrors($mailchimpStore, $this->getScopeId(), true);
             }
             $this->_helper->restoreAllCanceledBatches($this->getValue());
-            if ($createWebhook) {
+            // Same null, one consequence further on: without this the failed
+            // lookup went on to register a webhook against no audience at all.
+            if ($createWebhook && $newListId) {
                 $this->_helper->createWebHook($apiKey, $newListId);
             }
         }
         return parent::beforeSave();
     }
+    /**
+     * Whether a submitted value is a Mailchimp store rather than one of the
+     * dropdown's two non-answers.
+     *
+     * Falsy covers 0, '0' and the empty string; -1 is compared loosely because
+     * the form submits it as a string. This mirrors the guard the read side
+     * already applies in Helper\Data::getJsUrl().
+     *
+     * @param  mixed $value
+     * @return bool
+     */
+    private function isARealStore($value)
+    {
+        return (bool)$value && $value != -1;
+    }
+
     private function getStore($apiKey, $store)
     {
         try {

--- a/Model/Config/Backend/MonkeyStore.php
+++ b/Model/Config/Backend/MonkeyStore.php
@@ -69,8 +69,19 @@ class MonkeyStore extends Value
         $newListId = null;
         if (isset($data['ecommerce']['fields']['active']['value'])) {
             $active = $data['ecommerce']['fields']['active']['value'];
-        } elseif ($data['ecommerce']['fields']['active']['inherit']) {
-            $active = $data['ecommerce']['fields']['active']['inherit'];
+        } elseif (!empty($data['ecommerce']['fields']['active']['inherit'])) {
+            // 'inherit' is a flag, not a value: Magento posts inherit => 1 with
+            // no 'value' whenever "Use Default" is ticked, whatever the
+            // inherited setting happens to be. Reading the flag made $active
+            // true for every inheriting scope, so a scope inheriting ecommerce
+            // OFF would be told to turn ecommerce off -- with no way to comply
+            // at that scope, since the field it would have to change is the one
+            // it is inheriting. Resolve what is actually inherited instead.
+            $active = $this->_helper->getConfigValue(
+                Data::XML_PATH_ECOMMERCE_ACTIVE,
+                $this->getScopeId(),
+                $this->getScope()
+            );
         } else {
             $active = 0;
         }
@@ -85,6 +96,13 @@ class MonkeyStore extends Value
         // legitimate state, and rejecting it here would stop a merchant saving
         // any Mailchimp configuration at all -- including the switch that would
         // turn ecommerce off.
+        //
+        // Above the isValueChanged() gate on purpose, so this fires on every
+        // save of the section rather than only when the dropdown was touched.
+        // An install already holding -1 meets it the next time it saves
+        // anything here, which is what takes the value out of circulation
+        // rather than preserving it until someone happens to reopen that
+        // field.
         if ($active && !$this->isARealStore($this->getValue())) {
             throw new LocalizedException(
                 __('Select a Mailchimp store, or turn Mailchimp ecommerce off. '

--- a/Test/Unit/Model/Config/Backend/MonkeyStoreBeforeSaveTest.php
+++ b/Test/Unit/Model/Config/Backend/MonkeyStoreBeforeSaveTest.php
@@ -39,7 +39,7 @@ class MonkeyStoreBeforeSaveTest extends TestCase
      * @param  mixed $listLookupAnswer  audience id, or a throwable
      * @return MonkeyStore
      */
-    private function backend($valueChanged, $listLookupAnswer = 'list-new')
+    private function backend($valueChanged, $listLookupAnswer = 'list-new', $inheritedActive = null)
     {
         $this->saved = [];
         $this->webhooksCreated = 0;
@@ -67,7 +67,15 @@ class MonkeyStoreBeforeSaveTest extends TestCase
         $helper = $this->createMock(MailChimpHelper::class);
         $helper->method('getApiKey')->willReturn('key-us1');
         $helper->method('getApiByApiKey')->willReturn($api);
-        $helper->method('getConfigValue')->willReturn('list-existing');
+        $helper->method('getConfigValue')->willReturnCallback(
+            function ($path) use ($inheritedActive) {
+                if ($path === MailChimpHelper::XML_PATH_ECOMMERCE_ACTIVE) {
+                    return $inheritedActive;
+                }
+
+                return 'list-existing';
+            }
+        );
         $helper->method('saveConfigValue')->willReturnCallback(function ($path, $value) {
             $this->saved[$path] = $value;
         });
@@ -132,6 +140,34 @@ class MonkeyStoreBeforeSaveTest extends TestCase
     {
         $backend->setData('groups', ['ecommerce' => ['fields' => ['active' => ['value' => $active]]]]);
         $backend->setValue($value);
+        $backend->beforeSave();
+    }
+
+    /**
+     * "Use Default" posts inherit => 1 and no value, whatever the inherited
+     * setting is. Reading that flag as the answer made every inheriting scope
+     * look active -- and a scope inheriting ecommerce OFF would then be told to
+     * turn ecommerce off, with no field at that scope it could change to comply.
+     */
+    public function testAScopeInheritingEcommerceOffAcceptsTheNonStore()
+    {
+        $backend = $this->backend(true, 'list-new', 0);
+        $backend->setData('groups', ['ecommerce' => ['fields' => ['active' => ['inherit' => 1]]]]);
+        $backend->setValue('-1');
+
+        $backend->beforeSave();
+
+        $this->assertSame([], $this->saved);
+    }
+
+    public function testAScopeInheritingEcommerceOnStillRejectsIt()
+    {
+        $this->expectException(LocalizedException::class);
+
+        $backend = $this->backend(true, 'list-new', 1);
+        $backend->setData('groups', ['ecommerce' => ['fields' => ['active' => ['inherit' => 1]]]]);
+        $backend->setValue('-1');
+
         $backend->beforeSave();
     }
 

--- a/Test/Unit/Model/Config/Backend/MonkeyStoreBeforeSaveTest.php
+++ b/Test/Unit/Model/Config/Backend/MonkeyStoreBeforeSaveTest.php
@@ -1,0 +1,230 @@
+<?php
+/**
+ * Ebizmarts_MailChimp Magento Component
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Test\Unit\Model\Config\Backend;
+
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Ebizmarts\MailChimp\Helper\Sync as SyncHelper;
+use Ebizmarts\MailChimp\Model\Config\Backend\MonkeyStore;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Store\Model\StoreManager;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * beforeSave() is the only thing standing between the admin form and the two
+ * values the dropdown offers that are not stores, and it is also where a failed
+ * lookup used to overwrite a working audience id with nothing.
+ */
+class MonkeyStoreBeforeSaveTest extends TestCase
+{
+    /** @var array  every saveConfigValue() call, path => value */
+    private $saved = [];
+
+    /** @var int */
+    private $webhooksCreated = 0;
+
+    /**
+     * The backend model with its collaborators injected by hand. Value's own
+     * constructor wants half the framework and none of it is under test.
+     *
+     * @param  bool  $valueChanged
+     * @param  mixed $listLookupAnswer  audience id, or a throwable
+     * @return MonkeyStore
+     */
+    private function backend($valueChanged, $listLookupAnswer = 'list-new')
+    {
+        $this->saved = [];
+        $this->webhooksCreated = 0;
+
+        $stores = new class($listLookupAnswer) {
+            private $answer;
+            public function __construct($answer)
+            {
+                $this->answer = $answer;
+            }
+            public function get($id)
+            {
+                if ($this->answer instanceof \Throwable) {
+                    throw $this->answer;
+                }
+
+                return ['list_id' => $this->answer];
+            }
+        };
+        $ecommerce = new \stdClass();
+        $ecommerce->stores = $stores;
+        $api = new \stdClass();
+        $api->ecommerce = $ecommerce;
+
+        $helper = $this->createMock(MailChimpHelper::class);
+        $helper->method('getApiKey')->willReturn('key-us1');
+        $helper->method('getApiByApiKey')->willReturn($api);
+        $helper->method('getConfigValue')->willReturn('list-existing');
+        $helper->method('saveConfigValue')->willReturnCallback(function ($path, $value) {
+            $this->saved[$path] = $value;
+        });
+        $helper->method('createWebHook')->willReturnCallback(function () {
+            $this->webhooksCreated++;
+        });
+
+        $storeManager = $this->createMock(StoreManager::class);
+        $storeManager->method('getStores')->willReturn([]);
+
+        $backend = new class($valueChanged) extends MonkeyStore {
+            private $changed;
+            public function __construct($changed)
+            {
+                $this->changed = $changed;
+            }
+            public function isValueChanged()
+            {
+                return $this->changed;
+            }
+            public function getOldValue()
+            {
+                return 'store-old';
+            }
+            public function getScopeId()
+            {
+                return 0;
+            }
+            public function getScope()
+            {
+                return 'default';
+            }
+        };
+
+        $this->inject($backend, MonkeyStore::class, '_helper', $helper);
+        $this->inject($backend, MonkeyStore::class, 'syncHelper', $this->createMock(SyncHelper::class));
+        $this->inject($backend, MonkeyStore::class, '_storeManager', $storeManager);
+        $this->inject(
+            $backend,
+            \Magento\Framework\Model\AbstractModel::class,
+            '_eventManager',
+            $this->createMock(\Magento\Framework\Event\ManagerInterface::class)
+        );
+
+        return $backend;
+    }
+
+    private function inject($object, $class, $property, $value)
+    {
+        $p = new \ReflectionProperty($class, $property);
+        $p->setAccessible(true);
+        $p->setValue($object, $value);
+    }
+
+    /**
+     * @param  MonkeyStore $backend
+     * @param  mixed       $value
+     * @param  int         $active
+     * @return void
+     */
+    private function save(MonkeyStore $backend, $value, $active = 1)
+    {
+        $backend->setData('groups', ['ecommerce' => ['fields' => ['active' => ['value' => $active]]]]);
+        $backend->setValue($value);
+        $backend->beforeSave();
+    }
+
+    /**
+     * -1 is the dropdown's placeholder and 0 is the '---No Data---' option it
+     * shows when there is no key at this scope or the listing threw. Neither is
+     * a store, and persisting one leaves a setting every later reader has to
+     * special-case.
+     *
+     * @return array
+     */
+    public static function nonStoreProvider()
+    {
+        return [
+            'the placeholder'            => [-1],
+            'the placeholder as a string' => ['-1'],
+            'the ---No Data--- option'   => [0],
+            'that option as a string'    => ['0'],
+            'nothing at all'             => [''],
+        ];
+    }
+
+    /**
+     * @dataProvider nonStoreProvider
+     * @param mixed $value
+     */
+    public function testAValueThatIsNotAStoreIsRejectedWhileEcommerceIsActive($value)
+    {
+        $this->expectException(LocalizedException::class);
+
+        $this->save($this->backend(true), $value);
+    }
+
+    /**
+     * The scoping that matters: with ecommerce off, "no store selected" is a
+     * legitimate state. Rejecting it would leave a merchant unable to save any
+     * Mailchimp configuration -- including the switch that turns ecommerce off.
+     *
+     * @dataProvider nonStoreProvider
+     * @param mixed $value
+     */
+    public function testTheSameValueIsAcceptedWhileEcommerceIsOff($value)
+    {
+        $this->save($this->backend(true), $value, 0);
+
+        $this->assertSame([], $this->saved);
+    }
+
+    public function testARealStoreIsNotRejected()
+    {
+        $this->save($this->backend(false), 'abc123def456');
+
+        $this->assertSame([], $this->saved);
+    }
+
+    /**
+     * The second defect: getStore() answers null when its own lookup fails, and
+     * that null was written over whatever audience id was already configured.
+     * A failed lookup destroyed the answer it could not confirm.
+     */
+    public function testAFailedLookupDoesNotOverwriteTheConfiguredAudience()
+    {
+        $backend = $this->backend(true, new \Mailchimp_Error('/', 'GET', '', 'Not Found', 'nope'));
+
+        $this->save($backend, 'abc123def456');
+
+        $this->assertArrayNotHasKey(MailChimpHelper::XML_PATH_LIST, $this->saved);
+    }
+
+    /**
+     * And one consequence further on: that same null went on to register a
+     * webhook against no audience at all.
+     */
+    public function testAFailedLookupRegistersNoWebhook()
+    {
+        $backend = $this->backend(true, new \Mailchimp_Error('/', 'GET', '', 'Not Found', 'nope'));
+
+        $this->save($backend, 'abc123def456');
+
+        $this->assertSame(0, $this->webhooksCreated);
+    }
+
+    /**
+     * A lookup that succeeds still writes, so the guard did not simply disable
+     * the feature.
+     */
+    public function testASuccessfulLookupStillWritesTheAudience()
+    {
+        $backend = $this->backend(true, 'list-new');
+
+        $this->save($backend, 'abc123def456');
+
+        $this->assertSame('list-new', $this->saved[MailChimpHelper::XML_PATH_LIST]);
+        $this->assertSame(1, $this->webhooksCreated);
+    }
+}


### PR DESCRIPTION
Two defects in `Model/Config/Backend/MonkeyStore::beforeSave`, both on the admin save path.

## 1. It persisted values that are not stores

The dropdown offers two: **-1**, its placeholder, and **0**, the `---No Data---` option it falls back to when there is no API key at that scope or the store listing threw (`Model/Config/Source/MonkeyStore.php`). `beforeSave` stored either as though a store had been chosen.

The read side already treats both as inert, so this no longer arms anything at render time. What is left is a setting holding a value that is not a store, which every later reader has to know to special-case — and three already do (`Cron/Ecommerce.php`, `Cron/GenerateStatistics.php`, `Controller/Adminhtml/Ecommerce/Getaccountdetails.php`).

**The rejection is scoped to ecommerce being active, and that scoping is the whole care of this change.** With ecommerce off, "no store selected" is a legitimate state; rejecting there would leave a merchant unable to save *any* Mailchimp configuration — including the switch that would turn ecommerce off. The guard sits under the same `$active` the method already computes.

## 2. A failed lookup overwrote the configured audience with nothing

When the store value changed, `getStore()` answers `null` if its own lookup fails — a 404 on a store Mailchimp no longer has, a revoked key — and that `null` went straight into `XML_PATH_LIST` unconditionally.

So a failed lookup did not merely fail: **it destroyed the answer it could not confirm**, which is a plausible route to a configured audience that resolves to nothing.

The same `null` then reached `createWebHook($apiKey, null)`, registering a webhook against no audience. Both are guarded now, and what is already configured survives a lookup that could not confirm it.

## Verified

**Against the running install, through the real object graph** — the backend model built by the ObjectManager, not by hand:

```
ecommerce ON,  value=-1   -> REJECTED: Select a Mailchimp store, or turn Mailchimp ecommerce off...
ecommerce ON,  value=0    -> REJECTED
ecommerce ON,  value=""   -> REJECTED
ecommerce OFF, value=-1   -> ACCEPTED
```

And the premise of the second defect, confirmed against the live API on that install rather than assumed:

```
getStore() with a store id that 404s -> NULL
```

That is the value that used to be written over the audience id.

**Unit suite 183 → 197 tests, 372 assertions.** Each behaviour was checked against a mutant:

| mutation | result |
|---|---|
| drop the rejection | 5 failures |
| reject with ecommerce off too | 5 errors |
| `isARealStore` checks only -1 | 3 failures |
| write the null list id again | 1 failure |
| create the webhook on a null list again | 1 failure |

`phpcs --standard=Magento2`: 0 errors, and `MonkeyStore.php` stays at the same 11 warnings it had.

## What was not exercised end to end

The rejection path returns early and writes nothing, so it was safe to run for real. The **null-audience path was not** — running it on the install would delete connected-site URLs, cancel pending batches and reset errors for a store view, which is more than a verification should cost on a shared box. That half rests on the unit tests and their mutants, plus the live confirmation that `getStore()` really does answer null. Saying so rather than letting the section above imply otherwise.
