### PR TITLE
Ask for the audience's total contacts on the call already being made

### DIFF
--- a/Cron/GenerateStatistics.php
+++ b/Cron/GenerateStatistics.php
@@ -192,7 +192,30 @@ class GenerateStatistics
             if ($storeId != -1) {
                 $storeData = $api->ecommerce->stores->get($mailChimpStoreId);
                 $options['list_id'] = $storeData['list_id'];
-                $list = $api->lists->getLists($storeData['list_id']);
+                // The last argument asks for stats.total_contacts on this same
+                // response. It is the billable figure, and it is the only one
+                // the audience payload cannot be made to yield by arithmetic:
+                // member_count plus unsubscribe_count leaves out non-subscribed
+                // contacts entirely, which on an ecommerce account is most of
+                // the audience.
+                //
+                // Positional because that is the library's signature, and
+                // harmless against a library too old to have the parameter --
+                // PHP ignores surplus arguments to a userland function, so the
+                // field is simply absent there rather than an error.
+                $list = $api->lists->getLists(
+                    $storeData['list_id'],
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    true
+                );
                 $options['list_name'] = $list['name'];
                 $options['total_list_subscribers'] = $list['stats']['member_count'];
                 $totalCustomers = $api->ecommerce->customers->getAll($mailChimpStoreId, 'total_items');


### PR DESCRIPTION
One argument. The extension half of the per-audience member counts the QoS beacon has been carrying a column for since it was built and has never had a value for.

## What and why

`GenerateStatistics` reads `lists/{id}` every twelve hours. That response already carries the audience's member, unsubscribe and cleaned counts, and will also carry `total_contacts` if asked — **same call, same cadence, no quota, no latency**.

`total_contacts` is the one figure the payload cannot be made to yield by arithmetic. `member_count + unsubscribe_count` omits non-subscribed contacts entirely, and on an ecommerce account those are most of the audience — **413 against 20,971** on one account measured in the estate. The sum is not an approximation of the billable figure; it is a different number.

## Safe against an older library

The parameter is positional because that is the library's signature, and it lands in the library release after 103.4.83's floor. That is fine: **PHP ignores surplus arguments to a userland function**, so against a library without the parameter the field is simply absent rather than an error.

Verified both ways on a running 2.4.8:

| library on the box | result |
|---|---|
| **3.0.49** (no such parameter) | cron completes normally in 3.9 s, `total_contacts` absent |
| the library branch that has it | cron completes, and the beacon's bucket carries `list_total_contacts` |

The second run, end to end through the real cron rather than a synthetic call:

```
list_id                  '…'
list_member_count        3
list_unsubscribe_count   0
list_cleaned_count       0
list_total_contacts      5
```

## Nothing here reads it

This extension does not consume the new field, and the statistics payload is unchanged. It exists for the QoS beacon, which observes the response passively and can only report what a caller asked for — so without this argument, the library half delivers nothing.

Suite unchanged at 214 tests, 390 assertions.

