### PR TITLE
Compare the library version as a version, and align the floor it checks

### DIFF
--- a/Block/Adminhtml/System/Config/Fieldset/Hint.php
+++ b/Block/Adminhtml/System/Config/Fieldset/Hint.php
@@ -72,7 +72,13 @@ class Hint extends \Magento\Backend\Block\Template implements
     public function checkLibVersion()
     {
         $version = $this->_moduleVersion->getLibVersion('ebizmarts/mailchimp-lib');
-        if (\Ebizmarts\MailChimp\Helper\Data::MIN_LIB_VERSION > $version) {
+        // version_compare, not `>`. Comparing version strings with a relational
+        // operator compares them as strings, so '3.0.45' > '3.0.9' is false and
+        // an installation running 3.0.9 was told nothing -- the oldest
+        // libraries, which are the whole reason this warning exists, were the
+        // ones it could not see. It fails in the other direction too: it would
+        // have warned every installation from 3.0.100 onwards.
+        if (version_compare((string)$version, \Ebizmarts\MailChimp\Helper\Data::MIN_LIB_VERSION, '<')) {
             return $version;
         } else {
             return false;

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -155,7 +155,20 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
 
     const MAX_MERGEFIELDS = 100;
 
-    const MIN_LIB_VERSION = '3.0.45';
+    /**
+     * The oldest library this extension is willing to run against without
+     * saying so in the admin.
+     *
+     * This must track the `ebizmarts/mailchimp-lib` floor in composer.json.
+     * They answer for two different populations and only one of them is
+     * enforced: composer holds the floor for installations that were installed
+     * with composer, and this constant is the only thing that says anything at
+     * all to an app/code installation, where the merchant runs whichever
+     * library happens to be present. A constant left behind the floor is
+     * silence aimed at exactly the installations that cannot be told any other
+     * way.
+     */
+    const MIN_LIB_VERSION = '3.0.49';
 
     protected $counters = [];
 

--- a/Test/Unit/Block/Adminhtml/LibVersionWarningTest.php
+++ b/Test/Unit/Block/Adminhtml/LibVersionWarningTest.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Ebizmarts_MailChimp Magento Component
+ *
+ * @category    Ebizmarts
+ * @package     Ebizmarts_MailChimp
+ * @author      Ebizmarts Team <info@ebizmarts.com>
+ * @copyright   Ebizmarts (http://ebizmarts.com)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Ebizmarts\MailChimp\Test\Unit\Block\Adminhtml;
+
+use Ebizmarts\MailChimp\Block\Adminhtml\System\Config\Fieldset\Hint;
+use Ebizmarts\MailChimp\Helper\Data as MailChimpHelper;
+use Ebizmarts\MailChimp\Model\Config\ModuleVersion;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The admin warning for an out-of-date library compared version strings with a
+ * relational operator, which compares them as strings. '3.0.45' > '3.0.9' is
+ * false, so the oldest libraries -- the whole reason the warning exists -- were
+ * the ones it could not see.
+ */
+class LibVersionWarningTest extends TestCase
+{
+    /**
+     * @param  mixed $installed
+     * @return Hint
+     */
+    private function hint($installed)
+    {
+        $moduleVersion = $this->createMock(ModuleVersion::class);
+        $moduleVersion->method('getLibVersion')->willReturn($installed);
+
+        $hint = (new \ReflectionClass(Hint::class))->newInstanceWithoutConstructor();
+
+        $p = new \ReflectionProperty(Hint::class, '_moduleVersion');
+        $p->setAccessible(true);
+        $p->setValue($hint, $moduleVersion);
+
+        return $hint;
+    }
+
+    /**
+     * The defect, stated as the case it missed. A store on 3.0.9 is nine
+     * releases behind the floor and was told nothing.
+     */
+    public function testAVersionWithFewerDigitsIsStillOlder()
+    {
+        $this->assertSame('3.0.9', $this->hint('3.0.9')->checkLibVersion());
+    }
+
+    /**
+     * @return array
+     */
+    public static function olderProvider()
+    {
+        return [
+            'nine releases behind'  => ['3.0.9'],
+            'one release behind'    => ['3.0.48'],
+            'normalised by composer' => ['3.0.48.0'],
+            'far behind'            => ['3.0.44'],
+        ];
+    }
+
+    /**
+     * @dataProvider olderProvider
+     * @param string $installed
+     */
+    public function testAnOlderLibraryWarns($installed)
+    {
+        $this->assertSame($installed, $this->hint($installed)->checkLibVersion());
+    }
+
+    /**
+     * @return array
+     */
+    public static function currentProvider()
+    {
+        return [
+            'exactly the floor'      => [MailChimpHelper::MIN_LIB_VERSION],
+            'newer'                  => ['3.0.50'],
+            'newer past the decade'  => ['3.0.100'],
+            'a major ahead'          => ['3.1.0'],
+        ];
+    }
+
+    /**
+     * And the other direction, which the string comparison also got wrong: it
+     * would have warned every installation from 3.0.100 onwards.
+     *
+     * @dataProvider currentProvider
+     * @param string $installed
+     */
+    public function testALibraryAtOrAboveTheFloorIsSilent($installed)
+    {
+        $this->assertFalse($this->hint($installed)->checkLibVersion());
+    }
+
+    /**
+     * An app/code installation has no composer metadata to read, so the version
+     * arrives empty. Unknown is not the same as current, and warning is the
+     * behaviour that was already there.
+     */
+    public function testAnUnknownVersionStillWarns()
+    {
+        $this->assertSame('', $this->hint('')->checkLibVersion());
+    }
+
+    /**
+     * The constant is the only thing an app/code installation is ever told, so
+     * it has to agree with the floor composer enforces for everyone else.
+     */
+    public function testTheConstantTracksTheComposerFloor()
+    {
+        $composer = json_decode(file_get_contents(__DIR__ . '/../../../../composer.json'), true);
+        $floor = $composer['require']['ebizmarts/mailchimp-lib'];
+
+        $this->assertSame(
+            '>=' . MailChimpHelper::MIN_LIB_VERSION,
+            $floor,
+            'MIN_LIB_VERSION and the composer floor disagree, so app/code installations are told '
+            . 'something different from what composer enforces.'
+        );
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   },
   "require" : {
     "magento/framework": "103.0.*",
-    "ebizmarts/mailchimp-lib": ">=3.0.47",
+    "ebizmarts/mailchimp-lib": ">=3.0.49",
     "ext-json": "*"
   }
 }


### PR DESCRIPTION
Found in review of the QoS beacon work. Two defects that only look like one.

## 1. The comparison compares strings

`Block/Adminhtml/System/Config/Fieldset/Hint::checkLibVersion()` used a relational operator on version strings:

```php
if (Data::MIN_LIB_VERSION > $version) {
```

Measured, not reasoned — the same two values through both comparisons:

| installed | `MIN > $version` (string) | `version_compare($version, MIN, '<')` |
|---|---|---|
| `3.0.9` | false → **silent** | true → warns |
| `3.0.44` | true → warns | true → warns |
| `3.0.48.0` | false → silent | true → warns |
| `3.0.49` | false → silent | false → silent |
| `3.0.100` | true → **warns wrongly** | false → silent |

So the store nine releases behind was told nothing, and from `3.0.100` onwards everybody would have been warned. The warning was blind in exactly the direction it exists for.

`3.0.48.0` is in the table because that is the shape a real install reports — `InstalledVersions::getVersion()` returns a normalised four-segment string, which I checked on a running 2.4.8 rather than assuming three.

## 2. The constant had drifted behind the floor

`MIN_LIB_VERSION` sat at `3.0.45` while composer's floor moved twice without it.

They answer for **different populations, and only one of them is enforced**: composer holds the floor for installations installed with composer, while this constant is the only thing that says anything at all to an **app/code installation**, where the merchant runs whichever library happens to be present. A constant left behind the floor is silence aimed at exactly the installations that cannot be told any other way.

Both now say `>=3.0.49`, and `testTheConstantTracksTheComposerFloor` reads `composer.json` and asserts they agree, so they cannot drift apart silently again.

## Why the floor moves here and not in the release PR

It was in the release PR when I opened it. It belongs here: the floor and the constant express the same decision to two different audiences, and splitting them across two PRs is how they got out of step in the first place. The release PR now carries only the version bump and the changelog.

## Verified

11 tests. Both defects checked against mutants: restoring the string comparison fails three, and putting the constant back at `3.0.45` fails three.

Suite 203 → 214 tests, 390 assertions.
