### PR TITLE
Say that a partial interest-group load is deliberate

### DIFF
--- a/Cron/Webhook.php
+++ b/Cron/Webhook.php
@@ -358,7 +358,18 @@ class Webhook
      * webhook carrying a GROUPINGS merge field, so it is now called from there.
      *
      * The flag is set before the work rather than after, so a run that throws
-     * does not re-enter this once per row.
+     * does not re-enter this once per row. That has a consequence worth stating
+     * because it is invisible when it happens: getApi() is outside the try
+     * below, so a store view whose API construction throws takes this whole
+     * loop with it, and the flag is already set -- leaving $this->groups
+     * half-built and treated as complete for the rest of the process. Later
+     * store views never load, and _getGroups() matches against a partial tree
+     * without knowing it.
+     *
+     * That is deliberate rather than overlooked. Re-entering on failure would
+     * restore exactly the per-row amplification this method was changed to
+     * remove, and the job runs again in five minutes, so a partial load costs
+     * one cycle where a retry loop would cost a call per webhook row.
      *
      * @return void
      */


### PR DESCRIPTION
Comment only. No behaviour changes.

Raised in review of the lazy-load change, and left out of that PR rather than pushed onto it after approval.

## The behaviour

`getApi()` sits outside the `try` in `_loadGroups()`, so a store view whose API construction throws takes the whole loop with it. The loaded flag is set before the work, so `$this->groups` stays half-built and is treated as complete for the rest of the process: later store views never load, and `_getGroups()` matches against a partial tree without knowing it.

Nothing reports this. It is invisible when it happens.

## Why it stays

Re-entering on failure would restore exactly the per-row amplification the method was changed to remove, and the job runs again in five minutes — so a partial load costs one cycle where a retry loop would cost a call per webhook row.

That is a considered trade, and nothing said so. The next reader would have had to work out from scratch whether it had been thought about, which is the cost this line removes.

## Note for whoever reads this next

It is the same shape as the `getInterest()` behaviour noted on the storefront-latency issue: one `try` around a `1 + N` loop, where the first failure abandons the rest and returns what it has. Two instances now, in two files. If a third turns up it is a rule worth fixing as one, rather than three call sites.

Suite unchanged at 187 tests, 362 assertions. `phpcs --standard=Magento2`: 0 errors, and the file goes from 60 warnings to 59.
