### PR TITLE
version 83 for magento 2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [103.4.83](https://github.com/mailchimp/mc-magento2/tree/103.4.83)
+
+[Full Changelog](https://github.com/mailchimp/mc-magento2/compare/103.4.82...103.4.83)
+
+**Fewer calls to the Mailchimp API from merchant servers:**
+
+- Remember a failed connected-site lookup instead of repeating it every render [\#2358](https://github.com/mailchimp/mc-magento2/pull/2358)
+- Load the interest-group tree only when a webhook row needs it [\#2359](https://github.com/mailchimp/mc-magento2/pull/2359)
+
+**Fixed bugs:**
+
+- Reject the store dropdown's non-answers, and keep a good list id on a failed lookup [\#2361](https://github.com/mailchimp/mc-magento2/pull/2361)
+- Do not emit a script tag when the connected-site URL is empty [\#2360](https://github.com/mailchimp/mc-magento2/pull/2360)
+
+**Merged pull requests:**
+
+- Say that a partial interest-group load is deliberate [\#2362](https://github.com/mailchimp/mc-magento2/pull/2362)
+
+**Dependencies:**
+
+The library floor moves to `>=3.0.49`, which is the release that turns contact
+sharing on wherever nobody has declined. The constraint is a floor rather than a
+pin, as it has been since 3.0.44, so an install already resolving to something
+newer is unaffected.
+
 ## [103.4.82](https://github.com/mailchimp/mc-magento2/tree/103.4.82)
 
 [Full Changelog](https://github.com/mailchimp/mc-magento2/compare/103.4.81...103.4.82)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@
 
 **Fixed bugs:**
 
-- Reject the store dropdown's non-answers, and keep a good list id on a failed lookup [\#2361](https://github.com/mailchimp/mc-magento2/pull/2361)
 - Do not emit a script tag when the connected-site URL is empty [\#2360](https://github.com/mailchimp/mc-magento2/pull/2360)
+- Reject the store dropdown's non-answers, and keep a good list id on a failed lookup [\#2361](https://github.com/mailchimp/mc-magento2/pull/2361)
 - Compare the library version as a version, and align the floor it checks [\#2364](https://github.com/mailchimp/mc-magento2/pull/2364)
 
 **Merged pull requests:**
@@ -21,11 +21,12 @@
 
 **Dependencies:**
 
-The library floor moves to `>=3.0.49` in [\#2364](https://github.com/mailchimp/mc-magento2/pull/2364),
-alongside the `MIN_LIB_VERSION` constant that has to agree with it. 3.0.49 is the
-release that turns contact sharing on wherever nobody has declined. The
-constraint stays a floor rather than a pin, as it has been since 3.0.44, so an
-install already resolving to something newer is unaffected.
+- The `ebizmarts/mailchimp-lib` floor moves from `>=3.0.47` to `>=3.0.49` [\#2364](https://github.com/mailchimp/mc-magento2/pull/2364)
+
+  3.0.49 is the release that turns contact sharing on wherever nobody has declined.
+  It is a floor rather than a pin, as it has been since 3.0.44, so an installation
+  already resolving to something newer is unaffected — but an installation **pinned**
+  to 3.0.48 will not be able to install this release until it moves.
 
 ## [103.4.82](https://github.com/mailchimp/mc-magento2/tree/103.4.82)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Reject the store dropdown's non-answers, and keep a good list id on a failed lookup [\#2361](https://github.com/mailchimp/mc-magento2/pull/2361)
 - Do not emit a script tag when the connected-site URL is empty [\#2360](https://github.com/mailchimp/mc-magento2/pull/2360)
+- Compare the library version as a version, and align the floor it checks [\#2364](https://github.com/mailchimp/mc-magento2/pull/2364)
 
 **Merged pull requests:**
 
@@ -20,10 +21,11 @@
 
 **Dependencies:**
 
-The library floor moves to `>=3.0.49`, which is the release that turns contact
-sharing on wherever nobody has declined. The constraint is a floor rather than a
-pin, as it has been since 3.0.44, so an install already resolving to something
-newer is unaffected.
+The library floor moves to `>=3.0.49` in [\#2364](https://github.com/mailchimp/mc-magento2/pull/2364),
+alongside the `MIN_LIB_VERSION` constant that has to agree with it. 3.0.49 is the
+release that turns contact sharing on wherever nobody has declined. The
+constraint stays a floor rather than a pin, as it has been since 3.0.44, so an
+install already resolving to something newer is unaffected.
 
 ## [103.4.82](https://github.com/mailchimp/mc-magento2/tree/103.4.82)
 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   },
   "description": "Connect MailChimp with Magento",
   "type": "magento2-module",
-  "version": "103.4.82",
+  "version": "103.4.83",
   "authors": [
     {
       "name": "Ebizmarts Corp",
@@ -25,7 +25,7 @@
   },
   "require" : {
     "magento/framework": "103.0.*",
-    "ebizmarts/mailchimp-lib": ">=3.0.47",
+    "ebizmarts/mailchimp-lib": ">=3.0.49",
     "ext-json": "*"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   },
   "require" : {
     "magento/framework": "103.0.*",
-    "ebizmarts/mailchimp-lib": ">=3.0.49",
+    "ebizmarts/mailchimp-lib": ">=3.0.47",
     "ext-json": "*"
   }
 }

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -11,7 +11,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Ebizmarts_MailChimp" setup_version="103.4.82">
+    <module name="Ebizmarts_MailChimp" setup_version="103.4.83">
         <sequence>
             <module name="Magento_Newsletter"/>
             <module name="Magento_Sales"/>


### PR DESCRIPTION
> [!IMPORTANT]
> **Merge this after #2364, not before.**
>
> #2364 moves the library floor to `>=3.0.49` together with the `MIN_LIB_VERSION` constant that has to
> agree with it. This PR deliberately does not touch either — they belong in one place, and having them
> in two is how they drifted apart in the first place.
>
> Merged in the wrong order, 103.4.83 would be tagged asking for `>=3.0.47` while warning against
> `3.0.45`: the inconsistency published in a tag, which is the form that is hardest to correct
> afterwards. This branch will be refreshed from `develop-2.4` before it is merged, so the diff shows
> exactly what the tag will contain.

Version bump, changelog, and the library floor. No behaviour changes of its own.

## What it releases

Five PRs merged to `develop-2.4` since 103.4.82 was cut earlier today. All five are in milestone 10x.x.83.

**Fewer calls to the Mailchimp API from merchant servers**

- **2358** — a connected-site lookup that fails is remembered, instead of repeating on every uncached render. Measured on a 2.4.8 install: 4 uncached renders went from 4 API calls to 1.
- **2359** — the interest-group tree is no longer fetched at the top of the webhook cron, which read its queue two lines later. On the merchant this was found on, that was 21 calls and 232 KB every five minutes, discarded.

**Fixed bugs**

- **2361** — the store dropdown's `-1` and `0` are no longer persisted as though they were stores, and a failed audience lookup no longer overwrites a working list id with null, nor registers a webhook against no audience.
- **2360** — no `<script src="">` when the connected-site URL is empty.

**Merged pull requests**

- **2362** — records that a partial interest-group load is deliberate.

## Two things this PR carries that the last release PR did not

**The bump itself.** `composer.json` and `etc/module.xml` still said 103.4.82. For 103.4.82 the bump had arrived earlier with a feature PR, so that release PR only touched the changelog. This one does all three.

**The library floor moves to `>=3.0.49`.** That is the release that turns contact sharing on wherever nobody has declined. It stays a floor rather than a pin, as it has been since 3.0.44, so an install already resolving to something newer is unaffected. 3.0.49 is published on Packagist and on the mirror.

Suite 203 tests, 379 assertions. `composer validate`: valid.

